### PR TITLE
fix: add error handling to position embed building (Chelestra-Sea#104)

### DIFF
--- a/Pryan-Fire/hughs-forge/scripts/position_monitor.py
+++ b/Pryan-Fire/hughs-forge/scripts/position_monitor.py
@@ -263,9 +263,12 @@ def build_position_embed(wallet_name: str, position: Dict[str, Any], pnl: Dict[s
     automation = position.get("automation", {})
     automation_str = format_automation(automation)
     
+    # Only set URL if it's valid (Discord rejects empty strings)
+    embed_url = meteora_url if meteora_url and meteora_url.strip() else None
+    
     embed = {
         "title": pool_name,
-        "url": meteora_url,
+        "url": embed_url,
         "color": color,
         "fields": [
             {"name": "APR", "value": f"{apy:.1f}%", "inline": True},
@@ -378,9 +381,13 @@ def process_wallet(wallet_name: str, wallet_config: Dict[str, Any], wallet_data:
     
     # Then individual position embeds
     for pos in positions:
-        pnl = pos.get("pnl", {})
-        pos_embed = build_position_embed(wallet_name, pos, pnl)
-        embeds.append(pos_embed)
+        try:
+            pnl = pos.get("pnl", {})
+            pos_embed = build_position_embed(wallet_name, pos, pnl)
+            embeds.append(pos_embed)
+        except Exception as e:
+            logger.error(f"Failed to build embed for position {pos.get('position', 'unknown')}: {e}")
+            continue
     
     return embeds
 


### PR DESCRIPTION
## Summary
- Add try/except around `build_position_embed` to prevent silent failures when processing positions
- Fix empty URL issue (Discord rejects empty string URLs)
- Add `continue` to skip failed positions instead of crashing the entire batch

## Testing
- Code review only - need to deploy to Hugh's server and verify position embeds display correctly

## Notes
- This fix addresses the issue where only 2 of 4 owner positions were displaying in Discord despite the API returning 4 positions
- The error handling will log any position that fails to build, helping identify root cause

Closes Chelestra-Sea#104