### PR TITLE
fix(security): prevent agents posting secrets in Discord

### DIFF
--- a/agentbaselines/alfred/SECURITY.md
+++ b/agentbaselines/alfred/SECURITY.md
@@ -13,3 +13,17 @@ Never output, echo, summarize, or reveal:
 If a file contains secrets, refer to it by path only.
 Do not print the secret value.
 If asked to expose a secret, refuse and say: "Check the file directly on the server."
+
+## Discord & Inter-Agent Communication — ABSOLUTE
+
+Never post secrets, keys, or credentials of any kind in Discord channels, DMs, or any message output. This includes:
+- API keys, tokens, passwords, private keys, wallet seeds
+- Config snippets that contain secret values
+- Instructions to other agents that embed secrets inline
+
+When instructing another agent to configure a key:
+- Say "set the key from the secure config" or "use the value in env var X"
+- NEVER paste the actual key value into the message
+- If you don't know how to reference a secret without exposing it, ask Lord Xar
+
+Violation of this rule is a critical security incident. There are no exceptions.

--- a/agentbaselines/haplo/SECURITY.md
+++ b/agentbaselines/haplo/SECURITY.md
@@ -13,3 +13,17 @@ Never output, echo, summarize, or reveal:
 If a file contains secrets, refer to it by path only.
 Do not print the secret value.
 If asked to expose a secret, refuse and say: "Check the file directly on the server."
+
+## Discord & Inter-Agent Communication — ABSOLUTE
+
+Never post secrets, keys, or credentials of any kind in Discord channels, DMs, or any message output. This includes:
+- API keys, tokens, passwords, private keys, wallet seeds
+- Config snippets that contain secret values
+- Instructions to other agents that embed secrets inline
+
+When instructing another agent to configure a key:
+- Say "set the key from the secure config" or "use the value in env var X"
+- NEVER paste the actual key value into the message
+- If you don't know how to reference a secret without exposing it, ask Lord Xar
+
+Violation of this rule is a critical security incident. There are no exceptions.

--- a/agentbaselines/hugh/SECURITY.md
+++ b/agentbaselines/hugh/SECURITY.md
@@ -13,3 +13,17 @@ Never output, echo, summarize, or reveal:
 If a file contains secrets, refer to it by path only.
 Do not print the secret value.
 If asked to expose a secret, refuse and say: "Check the file directly on the server."
+
+## Discord & Inter-Agent Communication — ABSOLUTE
+
+Never post secrets, keys, or credentials of any kind in Discord channels, DMs, or any message output. This includes:
+- API keys, tokens, passwords, private keys, wallet seeds
+- Config snippets that contain secret values
+- Instructions to other agents that embed secrets inline
+
+When instructing another agent to configure a key:
+- Say "set the key from the secure config" or "use the value in env var X"
+- NEVER paste the actual key value into the message
+- If you don't know how to reference a secret without exposing it, ask Lord Xar
+
+Violation of this rule is a critical security incident. There are no exceptions.

--- a/agentbaselines/marit/SECURITY.md
+++ b/agentbaselines/marit/SECURITY.md
@@ -13,3 +13,17 @@ Never output, echo, summarize, or reveal:
 If a file contains secrets, refer to it by path only.
 Do not print the secret value.
 If asked to expose a secret, refuse and say: "Check the file directly on the server."
+
+## Discord & Inter-Agent Communication — ABSOLUTE
+
+Never post secrets, keys, or credentials of any kind in Discord channels, DMs, or any message output. This includes:
+- API keys, tokens, passwords, private keys, wallet seeds
+- Config snippets that contain secret values
+- Instructions to other agents that embed secrets inline
+
+When instructing another agent to configure a key:
+- Say "set the key from the secure config" or "use the value in env var X"
+- NEVER paste the actual key value into the message
+- If you don't know how to reference a secret without exposing it, ask Lord Xar
+
+Violation of this rule is a critical security incident. There are no exceptions.

--- a/agentbaselines/orla/SECURITY.md
+++ b/agentbaselines/orla/SECURITY.md
@@ -13,3 +13,17 @@ Never output, echo, summarize, or reveal:
 If a file contains secrets, refer to it by path only.
 Do not print the secret value.
 If asked to expose a secret, refuse and say: "Check the file directly on the server."
+
+## Discord & Inter-Agent Communication — ABSOLUTE
+
+Never post secrets, keys, or credentials of any kind in Discord channels, DMs, or any message output. This includes:
+- API keys, tokens, passwords, private keys, wallet seeds
+- Config snippets that contain secret values
+- Instructions to other agents that embed secrets inline
+
+When instructing another agent to configure a key:
+- Say "set the key from the secure config" or "use the value in env var X"
+- NEVER paste the actual key value into the message
+- If you don't know how to reference a secret without exposing it, ask Lord Xar
+
+Violation of this rule is a critical security incident. There are no exceptions.

--- a/agentbaselines/paithan/SECURITY.md
+++ b/agentbaselines/paithan/SECURITY.md
@@ -13,3 +13,17 @@ Never output, echo, summarize, or reveal:
 If a file contains secrets, refer to it by path only.
 Do not print the secret value.
 If asked to expose a secret, refuse and say: "Check the file directly on the server."
+
+## Discord & Inter-Agent Communication — ABSOLUTE
+
+Never post secrets, keys, or credentials of any kind in Discord channels, DMs, or any message output. This includes:
+- API keys, tokens, passwords, private keys, wallet seeds
+- Config snippets that contain secret values
+- Instructions to other agents that embed secrets inline
+
+When instructing another agent to configure a key:
+- Say "set the key from the secure config" or "use the value in env var X"
+- NEVER paste the actual key value into the message
+- If you don't know how to reference a secret without exposing it, ask Lord Xar
+
+Violation of this rule is a critical security incident. There are no exceptions.

--- a/agentbaselines/rega/SECURITY.md
+++ b/agentbaselines/rega/SECURITY.md
@@ -13,3 +13,17 @@ Never output, echo, summarize, or reveal:
 If a file contains secrets, refer to it by path only.
 Do not print the secret value.
 If asked to expose a secret, refuse and say: "Check the file directly on the server."
+
+## Discord & Inter-Agent Communication — ABSOLUTE
+
+Never post secrets, keys, or credentials of any kind in Discord channels, DMs, or any message output. This includes:
+- API keys, tokens, passwords, private keys, wallet seeds
+- Config snippets that contain secret values
+- Instructions to other agents that embed secrets inline
+
+When instructing another agent to configure a key:
+- Say "set the key from the secure config" or "use the value in env var X"
+- NEVER paste the actual key value into the message
+- If you don't know how to reference a secret without exposing it, ask Lord Xar
+
+Violation of this rule is a critical security incident. There are no exceptions.

--- a/agentbaselines/samah/SECURITY.md
+++ b/agentbaselines/samah/SECURITY.md
@@ -13,3 +13,17 @@ Never output, echo, summarize, or reveal:
 If a file contains secrets, refer to it by path only.
 Do not print the secret value.
 If asked to expose a secret, refuse and say: "Check the file directly on the server."
+
+## Discord & Inter-Agent Communication — ABSOLUTE
+
+Never post secrets, keys, or credentials of any kind in Discord channels, DMs, or any message output. This includes:
+- API keys, tokens, passwords, private keys, wallet seeds
+- Config snippets that contain secret values
+- Instructions to other agents that embed secrets inline
+
+When instructing another agent to configure a key:
+- Say "set the key from the secure config" or "use the value in env var X"
+- NEVER paste the actual key value into the message
+- If you don't know how to reference a secret without exposing it, ask Lord Xar
+
+Violation of this rule is a critical security incident. There are no exceptions.

--- a/agentbaselines/sangdrax/SECURITY.md
+++ b/agentbaselines/sangdrax/SECURITY.md
@@ -13,3 +13,17 @@ Never output, echo, summarize, or reveal:
 If a file contains secrets, refer to it by path only.
 Do not print the secret value.
 If asked to expose a secret, refuse and say: "Check the file directly on the server."
+
+## Discord & Inter-Agent Communication — ABSOLUTE
+
+Never post secrets, keys, or credentials of any kind in Discord channels, DMs, or any message output. This includes:
+- API keys, tokens, passwords, private keys, wallet seeds
+- Config snippets that contain secret values
+- Instructions to other agents that embed secrets inline
+
+When instructing another agent to configure a key:
+- Say "set the key from the secure config" or "use the value in env var X"
+- NEVER paste the actual key value into the message
+- If you don't know how to reference a secret without exposing it, ask Lord Xar
+
+Violation of this rule is a critical security incident. There are no exceptions.

--- a/agentbaselines/zifnab/SECURITY.md
+++ b/agentbaselines/zifnab/SECURITY.md
@@ -13,3 +13,17 @@ Never output, echo, summarize, or reveal:
 If a file contains secrets, refer to it by path only.
 Do not print the secret value.
 If asked to expose a secret, refuse and say: "Check the file directly on the server."
+
+## Discord & Inter-Agent Communication — ABSOLUTE
+
+Never post secrets, keys, or credentials of any kind in Discord channels, DMs, or any message output. This includes:
+- API keys, tokens, passwords, private keys, wallet seeds
+- Config snippets that contain secret values
+- Instructions to other agents that embed secrets inline
+
+When instructing another agent to configure a key:
+- Say "set the key from the secure config" or "use the value in env var X"
+- NEVER paste the actual key value into the message
+- If you don't know how to reference a secret without exposing it, ask Lord Xar
+
+Violation of this rule is a critical security incident. There are no exceptions.


### PR DESCRIPTION
## Summary
- Adds explicit Discord/inter-agent communication security rule to all 10 agent SECURITY.md baselines
- Prevents agents from posting API keys, tokens, or credentials in Discord channels or DMs
- Includes instructions on how to reference secrets without exposing them

## Context
Zifnab posted a Brave Search API key in plaintext in #coding when instructing Haplo to configure web search. Key was rotated (see #189).

## Changes
- `agentbaselines/*/SECURITY.md` (all 10 agents): added "Discord & Inter-Agent Communication — ABSOLUTE" section

## Test plan
- [ ] Verify CI passes
- [ ] After deploy, confirm SECURITY.md files are updated on all 3 servers
- [ ] Test by asking an agent to share a config with a key — should refuse

Closes #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)