### PR TITLE
fix: align killfeed deploy path with pipeline

### DIFF
--- a/.github/workflows/deploy-mvp.yml
+++ b/.github/workflows/deploy-mvp.yml
@@ -52,8 +52,13 @@ jobs:
           # Install position monitor timer
           cp hughs-forge/scripts/position-monitor.service ~/.config/systemd/user/position-monitor.service
           cp hughs-forge/scripts/position-monitor.timer ~/.config/systemd/user/position-monitor.timer
+
+          # Install killfeed discord poster timer
+          cp hughs-forge/scripts/killfeed-discord-poster.service ~/.config/systemd/user/killfeed-discord-poster.service
+          cp hughs-forge/scripts/killfeed-discord-poster.timer ~/.config/systemd/user/killfeed-discord-poster.timer
           systemctl --user daemon-reload
           systemctl --user enable --now position-monitor.timer || echo "Position monitor timer not enabled"
+          systemctl --user enable --now killfeed-discord-poster.timer || echo "Killfeed timer not enabled"
 
           # 5. Restart service
           systemctl --user restart patryn-trader || echo "Systemd service not found"

--- a/Pryan-Fire/hughs-forge/scripts/killfeed-discord-poster.service
+++ b/Pryan-Fire/hughs-forge/scripts/killfeed-discord-poster.service
@@ -3,9 +3,9 @@ Description=Kill Feed Discord Poster - Posts new Meteora DLMM pools to Discord
 
 [Service]
 Type=oneshot
-WorkingDirectory=/data/openclaw/workspace/The-Nexus/Pryan-Fire/hughs-forge/scripts
-ExecStart=/usr/bin/python3 /data/openclaw/workspace/The-Nexus/Pryan-Fire/hughs-forge/scripts/killfeed_discord_poster.py
-Environment="PYTHONPATH=/data/openclaw/workspace/The-Nexus/Pryan-Fire/hughs-forge/scripts"
+WorkingDirectory=/data/repos/The-Nexus/Pryan-Fire
+ExecStart=/usr/bin/python3 /data/repos/The-Nexus/Pryan-Fire/hughs-forge/scripts/killfeed_discord_poster.py
+Environment="PYTHONPATH=/data/repos/The-Nexus/Pryan-Fire/hughs-forge/scripts"
 StandardOutput=journal
 StandardError=journal
 


### PR DESCRIPTION
## Summary
- Killfeed service was running from `/data/openclaw/workspace/` while deploys only update `/data/repos/` — so merges to main never reached the killfeed poster
- Changed service paths to `/data/repos/` (same as position-monitor and patryn-trader)
- Added killfeed service + timer install to deploy-mvp.yml

## Impact
After merge, all three services (patryn-trader, position-monitor, killfeed-poster) will be deployed and updated from the same pipeline path.

## Test plan
- [ ] After merge, verify killfeed service ExecStart points to `/data/repos/`
- [ ] Verify next killfeed run picks up latest code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)