### PR TITLE
feat: dry-run logging for automation alerts

### DIFF
--- a/Pryan-Fire/hughs-forge/scripts/automation_engine.py
+++ b/Pryan-Fire/hughs-forge/scripts/automation_engine.py
@@ -166,6 +166,9 @@ def handle_alert_owner(wallet_name: str, trigger: Dict, config: Dict, state: Dic
                        (f" — Auto-close in {remaining} more alert{'s' if remaining > 1 else ''} if no response." if remaining > 0 else " — FINAL WARNING!"),
         }
         
+        
+        # Log what would be sent (for verification)
+        logger.info(f"[{wallet_name}] ALERT WOULD BE SENT: {trigger_type.upper()} {pool_name} PnL={pnl_pct:+.1f}% (alert {alert_num}/{alert_count})")
         if _post_to_discord_alerts(msg):
             alert["alerts_sent"] += 1
             alert["last_alert_at"] = datetime.utcnow().isoformat() + "Z"


### PR DESCRIPTION
Logs what alert would be sent even when DISCORD_WEBHOOK_ALERTS is not configured, for verification purposes.

Example output:
```
INFO:automation_engine:[owner] ALERT WOULD BE SENT: TAKE_PROFIT Lobstar-SOL PnL=+1.9% (alert 1/3)
WARNING:automation_engine:DISCORD_WEBHOOK_ALERTS not set - cannot send alert
```