### PR TITLE
Enable active trading: launch EventLoop and scanners

### DIFF
--- a/Pryan-Fire/hughs-forge/services/trade-orchestrator/src/TradeOrchestrator.py
+++ b/Pryan-Fire/hughs-forge/services/trade-orchestrator/src/TradeOrchestrator.py
@@ -1,155 +1,198 @@
+#!/usr/bin/env python3
+"""
+Patryn Trading Launcher — starts EventLoop, scanners, and monitors.
+This is the main entry point for the patryn-trader service.
+"""
+
+import os
+import sys
 import asyncio
-import uuid
+import threading
+import time
 import logging
 import json
-import os
 from typing import Dict, Any
-from AuditLogger import AuditLogger
-from RiskManager import RiskManager
 
-# The Conciliator: Unified Master Process for the Patryn Trading Pipeline.
-# Inscribed by Haplo (ola-claw-dev) for Lord Xar.
+# ----------------------------------------------------------------------
+# PATH SETUP — ensure imports resolve from monorepo
+# ----------------------------------------------------------------------
+REPO_ROOT = "/data/openclaw/workspace/Pryan-Fire"
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
 
-class TradeOrchestrator:
-    def __init__(self, risk_manager: RiskManager, audit_logger: AuditLogger, config_path: str = None):
-        self.risk_manager = risk_manager
-        self.audit_logger = audit_logger
-        self.config = self._load_config(config_path)
-        self.logger = logging.getLogger("Orchestrator")
+SRC_PATH = os.path.join(REPO_ROOT, "src")
+if SRC_PATH not in sys.path:
+    sys.path.insert(0, SRC_PATH)
 
-    def _load_config(self, config_path: str) -> Dict[str, Any]:
-        default_config = {
-            "reinvest_enabled": True,
-            "strategy_type": "SPOT_WIDE",
-            "risk_gate_active": True
+# ----------------------------------------------------------------------
+# LOGGING
+# ----------------------------------------------------------------------
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s [%(name)s] %(levelname)s: %(message)s',
+    datefmt='%H:%M:%S'
+)
+logger = logging.getLogger("Launcher")
+
+# ----------------------------------------------------------------------
+# FLEXIBLE TRADE AMOUNT CONFIG (Pump.fun)
+# ----------------------------------------------------------------------
+PUMP_BASE_AMOUNT = float(os.getenv("PUMP_TRADE_AMOUNT_BASE", "10.0"))
+PUMP_AMOUNT_MODE = os.getenv("PUMP_TRADE_AMOUNT_MODE", "fixed").lower()  # "fixed" or "flexible"
+
+# ----------------------------------------------------------------------
+# SIGNAL HANDLER — validates and computes trade size before enqueueing
+# ----------------------------------------------------------------------
+class SignalHandler:
+    def __init__(self, event_loop: EventLoop):
+        self.event_loop = event_loop
+        self.momentum_scanner = MomentumScanner()
+        self.rugcheck_scanner = RugcheckScanner()
+        self.sentinel = AntiRugScanner(self._get_security_profile())
+        logger.info("SignalHandler initialized with security profile")
+
+    def _get_security_profile(self):
+        return {
+            "name": "Standard_Security",
+            "buy_amount_sol": 0.1,
+            "min_liquidity_usd": 10000,
+            "security": {"use_rug_check": True, "use_bundle_check": True}
         }
-        
-        target_path = config_path or os.path.join(os.path.dirname(__file__), "orchestrator_config.json")
-        
-        try:
-            if os.path.exists(target_path):
-                with open(target_path, "r") as f:
-                    return {**default_config, **json.load(f)}
-        except Exception as e:
-            logging.error(f"Failed to load config from {target_path}: {e}")
-            
-        return default_config
 
-    async def orchestrate_trade(self, trade_intent: Dict[str, Any]):
-        """
-        Executes the full pipeline lifecycle: Intent -> Audit -> Risk Gate -> Execution -> Reinvestment.
-        """
-        trade_id = str(uuid.uuid4())[:8]
-        
-        # 1. Inscribe Intent
-        self.audit_logger.log_event("TRADE_INTENT", {
+    async def on_token_discovered(self, mint: str, metadata: dict):
+        """Callback for Pump.fun new token."""
+        symbol = metadata.get('symbol', 'UNKNOWN')
+        logger.info(f"New token discovered: {symbol} ({mint})")
+
+        # 1. Momentum validation (DEX Screener)
+        try:
+            intel = await self.momentum_scanner.validate_momentum(mint)
+            if not intel.get("passed"):
+                reason = intel.get("reason", "Unknown")
+                reasons_list = intel.get("reasons", [])
+                if reasons_list:
+                    reason = " | ".join(reasons_list)
+                logger.info(f"Token {symbol} rejected (momentum): {reason}")
+                return
+        except Exception as e:
+            logger.error(f"Momentum validation error for {mint}: {e}")
+            return
+
+        logger.info(f"Token {symbol} passed momentum validation")
+
+        # 2. Rugcheck security scan
+        try:
+            dex_liq = intel.get("metrics", {}).get("liquidity", 0)
+            safety = await self.rugcheck_scanner.scan_token(mint, dex_liquidity=dex_liq)
+            if not safety["safe"]:
+                logger.info(f"Token {symbol} failed rugcheck: {safety['reason']}")
+                return
+            if not safety.get("skipped"):
+                logger.info(f"Token {symbol} passed rugcheck (score={safety['score']}, lp={safety.get('lp_locked_pct', 0):.1f}%)")
+        except Exception as e:
+            logger.warning(f"Rugcheck error for {mint}: {e} — allowing trade (fail-open)")
+
+        # 3. Determine trade amount (flexible or fixed)
+        amount = self._compute_amount(intel.get("metrics", {}))
+        trade_id = f"pump-{mint[:8]}"
+
+        signal = {
+            "token_address": mint,
+            "amount": amount,
             "trade_id": trade_id,
-            "details": trade_intent,
-            "strategy": self.config.get("strategy_type")
-        })
-
-        # 2. Gate via The Warden (Risk Manager)
-        if self.config.get("risk_gate_active", True):
-            approved = await self.risk_manager.check_trade(trade_id, trade_intent)
-            if not approved:
-                self.audit_logger.log_event("TRADE_ABORTED", {"trade_id": trade_id, "reason": "Risk Gate / Timeout"})
-                return False
-        
-        # 3. Trigger Execution Armory (Meteora TS)
-        # Apply Sterol Toggles to the execution intent
-        execution_intent = {
-            **trade_intent,
-            "swap_on_entry": self.config.get("swap_on_entry", True),
-            "strategy": self.config.get("strategy_type", "SPOT_WIDE"),
-            "padding": self.config.get("bin_step_padding", 2)
+            "source": "pump_fun"
         }
-        
-        self.audit_logger.log_event("TRADE_EXECUTING", {"trade_id": trade_id, "mode": execution_intent["strategy"]})
-        
-        try:
-            # Command bridge to the TypeScript Armory logic
-            success = await self._invoke_ts_armory(execution_intent)
-            
-            if success:
-                # 4. REINVESTMENT PULSE
-                if trade_intent.get("action") == "CLAIM_FEES" and self.config.get("reinvest_enabled", True):
-                    self.audit_logger.log_event("TREASURY_REINVESTING", {"trade_id": trade_id})
-                    
-                    # Logic call to CompoundingEngine.ts strike
-                    reinvest_success = await self._invoke_ts_compounding(trade_id)
-                    
-                    if reinvest_success:
-                        self.audit_logger.log_event("REINVEST_SUCCESS", {"trade_id": trade_id})
-                    else:
-                        self.audit_logger.log_event("REINVEST_FAILURE", {"trade_id": trade_id})
-                
-                self.audit_logger.log_event("TRADE_SUCCESS", {"trade_id": trade_id})
-                return True
-            else:
-                self.audit_logger.log_event("TRADE_FAILURE", {"trade_id": trade_id})
-                return False
-        except Exception as e:
-            self.audit_logger.log_event("SYSTEM_ERROR", {"trade_id": trade_id, "error": str(e)})
-            return False
+        logger.info(f"Enqueuing signal for {symbol}: amount={amount:.6f} tokens")
+        self.event_loop.enqueue_signal(signal)
 
-    async def _invoke_ts_armory(self, intent: Dict[str, Any]) -> bool:
-        self.logger.info(f"Triggering TS Armory with Strategy: {intent.get('strategy')} | SwapOnEntry: {intent.get('swap_on_entry')}")
-        # Command bridge would pass intent keys as CLI args or environment to the TS process
-        return True
+    def _compute_amount(self, metrics: Dict[str, Any]) -> float:
+        """Compute trade amount based on configuration and metrics."""
+        if PUMP_AMOUNT_MODE == "fixed":
+            return PUMP_BASE_AMOUNT
+        # Flexible mode: scale by liquidity
+        liquidity = metrics.get("liquidity", 0)
+        factor = max(0.1, min(1.0, liquidity / 100_000.0))
+        return PUMP_BASE_AMOUNT * factor
 
-    async def _invoke_ts_compounding(self, trade_id: str) -> bool:
-        strategy = self.config.get("strategy_type", "SPOT_WIDE")
-        padding = self.config.get("bin_step_padding", 5)
-        self.logger.info(f"Triggering TS Compounding with Strategy: {strategy} | Padding: {padding}")
-        # Command bridge passes these configuration runes to CompoundingEngine.ts
-        return True
-
-async def main():
-    logging.basicConfig(level=logging.INFO)
-
-    # --- ZIFNAB'S RUNE OF BINDING ---
-    config = {}
+# ----------------------------------------------------------------------
+# MAIN LAUNCHER
+# ----------------------------------------------------------------------
+def main():
+    # Load configuration for core orchestrator
     config_path = os.path.join(os.path.dirname(__file__), "orchestrator_config.json")
+    config = {}
     try:
         with open(config_path, 'r') as f:
             config = json.load(f)
-        logging.info(f"Successfully loaded configuration from {config_path}")
-    except FileNotFoundError:
-        logging.error(f"FATAL: Configuration file not found at {config_path}")
-        return
-    except json.JSONDecodeError:
-        logging.error(f"FATAL: Could not decode JSON from {config_path}")
-        return
+        logger.info(f"Loaded orchestrator config from {config_path}")
     except Exception as e:
-        logging.error(f"Error loading configuration: {e}")
+        logger.error(f"Failed to load config: {e}")
         return
-    # --- END RUNE ---
 
-    # Initialize Core Components with bound config
+    # Initialize Audit Logger
     audit_logger = AuditLogger()
-    
-    # Load Discord credentials from environment for RiskManager (optional)
+
+    # Initialize Risk Manager (mock or real)
     discord_token = os.getenv("DISCORD_TOKEN")
     channel_id_str = os.getenv("DISCORD_CHANNEL_ID")
     if discord_token and channel_id_str:
         try:
             channel_id = int(channel_id_str)
             risk_manager = RiskManager(discord_token, channel_id)
-            logging.info("RiskManager initialized with Discord gate (real mode).")
+            logger.info("RiskManager initialized with Discord (real mode)")
         except ValueError:
-            logging.error("DISCORD_CHANNEL_ID must be an integer. Using MOCK RiskManager (auto-approve).")
-            risk_manager = RiskManager()  # Mock mode
+            logger.error("DISCORD_CHANNEL_ID invalid. Using MOCK RiskManager")
+            risk_manager = RiskManager()
     else:
-        logging.warning("DISCORD_TOKEN or DISCORD_CHANNEL_ID not set. Using MOCK RiskManager (auto-approve).")
-        risk_manager = RiskManager()  # Mock mode
-    
-    orchestrator = TradeOrchestrator(risk_manager, audit_logger)
-    
-    orchestrator.logger.info("Orchestrator initialized and bound to stone law.")
+        logger.warning("Discord credentials not set. Using MOCK RiskManager (auto-approve)")
+        risk_manager = RiskManager()
 
-    while True:
-        # Your main loop logic here...
-        await asyncio.sleep(3600)
+    # Create Core Orchestrator
+    core_orchestrator = TradeOrchestrator(risk_manager, audit_logger, config_path=config_path)
+    logger.info("Core Orchestrator created")
+
+    # Create and start EventLoop in daemon thread
+    event_loop = EventLoop(core_orchestrator)
+    loop_thread = threading.Thread(target=event_loop.run, daemon=True, name="EventLoop")
+    loop_thread.start()
+    logger.info("EventLoop started")
+
+    # Signal handler (scanners callbacks)
+    handler = SignalHandler(event_loop)
+
+    # Start Pump.fun scanner in daemon thread
+    def run_pump():
+        pump_scanner = PumpFunSignal(on_token_received=handler.on_token_discovered)
+        try:
+            asyncio.run(pump_scanner.run())
+        except Exception as e:
+            logger.error(f"Pump.fun scanner thread error: {e}", exc_info=True)
+    pump_thread = threading.Thread(target=run_pump, daemon=True, name="PumpFun-Scanner")
+    pump_thread.start()
+    logger.info("Pump.fun scanner started")
+
+    # Start Meteora scanner if enabled
+    if os.getenv("METEORA_ENABLED", "").lower() == "true":
+        devnet = "devnet" in os.getenv("SOLANA_RPC_URL", "").lower()
+        meteora_scanner = MeteoraDLMMScanner(orchestrator=core_orchestrator, devnet=devnet)
+        def run_meteora():
+            try:
+                asyncio.run(meteora_scanner.run())
+            except Exception as e:
+                logger.error(f"Meteora scanner thread error: {e}", exc_info=True)
+        meteora_thread = threading.Thread(target=run_meteora, daemon=True, name="Meteora-DLMM-Scanner")
+        meteora_thread.start()
+        logger.info("Meteora DLMM scanner started")
+    else:
+        logger.info("Meteora scanner disabled (set METEORA_ENABLED=true to enable)")
+
+    # Keep main thread alive
+    logger.info("All components launched. Entering main loop.")
+    try:
+        while True:
+            time.sleep(30)
+    except KeyboardInterrupt:
+        logger.info("Shutting down launcher...")
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    main()


### PR DESCRIPTION
Fixes #209

This PR transforms the TradeOrchestrator wrapper into a launcher that:
- Starts EventLoop (queue consumer)
- Launches Pump.fun and Meteora scanners
- Validates signals via momentum + rugcheck
- Supports flexible trade sizing (fixed/flexible modes)

Deployment: After merge, restart patryn-trader service. Set env vars PUMP_TRADE_AMOUNT_BASE and PUMP_TRADE_AMOUNT_MODE as needed.