### PR TITLE
fix: killfeed falsy bug, extract liquidity helper, add /toppools endpoint

### DIFF
--- a/Pryan-Fire/hughs-forge/scripts/killfeed_discord_poster.py
+++ b/Pryan-Fire/hughs-forge/scripts/killfeed_discord_poster.py
@@ -24,11 +24,13 @@ logger = logging.getLogger(__name__)
 
 # Configuration
 KILLFEED_URL = os.getenv("KILLFEED_URL", "http://100.104.166.53:8002/killfeed")
+TOPPOOLS_URL = os.getenv("TOPPOOLS_URL", "http://100.104.166.53:8002/toppools")
 
 # Tiered Discord webhooks
-WEBHOOK_EXTREME = os.getenv("DISCORD_WEBHOOK_EXTREME")  # 200%+
-WEBHOOK_KILLER = os.getenv("DISCORD_WEBHOOK_KILLER")    # 100-200%
-WEBHOOK_ALPHA = os.getenv("DISCORD_WEBHOOK_ALPHA")      # 50-100%
+WEBHOOK_EXTREME = os.getenv("DISCORD_WEBHOOK_EXTREME")   # 200%+
+WEBHOOK_KILLER = os.getenv("DISCORD_WEBHOOK_KILLER")     # 100-200%
+WEBHOOK_ALPHA = os.getenv("DISCORD_WEBHOOK_ALPHA")       # 50-100%
+WEBHOOK_TOPPOOLS = os.getenv("DISCORD_WEBHOOK_TOPPOOLS") # Top by liquidity
 
 STATE_FILE = os.getenv("KILLFEED_STATE_FILE", "/data/openclaw/.killfeed_state.json")
 MIN_APY = float(os.getenv("KILLFEED_MIN_APY", "50"))  # Baseline: 50%
@@ -227,13 +229,68 @@ def post_to_discord(pools: List[Dict[str, Any]], tier: str):
         logger.error(f"Failed to post to {tier} channel: {e}")
 
 
+def fetch_toppools(limit: int = 20) -> List[Dict[str, Any]]:
+    """Fetch top pools by liquidity from /toppools endpoint."""
+    for attempt in range(3):
+        try:
+            response = requests.get(
+                TOPPOOLS_URL,
+                params={"limit": limit},
+                timeout=30
+            )
+            response.raise_for_status()
+            data = response.json()
+            return data.get("pools", [])
+        except Exception as e:
+            logger.warning(f"Toppools fetch attempt {attempt + 1}/3 failed: {e}")
+            if attempt < 2:
+                time.sleep(2 ** attempt)
+    logger.error("Failed to fetch toppools after 3 attempts")
+    return []
+
+
+def post_toppools_to_discord(pools: List[Dict[str, Any]]):
+    """Post top pools by liquidity to the toppools channel."""
+    if not WEBHOOK_TOPPOOLS:
+        logger.warning("No webhook configured for toppools (DISCORD_WEBHOOK_TOPPOOLS)")
+        return
+    if not pools:
+        return
+
+    embeds = []
+    for pool in pools[:10]:
+        embed = {
+            "title": f"💧 {pool.get('name', 'Unknown')}",
+            "url": get_pool_url(pool.get("address", "")),
+            "color": 0x0099FF,
+            "fields": format_pool_fields(pool),
+            "footer": {"text": f"Hugh Top Pools | Min Liquidity: ${MIN_LIQUIDITY:,.0f}"},
+            "timestamp": datetime.utcnow().isoformat() + "Z"
+        }
+        embeds.append(embed)
+
+    payload = {
+        "content": f"💧 **TOP POOLS by Liquidity** — {len(pools)} pools",
+        "embeds": embeds
+    }
+    if len(pools) > 10:
+        payload["content"] += f"\n_+{len(pools) - 10} more_"
+
+    try:
+        response = requests.post(WEBHOOK_TOPPOOLS, json=payload, timeout=10)
+        response.raise_for_status()
+        logger.info(f"Posted {len(pools)} toppools to toppools channel")
+    except Exception as e:
+        logger.error(f"Failed to post to toppools channel: {e}")
+
+
 def main():
     """Main loop - check for new pools and post to tiered Discord channels."""
     logger.info("Kill Feed Discord Poster (TIERED) starting...")
     
     # Validate webhooks configured
-    if not any([WEBHOOK_EXTREME, WEBHOOK_KILLER, WEBHOOK_ALPHA]):
-        logger.warning("No Discord webhooks configured! Set DISCORD_WEBHOOK_EXTREME/KILL/ALPHA")
+    if not any([WEBHOOK_EXTREME, WEBHOOK_KILLER, WEBHOOK_ALPHA, WEBHOOK_TOPPOOLS]):
+        logger.warning("No Discord webhooks configured! Set DISCORD_WEBHOOK_EXTREME/KILLER/ALPHA/TOPPOOLS")
         return
     
     seen_pools = load_seen_pools()
@@ -277,6 +334,13 @@ def main():
         else:
             logger.info(f"No new pools in {tier} tier")
     
+    # Post toppools (always, not deduped — it's a snapshot)
+    if WEBHOOK_TOPPOOLS:
+        top_pools = fetch_toppools(limit=20)
+        if top_pools:
+            logger.info(f"Fetched {len(top_pools)} top pools by liquidity")
+            post_toppools_to_discord(top_pools)
+
     # Update seen pools
     if current_addresses:
         seen_pools.update(current_addresses)

--- a/Pryan-Fire/hughs-forge/services/trade-orchestrator/src/health_server.py
+++ b/Pryan-Fire/hughs-forge/services/trade-orchestrator/src/health_server.py
@@ -83,6 +83,30 @@ _scanner_state = {
     "errors": 0,
 }
 
+def _calculate_usd_liquidity(pool: Dict[str, Any]) -> float:
+    """Calculate USD liquidity for a pool from reserve amounts."""
+    USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+    reserve_x = float(pool.get("reserve_x_amount", 0))
+    reserve_y = float(pool.get("reserve_y_amount", 0))
+    mint_x = pool.get("mint_x", "")
+    mint_y = pool.get("mint_y", "")
+
+    if mint_y == USDC_MINT:
+        usd = reserve_y / 1_000_000
+        current_price = float(pool.get("current_price", 0))
+        if current_price > 0:
+            usd += (reserve_x * current_price) / 1e9
+        return usd
+    elif mint_x == USDC_MINT:
+        usd = reserve_x / 1_000_000
+        current_price = float(pool.get("current_price", 0))
+        if current_price > 0:
+            usd += (reserve_y * current_price) / 1e9
+        return usd
+    else:
+        return float(pool.get("cumulative_fee_volume", 0))
+
+
 def _rpc_call(method: str, params: List[Any]) -> Optional[Dict]:
     """Make a Solana RPC call."""
     try:
@@ -171,10 +195,12 @@ def get_pools(limit: int = 100, min_apy: float = None, min_liquidity: float = No
     - min_liquidity: filter by minimum liquidity in USD (default from config)
     """
     
-    min_apy = min_apy or SCANNER_CONFIG["min_apy"]
-    min_liquidity = min_liquidity or SCANNER_CONFIG["min_liquidity"]
+    if min_apy is None:
+        min_apy = SCANNER_CONFIG["min_apy"]
+    if min_liquidity is None:
+        min_liquidity = SCANNER_CONFIG["min_liquidity"]
     limit = min(limit, 500)  # Cap at 500
-    
+
     try:
         # Fetch from Meteora API
         response = requests.get(
@@ -182,59 +208,29 @@ def get_pools(limit: int = 100, min_apy: float = None, min_liquidity: float = No
             timeout=30
         )
         pools = response.json()
-        
+
         if not isinstance(pools, list):
             return {"error": "Invalid API response", "pools": []}
-        
-        # Apply filters - calculate USD liquidity
+
         filtered = []
         for pool in pools:
             try:
                 pool_apy = float(pool.get("apy", 0))
-                
-                # Calculate USD liquidity from reserves
-                reserve_x = float(pool.get("reserve_x_amount", 0))
-                reserve_y = float(pool.get("reserve_y_amount", 0))
-                mint_x = pool.get("mint_x", "")
-                mint_y = pool.get("mint_y", "")
-                
-                # Estimate USD value
-                # USDC mint: EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v
-                USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
-                
-                usd_liquidity = 0.0
-                
-                if mint_y == USDC_MINT:
-                    # mint_y is USDC - reserve_y is in USDC (6 decimals)
-                    usd_liquidity = reserve_y / 1_000_000
-                    # Add estimate for mint_x using current_price
-                    current_price = float(pool.get("current_price", 0))
-                    if current_price > 0:
-                        usd_liquidity += (reserve_x * current_price) / 1e9
-                elif mint_x == USDC_MINT:
-                    # mint_x is USDC
-                    usd_liquidity = reserve_x / 1_000_000
-                    current_price = float(pool.get("current_price", 0))
-                    if current_price > 0:
-                        usd_liquidity += (reserve_y * current_price) / 1e9
-                else:
-                    # No USDC pair - use cumulative fee volume as proxy
-                    usd_liquidity = float(pool.get("cumulative_fee_volume", 0))
-                
+                usd_liquidity = _calculate_usd_liquidity(pool)
+
                 if pool_apy >= min_apy and pool_apy < 1000 and usd_liquidity >= min_liquidity:
-                    # Cap APY at 10000% to filter out API data errors
-                    display_apy = min(pool_apy, 500.0) if pool_apy < 1000 else 0
+                    display_apy = min(pool_apy, 500.0)
                     filtered.append({
                         "address": pool.get("address"),
                         "name": pool.get("name"),
-                        "mint_x": mint_x,
-                        "mint_y": mint_y,
+                        "mint_x": pool.get("mint_x"),
+                        "mint_y": pool.get("mint_y"),
                         "liquidity_usd": round(usd_liquidity, 2),
                         "apy": round(display_apy, 2),
                         "fee": pool.get("base_fee_percentage"),
                         "volume_24h": pool.get("trade_volume_24h"),
                     })
-                    
+
                     if len(filtered) >= limit:
                         break
             except (ValueError, TypeError, ZeroDivisionError):
@@ -274,67 +270,47 @@ def get_killfeed(min_apy: float = None, min_liquidity: float = None):
     - min_liquidity: filter by minimum liquidity in USD (default from config)
     """
     
-    min_apy = min_apy or SCANNER_CONFIG["min_apy"]
-    min_liquidity = min_liquidity or SCANNER_CONFIG["min_liquidity"]
-    
+    if min_apy is None:
+        min_apy = SCANNER_CONFIG["min_apy"]
+    if min_liquidity is None:
+        min_liquidity = SCANNER_CONFIG["min_liquidity"]
+
     try:
         response = requests.get(
             "https://dlmm-api.meteora.ag/pair/all",
             timeout=30
         )
         pools = response.json()
-        
+
         if not isinstance(pools, list):
-            return {"error": "Invalid API response", "pools": []}
-        
-        USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
-        
+            return {"error": "Invalid API response", "killfeed": []}
+
         filtered = []
         for pool in pools:
             try:
                 pool_apy = float(pool.get("apy", 0))
-                
-                reserve_x = float(pool.get("reserve_x_amount", 0))
-                reserve_y = float(pool.get("reserve_y_amount", 0))
-                mint_x = pool.get("mint_x", "")
-                mint_y = pool.get("mint_y", "")
-                
-                usd_liquidity = 0.0
-                
-                if mint_y == USDC_MINT:
-                    usd_liquidity = reserve_y / 1_000_000
-                    current_price = float(pool.get("current_price", 0))
-                    if current_price > 0:
-                        usd_liquidity += (reserve_x * current_price) / 1e9
-                elif mint_x == USDC_MINT:
-                    usd_liquidity = reserve_x / 1_000_000
-                    current_price = float(pool.get("current_price", 0))
-                    if current_price > 0:
-                        usd_liquidity += (reserve_y * current_price) / 1e9
-                else:
-                    usd_liquidity = float(pool.get("cumulative_fee_volume", 0))
-                
+                usd_liquidity = _calculate_usd_liquidity(pool)
+
                 if pool_apy >= min_apy and pool_apy < 1000 and usd_liquidity >= min_liquidity:
-                    # Cap APY at 10000% to filter out API data errors
-                    display_apy = min(pool_apy, 500.0) if pool_apy < 1000 else 0
+                    display_apy = min(pool_apy, 500.0)
                     filtered.append({
                         "address": pool.get("address"),
                         "name": pool.get("name"),
-                        "mint_x": mint_x,
-                        "mint_y": mint_y,
+                        "mint_x": pool.get("mint_x"),
+                        "mint_y": pool.get("mint_y"),
                         "liquidity_usd": round(usd_liquidity, 2),
                         "apy": round(display_apy, 2),
                         "fee": pool.get("base_fee_percentage"),
                         "volume_24h": round(float(pool.get("trade_volume_24h", 0)), 2),
-                        "reserve_x": int(reserve_x),
-                        "reserve_y": int(reserve_y),
+                        "reserve_x": int(float(pool.get("reserve_x_amount", 0))),
+                        "reserve_y": int(float(pool.get("reserve_y_amount", 0))),
                     })
             except (ValueError, TypeError, ZeroDivisionError):
                 continue
-        
+
         # Sort by APY descending
         filtered.sort(key=lambda x: x["apy"], reverse=True)
-        
+
         return {
             "killfeed": filtered,
             "count": len(filtered),
@@ -346,6 +322,70 @@ def get_killfeed(min_apy: float = None, min_liquidity: float = None):
         }
     except Exception as e:
         return {"error": str(e), "killfeed": []}
+
+@app.get("/toppools")
+def get_toppools(limit: int = 20, min_liquidity: float = None, min_apy: float = None):
+    """
+    Top Pools - sorted by USD liquidity descending.
+
+    Query params:
+    - limit: max pools to return (default 20, max 100)
+    - min_liquidity: minimum liquidity in USD (default from config)
+    - min_apy: minimum APY filter (default 0 — all pools)
+    """
+    if min_liquidity is None:
+        min_liquidity = SCANNER_CONFIG["min_liquidity"]
+    if min_apy is None:
+        min_apy = 0.0
+    limit = min(limit, 100)
+
+    try:
+        response = requests.get(
+            "https://dlmm-api.meteora.ag/pair/all",
+            timeout=30
+        )
+        pools = response.json()
+
+        if not isinstance(pools, list):
+            return {"error": "Invalid API response", "pools": []}
+
+        filtered = []
+        for pool in pools:
+            try:
+                pool_apy = float(pool.get("apy", 0))
+                usd_liquidity = _calculate_usd_liquidity(pool)
+
+                if usd_liquidity >= min_liquidity and pool_apy >= min_apy and pool_apy < 1000:
+                    display_apy = min(pool_apy, 500.0)
+                    filtered.append({
+                        "address": pool.get("address"),
+                        "name": pool.get("name"),
+                        "mint_x": pool.get("mint_x"),
+                        "mint_y": pool.get("mint_y"),
+                        "liquidity_usd": round(usd_liquidity, 2),
+                        "apy": round(display_apy, 2),
+                        "fee": pool.get("base_fee_percentage"),
+                        "volume_24h": round(float(pool.get("trade_volume_24h", 0)), 2),
+                    })
+            except (ValueError, TypeError, ZeroDivisionError):
+                continue
+
+        # Sort by liquidity descending
+        filtered.sort(key=lambda x: x["liquidity_usd"], reverse=True)
+
+        return {
+            "pools": filtered[:limit],
+            "count": min(len(filtered), limit),
+            "total_matched": len(filtered),
+            "filters": {
+                "min_liquidity_usd": min_liquidity,
+                "min_apy": min_apy,
+            },
+            "total_pools_scanned": len(pools)
+        }
+    except Exception as e:
+        return {"error": str(e), "pools": []}
+
 
 def start_orchestrator_health_server(port=8002):
     """Starts the health server using uvicorn."""


### PR DESCRIPTION
## Summary
- Fix `min_apy=0` / `min_liquidity=0` falsy bug in `/pools` and `/killfeed` — zero was silently falling back to config default
- Extract `_calculate_usd_liquidity()` helper to remove 3x duplicate code across endpoints
- Add `/toppools` endpoint (sorted by liquidity descending)
- Add `DISCORD_WEBHOOK_TOPPOOLS` support to killfeed poster

## Changes Made
- `health_server.py`: `min_apy is None` check (not `or`), shared liquidity helper, new `/toppools` endpoint
- `killfeed_discord_poster.py`: `WEBHOOK_TOPPOOLS` env var, `fetch_toppools()`, `post_toppools_to_discord()`, wired into `main()`

## Test plan
- [ ] `GET /pools?min_apy=0` should return all pools (not filtered by config default)
- [ ] `GET /killfeed?min_apy=0` same
- [ ] `GET /toppools` returns pools sorted by liquidity_usd desc
- [ ] Set `DISCORD_WEBHOOK_TOPPOOLS` — verify toppools posts appear in Discord on next timer run

Closes #132
Refs #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)