### PR TITLE
fix: save automation state after SL/TP checks run

### DIFF
--- a/Pryan-Fire/hughs-forge/scripts/position_monitor.py
+++ b/Pryan-Fire/hughs-forge/scripts/position_monitor.py
@@ -464,9 +464,6 @@ def main():
         total_embeds += len(embeds)
         total_messages += len(new_ids)
 
-    # Save state
-    save_state(state)
-
     # Run automation checks (SL/TP)
     for wallet_name, wallet_config in config_wallets.items():
         wallet_address = wallet_config.get("address", "")
@@ -485,6 +482,9 @@ def main():
                 state,
                 config
             )
+
+    # Save state (after automation so alert counters are persisted)
+    save_state(state)
 
     logger.info(f"Position monitor complete. Posted {total_embeds} embeds across {total_messages} messages")
 


### PR DESCRIPTION
## Summary
- Moves `save_state(state)` to after the automation loop in `main()`
- Fixes critical bug from #149 where alert counters were never persisted between runs

## Bug
`save_state()` was called before `run_automation_checks()`. The automation engine writes `alerts_sent`, `escalation_state`, and `last_alert_at` into state, but those changes were discarded. Result: every run started with `alerts_sent = 0`, owners received infinite repeat alerts, auto-execute never triggered.

## Fix
`save_state(state)` moved to after the automation loop.

Follow-up to #149