### PR TITLE
fix: wire health server to TradeOrchestrator + fix deploy pipeline

### DIFF
--- a/.github/workflows/deploy-mvp.yml
+++ b/.github/workflows/deploy-mvp.yml
@@ -28,22 +28,27 @@ jobs:
           # 1. Prepare Target Environment
           mkdir -p /data/repos/The-Nexus
           mkdir -p /data/repos/The-Nexus/Pryan-Fire/data
-          
+
           # 2. Sync Codebase
           cd /data/repos/The-Nexus
           git pull origin main || git clone https://github.com/The-Nexus-Decoded/The-Nexus.git .
           cd Pryan-Fire
-          
-          # 3. Process Management
-          if [ ! -d "venv" ]; then
-            python3 -m venv venv
+
+          # 3. Venv + Dependencies
+          TRADE_DIR=hughs-forge/services/trade-orchestrator
+          if [ ! -d "${TRADE_DIR}/venv" ]; then
+            python3 -m venv "${TRADE_DIR}/venv"
           fi
-          
-          # Install dependencies
-          ./venv/bin/pip install --upgrade pip
-          ./venv/bin/pip install aiohttp websockets base58 solders solana
-          
-          # Restart via systemd (if configured)
+          ${TRADE_DIR}/venv/bin/pip install --upgrade pip -q
+          ${TRADE_DIR}/venv/bin/pip install -r ${TRADE_DIR}/requirements.txt -q
+
+          # 4. Install service file + reload
+          mkdir -p ~/.config/systemd/user
+          cp ${TRADE_DIR}/patryn-trader.service ~/.config/systemd/user/patryn-trader.service
+          systemctl --user daemon-reload
+
+          # 5. Restart service
           systemctl --user restart patryn-trader || echo "Systemd service not found"
-          
+          systemctl --user status patryn-trader --no-pager || true
+
           echo "MVP Deployment Complete."

--- a/Pryan-Fire/hughs-forge/services/trade-orchestrator/patryn-trader.service
+++ b/Pryan-Fire/hughs-forge/services/trade-orchestrator/patryn-trader.service
@@ -1,16 +1,16 @@
 [Unit]
-Description=Patryn Trade Orchestrator
-After=network.target
+Description=Hugh's Trade Orchestrator
+After=network-online.target
+Wants=network-online.target
 
 [Service]
 Type=simple
-User=openclaw
 WorkingDirectory=/data/repos/The-Nexus/Pryan-Fire
 ExecStart=/data/repos/The-Nexus/Pryan-Fire/hughs-forge/services/trade-orchestrator/start-patryn-trader.sh
 Restart=always
 RestartSec=10
-StandardOutput=append:/var/log/patryn-trader.log
-StandardError=append:/var/log/patryn-trader.log
+StandardOutput=journal
+StandardError=journal
 
 [Install]
 WantedBy=default.target

--- a/Pryan-Fire/hughs-forge/services/trade-orchestrator/src/TradeOrchestrator.py
+++ b/Pryan-Fire/hughs-forge/services/trade-orchestrator/src/TradeOrchestrator.py
@@ -3,9 +3,11 @@ import uuid
 import logging
 import json
 import os
+import threading
 from typing import Dict, Any
 from AuditLogger import AuditLogger
 from RiskManager import RiskManager
+from health_server import start_orchestrator_health_server
 
 # The Conciliator: Unified Master Process for the Patryn Trading Pipeline.
 # Inscribed by Haplo (ola-claw-dev) for Lord Xar.
@@ -146,6 +148,16 @@ async def main():
     orchestrator = TradeOrchestrator(risk_manager, audit_logger)
     
     orchestrator.logger.info("Orchestrator initialized and bound to stone law.")
+
+    # Start health server (FastAPI) on port 8002 in daemon thread
+    health_thread = threading.Thread(
+        target=start_orchestrator_health_server,
+        kwargs={"port": 8002},
+        daemon=True,
+        name="Health-Server"
+    )
+    health_thread.start()
+    logging.info("Health server started on port 8002")
 
     while True:
         # Your main loop logic here...


### PR DESCRIPTION
## Summary
- Start `health_server.py` (port 8002) as a daemon thread inside `TradeOrchestrator.main()` so `/toppools`, `/killfeed`, `/pools`, `/health` endpoints are served from the monorepo code
- Fix `deploy-mvp.yml` to install the service file from the repo, use `requirements.txt`, and create the venv in the correct location
- Fix `patryn-trader.service` for user-service compatibility (journal output, `network-online.target`)

### Root Cause
`combined_runner.py` (the old process serving port 8002) was **deleted from disk** but still running in RAM since Mar 5. It lacked `/toppools`. The monorepo `health_server.py` (with `/toppools`) was never started because `TradeOrchestrator.py` didn't launch it. The deploy workflow also never updated the installed service file from the repo.

### Changes
| File | What |
|------|------|
| `TradeOrchestrator.py` | Import + start `health_server` in daemon thread |
| `patryn-trader.service` | journal output, drop `User=`, add `network-online` |
| `deploy-mvp.yml` | Install service file, daemon-reload, use requirements.txt, fix venv path |

## Test plan
- [ ] Merge triggers deploy-mvp.yml on self-hosted runner
- [ ] After deploy: `curl http://100.104.166.53:8002/toppools` returns pools (not 404)
- [ ] After deploy: `curl http://100.104.166.53:8002/health` returns healthy
- [ ] killfeed-discord-poster toppools channel starts receiving posts

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)