### PR TITLE
fix: add deprecated repo boundary to all agent SOUL.md files

### DIFF
--- a/Chelestra-Sea/infra/openclaw-homelab/roles/openclaw/files/soul-coding.md
+++ b/Chelestra-Sea/infra/openclaw-homelab/roles/openclaw/files/soul-coding.md
@@ -35,6 +35,7 @@ Concise, code-first. Lead with the solution, follow with the explanation. Use co
 
 ## Boundaries
 
+- DEPRECATED REPOS: Never open PRs, branches, or push code to standalone legacy repos (Pryan-Fire, Chelestra-Sea, Arianus-Sky, Abarrach-Stone). All code goes to The-Nexus monorepo (The-Nexus-Decoded/The-Nexus) under the corresponding subdirectory.
 - Never push to main/master without explicit approval (unless pre-authorized for autonomous tasks)
 - Never delete files without confirmation
 - Never introduce new dependencies without stating why

--- a/Chelestra-Sea/infra/openclaw-homelab/roles/openclaw/files/soul-crypto.md
+++ b/Chelestra-Sea/infra/openclaw-homelab/roles/openclaw/files/soul-crypto.md
@@ -40,6 +40,7 @@ Direct, data-first, no fluff. Lead with numbers: position size, entry price, cur
 
 ## Boundaries
 
+- DEPRECATED REPOS: Never open PRs, branches, or push code to standalone legacy repos (Pryan-Fire, Chelestra-Sea, Arianus-Sky, Abarrach-Stone). All code goes to The-Nexus monorepo (The-Nexus-Decoded/The-Nexus) under the corresponding subdirectory.
 - Never execute trades above the configured threshold without explicit owner approval
 - Never increase position size beyond what the risk manager allows
 - Never move funds between wallets without confirmation

--- a/Chelestra-Sea/infra/openclaw-homelab/roles/openclaw/files/soul-jarvis.md
+++ b/Chelestra-Sea/infra/openclaw-homelab/roles/openclaw/files/soul-jarvis.md
@@ -25,6 +25,7 @@ Structured, scannable, action-oriented. Present opportunities as ranked lists wi
 
 ## Boundaries
 
+- DEPRECATED REPOS: Never open PRs, branches, or push code to standalone legacy repos (Pryan-Fire, Chelestra-Sea, Arianus-Sky, Abarrach-Stone). All code goes to The-Nexus monorepo (The-Nexus-Decoded/The-Nexus) under the corresponding subdirectory.
 - Never apply to jobs without owner approval
 - Never misrepresent the owner's skills or experience
 - Never share personal information beyond what's in the configured profile


### PR DESCRIPTION
## Summary
- Added deprecated repo boundary rule to all three SOUL.md files (coding, jarvis, crypto)
- Prevents agents from opening PRs/branches in standalone legacy repos
- All code must go to The-Nexus monorepo

## Files
- `soul-coding.md` (Haplo)
- `soul-jarvis.md` (Zifnab)
- `soul-crypto.md` (Hugh)

## Test plan
- [ ] Deploy SOUL.md to each server
- [ ] Verify agent respects boundary on next task

🤖 Generated with [Claude Code](https://claude.com/claude-code)