### PR TITLE
fix: killfeed/toppools/position data quality (#158)

### DIFF
--- a/Pryan-Fire/hughs-forge/scripts/killfeed_discord_poster.py
+++ b/Pryan-Fire/hughs-forge/scripts/killfeed_discord_poster.py
@@ -36,10 +36,16 @@ STATE_FILE = os.getenv("KILLFEED_STATE_FILE", "/data/openclaw/.killfeed_state.js
 MIN_APY = float(os.getenv("KILLFEED_MIN_APY", "50"))  # Baseline: 50%
 MIN_LIQUIDITY = float(os.getenv("KILLFEED_MIN_LIQUIDITY", "5000"))
 
-# APY thresholds for tiers
+# APY thresholds for tiers (fallback only)
 APY_EXTREME = 200  # 200%+
 APY_KILLER = 100   # 100-200%
 APY_ALPHA = 50     # 50-100%
+
+# Fee/TVL ratio thresholds (daily ratio — primary tier signal)
+# 0.5% daily = ~182% annualized, 0.25% = ~91%, 0.1% = ~36%
+FEE_TVL_EXTREME = 0.005   # 0.5%+ daily fee/tvl ratio
+FEE_TVL_KILLER = 0.0025   # 0.25-0.5%
+FEE_TVL_ALPHA = 0.001     # 0.1-0.25%
 
 os.makedirs(os.path.dirname(STATE_FILE), exist_ok=True)
 
@@ -131,14 +137,28 @@ def get_dexscreener_url(mint_address: str) -> str:
     return f"https://dexscreener.com/solana/{mint_address}"
 
 
-def get_tier(apy: float) -> str:
-    """Determine APY tier for a pool."""
+def get_tier(pool: Dict[str, Any]) -> str:
+    """Determine tier for a pool using fee/TVL ratio (primary) with APY fallback."""
+    fee_tvl = float(pool.get('fee_tvl_ratio', 0))
+
+    if fee_tvl > 0:
+        if fee_tvl >= FEE_TVL_EXTREME:
+            return "extreme"
+        elif fee_tvl >= FEE_TVL_KILLER:
+            return "killer"
+        else:
+            return "alpha"
+
+    # Fallback to APY if fee_tvl_ratio not available
+    try:
+        apy = float(pool.get('apy', 0)) if pool.get('apy') not in (None, 'N/A', '') else 0
+    except (ValueError, TypeError):
+        apy = 0
     if apy >= APY_EXTREME:
         return "extreme"
     elif apy >= APY_KILLER:
         return "killer"
-    else:
-        return "alpha"
+    return "alpha"
 
 
 def format_pool_fields(pool: Dict[str, Any]) -> List[Dict[str, str]]:
@@ -153,22 +173,31 @@ def format_pool_fields(pool: Dict[str, Any]) -> List[Dict[str, str]]:
     fee = pool.get('fee', '0')
     
     APY_CAP = 500
+    is_spike = pool.get('apy_spike', False) or apy > APY_CAP
     if apy > APY_CAP:
-        apy_str = f"500%+"
+        apy_str = "500%+ SPIKE" if is_spike else "500%+"
     else:
         apy_str = f"{apy:,.1f}%" if apy and apy > 0 else "N/A"
-    
+
+    fee_tvl = float(pool.get('fee_tvl_ratio', 0))
+    fee_tvl_str = f"{fee_tvl * 100:.2f}%/day" if fee_tvl > 0 else "N/A"
+
+    fees_24h = float(pool.get('fees_24h', 0))
+    fees_str = f"${fees_24h:,.0f}" if fees_24h else "$0"
+
     liquidity_str = f"${liquidity:,.0f}" if liquidity else "$0"
     volume_str = f"${volume:,.0f}" if volume else "$0"
-    
+
     mint_x = pool.get('mint_x', '')[:8] + '...' if len(pool.get('mint_x', '')) > 8 else pool.get('mint_x', '')
     mint_y = pool.get('mint_y', '')[:8] + '...' if len(pool.get('mint_y', '')) > 8 else pool.get('mint_y', '')
-    
+
     return [
         {"name": "💧 Liquidity", "value": liquidity_str, "inline": True},
         {"name": "📈 APY", "value": apy_str, "inline": True},
-        {"name": "📊 24h", "value": volume_str, "inline": True},
-        {"name": "💰 Fee", "value": f"{fee}%", "inline": True},
+        {"name": "📊 Fee/TVL", "value": fee_tvl_str, "inline": True},
+        {"name": "💰 Fees (24h)", "value": fees_str, "inline": True},
+        {"name": "📊 Vol (24h)", "value": volume_str, "inline": True},
+        {"name": "💰 Base Fee", "value": f"{fee}%", "inline": True},
         {"name": "🪙 Tokens", "value": f"{mint_x} / {mint_y}", "inline": False},
         {"name": "🔗 Meteora", "value": get_pool_url(pool.get('address', '')), "inline": False},
         {"name": "📈 DexScreener", "value": get_dexscreener_url(pool.get('mint_x', '')), "inline": False},
@@ -196,7 +225,7 @@ def post_to_discord(pools: List[Dict[str, Any]], tier: str):
     if not pools:
         return
     
-    pools_sorted = sorted(pools, key=lambda x: x.get('apy', 0), reverse=True)
+    pools_sorted = sorted(pools, key=lambda x: x.get('fee_tvl_ratio', 0), reverse=True)
     top_pools = pools_sorted[:5]
     
     embeds = []
@@ -309,12 +338,7 @@ def main():
     tiers = {"extreme": [], "killer": [], "alpha": []}
     
     for pool in valid_pools:
-        try:
-            apy = float(pool.get('apy', 0)) if pool.get('apy') not in (None, 'N/A', '') else 0
-        except (ValueError, TypeError):
-            apy = 0
-        
-        tier = get_tier(apy)
+        tier = get_tier(pool)
         tiers[tier].append(pool)
     
     # Log tier counts

--- a/Pryan-Fire/hughs-forge/scripts/position_monitor.py
+++ b/Pryan-Fire/hughs-forge/scripts/position_monitor.py
@@ -208,7 +208,7 @@ def build_wallet_embed(wallet_name: str, wallet_config: Dict[str, Any], wallet_d
     
     # Calculate totals
     total_value = sum(p.get("liquidity_usd", 0) for p in positions)
-    total_fees = sum(p.get("fees_24h", 0) for p in positions)
+    total_fees_claimed = sum(p.get("fees_claimed_usd", 0) for p in positions)
     
     # Calculate total PnL
     total_pnl = 0
@@ -231,8 +231,8 @@ def build_wallet_embed(wallet_name: str, wallet_config: Dict[str, Any], wallet_d
         "fields": [
             {"name": "SOL Balance", "value": f"{sol_balance:.4f} SOL", "inline": True},
             {"name": "Positions", "value": str(len(positions)), "inline": True},
-            {"name": "Total Value", "value": f"${total_value:,.2f}", "inline": True},
-            {"name": "Total Fees (24h)", "value": f"${total_fees:,.2f}", "inline": True},
+            {"name": "Pool TVL (all)", "value": f"${total_value:,.2f}", "inline": True},
+            {"name": "Fees Claimed", "value": f"${total_fees_claimed:,.2f}", "inline": True},
             {"name": "Total PnL", "value": f"${total_pnl:,.2f} ({total_pnl_pct:.1f}%)", "inline": True},
         ],
         "footer": {"text": f"Position Monitor | {wallet_name}"},
@@ -266,19 +266,21 @@ def build_position_embed(wallet_name: str, position: Dict[str, Any], pnl: Dict[s
     # Only set URL if it's valid (Discord rejects empty strings)
     embed_url = meteora_url if meteora_url and meteora_url.strip() else None
     
+    fees_claimed = position.get("fees_claimed_usd", 0)
+
     embed = {
         "title": pool_name,
         "url": embed_url,
         "color": color,
         "fields": [
-            {"name": "APR", "value": f"{apy:.1f}%", "inline": True},
+            {"name": "Fee APY (24h)", "value": f"{apy:.1f}%", "inline": True},
             {"name": "Status", "value": status, "inline": True},
+            {"name": "Fees Claimed", "value": f"${fees_claimed:,.2f}", "inline": True},
             {"name": "PnL", "value": f"${pnl.get('pnl_usd', 0):,.2f} ({pnl.get('pnl_pct', 0):.1f}%)", "inline": True},
             {"name": "Entry Value", "value": f"${pnl.get('entry_value_usd', 0):,.2f}", "inline": True},
             {"name": "Current Value", "value": f"${pnl.get('current_value_usd', 0):,.2f}", "inline": True},
             {"name": "24h PnL", "value": f"${pnl.get('pnl_24h', 0):,.2f}", "inline": True},
-            {"name": "Fees (24h)", "value": f"${position.get('fees_24h', 0):,.2f}", "inline": True},
-            {"name": "Liquidity", "value": f"${position.get('liquidity_usd', 0):,.2f}", "inline": True},
+            {"name": "Pool TVL", "value": f"${position.get('liquidity_usd', 0):,.2f}", "inline": True},
             {"name": "Volume (24h)", "value": f"${position.get('volume_24h', 0):,.2f}", "inline": True},
             {"name": "Bin Range", "value": f"{lower_bin}-{upper_bin} (Active: {active_bin})", "inline": False},
             {"name": "Links", "value": f"[Meteora]({meteora_url}) | [DexScreener]({get_dexscreener_url(mint_x)})", "inline": False},

--- a/Pryan-Fire/hughs-forge/services/trade-orchestrator/src/health_server.py
+++ b/Pryan-Fire/hughs-forge/services/trade-orchestrator/src/health_server.py
@@ -269,9 +269,8 @@ def _enrich_positions(parsed: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
             "lb_pair": p["lb_pair"],
             "pool_name": pool.get("name", "Unknown"),
             "apy": round(fee_apy_24h, 2),          # per-position 24h APY
-            "pool_apy": round(float(pool.get("apy", 0)), 2),  # pool-level APY
-            "fees_claimed_usd": round(fees_claimed_usd, 2),   # historical claimed fees
-            "fees_24h": round(float(pool.get("today_fees", 0)), 2),  # pool-level (TODO: per-position)
+            "fees_claimed_usd": round(fees_claimed_usd, 2),   # historical claimed fees per position
+            "fees_24h": round(float(pool.get("today_fees", 0)), 2),  # pool-level total
             "base_fee": pool.get("base_fee_percentage", "?"),
             "volume_24h": round(float(pool.get("trade_volume_24h", 0)), 2),
             "liquidity_usd": round(_calculate_usd_liquidity(pool), 2) if pool else 0,
@@ -399,10 +398,12 @@ def get_pools(limit: int = 100, min_apy: float = None, min_liquidity: float = No
                 usd_liquidity = _calculate_usd_liquidity(pool)
                 volume_24h = float(pool.get("trade_volume_24h", 0))
 
+                fees_24h = float(pool.get("today_fees", 0))
                 if (pool_apy >= min_apy and pool_apy < 1000
                         and usd_liquidity >= min_liquidity
                         and volume_24h >= min_volume_24h):
                     display_apy = min(pool_apy, 500.0)
+                    fee_tvl_ratio = round(fees_24h / usd_liquidity, 6) if usd_liquidity > 0 else 0
                     filtered.append({
                         "address": pool.get("address"),
                         "name": pool.get("name"),
@@ -410,7 +411,10 @@ def get_pools(limit: int = 100, min_apy: float = None, min_liquidity: float = No
                         "mint_y": pool.get("mint_y"),
                         "liquidity_usd": round(usd_liquidity, 2),
                         "apy": round(display_apy, 2),
+                        "apy_spike": pool_apy > 500,
                         "fee": pool.get("base_fee_percentage"),
+                        "fees_24h": round(fees_24h, 2),
+                        "fee_tvl_ratio": fee_tvl_ratio,
                         "volume_24h": round(volume_24h, 2),
                     })
 
@@ -479,10 +483,12 @@ def get_killfeed(min_apy: float = None, min_liquidity: float = None, min_volume_
                 usd_liquidity = _calculate_usd_liquidity(pool)
 
                 volume_24h = float(pool.get("trade_volume_24h", 0))
+                fees_24h = float(pool.get("today_fees", 0))
                 if (pool_apy >= min_apy and pool_apy < 1000
                         and usd_liquidity >= min_liquidity
                         and volume_24h >= min_volume_24h):
                     display_apy = min(pool_apy, 500.0)
+                    fee_tvl_ratio = round(fees_24h / usd_liquidity, 6) if usd_liquidity > 0 else 0
                     filtered.append({
                         "address": pool.get("address"),
                         "name": pool.get("name"),
@@ -490,7 +496,10 @@ def get_killfeed(min_apy: float = None, min_liquidity: float = None, min_volume_
                         "mint_y": pool.get("mint_y"),
                         "liquidity_usd": round(usd_liquidity, 2),
                         "apy": round(display_apy, 2),
+                        "apy_spike": pool_apy > 500,
                         "fee": pool.get("base_fee_percentage"),
+                        "fees_24h": round(fees_24h, 2),
+                        "fee_tvl_ratio": fee_tvl_ratio,
                         "volume_24h": round(volume_24h, 2),
                         "reserve_x": int(float(pool.get("reserve_x_amount", 0))),
                         "reserve_y": int(float(pool.get("reserve_y_amount", 0))),
@@ -498,8 +507,8 @@ def get_killfeed(min_apy: float = None, min_liquidity: float = None, min_volume_
             except (ValueError, TypeError, ZeroDivisionError):
                 continue
 
-        # Sort by APY descending
-        filtered.sort(key=lambda x: x["apy"], reverse=True)
+        # Sort by fee/TVL ratio descending (more reliable than raw APY)
+        filtered.sort(key=lambda x: x["fee_tvl_ratio"], reverse=True)
 
         return {
             "killfeed": filtered,
@@ -545,9 +554,12 @@ def get_toppools(limit: int = 20, min_liquidity: float = None, min_apy: float = 
             try:
                 pool_apy = float(pool.get("apy", 0))
                 usd_liquidity = _calculate_usd_liquidity(pool)
+                volume_24h = float(pool.get("trade_volume_24h", 0))
+                fees_24h = float(pool.get("today_fees", 0))
 
                 if usd_liquidity >= min_liquidity and pool_apy >= min_apy and pool_apy < 1000:
                     display_apy = min(pool_apy, 500.0)
+                    fee_tvl_ratio = round(fees_24h / usd_liquidity, 6) if usd_liquidity > 0 else 0
                     filtered.append({
                         "address": pool.get("address"),
                         "name": pool.get("name"),
@@ -555,14 +567,17 @@ def get_toppools(limit: int = 20, min_liquidity: float = None, min_apy: float = 
                         "mint_y": pool.get("mint_y"),
                         "liquidity_usd": round(usd_liquidity, 2),
                         "apy": round(display_apy, 2),
+                        "apy_spike": pool_apy > 500,
                         "fee": pool.get("base_fee_percentage"),
-                        "volume_24h": round(float(pool.get("trade_volume_24h", 0)), 2),
+                        "fees_24h": round(fees_24h, 2),
+                        "fee_tvl_ratio": fee_tvl_ratio,
+                        "volume_24h": round(volume_24h, 2),
                     })
             except (ValueError, TypeError, ZeroDivisionError):
                 continue
 
-        # Sort by liquidity descending
-        filtered.sort(key=lambda x: x["liquidity_usd"], reverse=True)
+        # Sort by fee/TVL ratio descending (more reliable than liquidity alone)
+        filtered.sort(key=lambda x: x["fee_tvl_ratio"], reverse=True)
 
         return {
             "pools": filtered[:limit],


### PR DESCRIPTION
## Summary
- **Killfeed/toppools**: Sort by `fee_tvl_ratio` instead of raw APY. Add `fee_tvl_ratio`, `fees_24h`, `apy_spike` fields to all pool API responses. Tier classification uses daily fee/TVL thresholds (0.5%=extreme, 0.25%=killer, 0.1%=alpha) — reduces extreme tier from ~50 pools to ~7.
- **Position monitor**: Replace pool-level "Fees (24h)" with per-position "Fees Claimed" (`fees_claimed_usd`). Rename "Liquidity" → "Pool TVL", "APR" → "Fee APY (24h)". Drop misleading `pool_apy` (was showing millions of %) from API response.

## Test plan
- [x] Syntax check — all 3 files compile clean
- [x] Simulated new tier distribution against live Meteora data: extreme=7, killer=51, alpha=48 (was extreme=50)
- [x] Verified baseline data on Hugh shows the problems (all APY capped at 500, toppools showing $9T liquidity garbage, pool_apy at 3M-227B%)
- [ ] Deploy to Hugh and verify `/killfeed` returns `fee_tvl_ratio` field
- [ ] Verify killfeed Discord posts show Fee/TVL column and spike flags
- [ ] Verify position monitor embeds show "Fees Claimed" and "Pool TVL"

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)