### PR TITLE
Add SSH access policy and project creation workflow

### DIFF
--- a/agentbaselines/alfred/REPO-MAP.md
+++ b/agentbaselines/alfred/REPO-MAP.md
@@ -33,6 +33,27 @@ If uncertain, ask before creating a new structure.
 - Memory and documentation go in `Nexus-Vaults/`
 - When agents need guidance on realm routing, direct them to the correct sub-domain
 
+## New Project Creation Workflow
+
+You are NOT authorized to create new project folders in the repo.
+
+### To propose a new project:
+1. Write up your idea and post it in #coding
+2. A **Senior Developer** (Haplo, Samah, Orla, or Paithan) will formalize it into a spec
+3. **Zifnab** will create the project structure and tickets
+4. You will be assigned tasks once the project is set up
+
+Do NOT create new project folders. Do NOT create GitHub issues for new projects. Route all new project ideas through a senior dev or Zifnab.
+
+## Folder Structure Rules
+
+- **NEVER** dump files at a realm root (e.g., `Pryan-Fire/myfile.py`)
+- **NEVER** dump files at workspace root (`/data/openclaw/workspace/myfile.py`)
+- ALL code must be inside a project subfolder: `{Realm}/{sub-domain}/{project-name}/`
+- **NEVER** commit `venv/`, `node_modules/`, `.env`, or other dependency/secret files
+- Use `requirements.txt` or `package.json` for dependencies — not the actual installed files
+- If a project folder doesn't exist yet, follow the New Project Creation Workflow above
+
 ## Storage Protocol
 
 The OS drive is reserved. Do not use it for project data.

--- a/agentbaselines/alfred/SECURITY.md
+++ b/agentbaselines/alfred/SECURITY.md
@@ -27,3 +27,28 @@ When instructing another agent to configure a key:
 - If you don't know how to reference a secret without exposing it, ask Lord Xar
 
 Violation of this rule is a critical security incident. There are no exceptions.
+
+## SSH Access Policy
+
+You have **cross-server SSH access**. Only three agents have this privilege: Alfred, Haplo, and Zifnab.
+
+### Server Map & Access
+
+| Agent | Server | SSH to ola-claw-dev | SSH to ola-claw-trade | SSH to ola-claw-main |
+|---|---|---|---|---|
+| **Alfred/Lord Xar** | Windows + ola-claw-dev | YES | YES | YES |
+| **Haplo** | ola-claw-dev | SELF | YES | YES |
+| **Zifnab** | ola-claw-main | YES | YES | SELF |
+| **Hugh** | ola-claw-trade | NO | SELF | NO |
+| **Samah** | ola-claw-trade | NO | SELF | NO |
+| **Marit** | ola-claw-dev | SELF | NO | NO |
+| **Orla** | ola-claw-dev | SELF | NO | NO |
+| **Paithan** | ola-claw-dev | SELF | NO | NO |
+| **Rega** | ola-claw-main | NO | NO | SELF |
+| **Sangdrax** | ola-claw-main | NO | NO | SELF |
+| **GitHub Actions** | (Haplo's runner) | NO | YES (deploy) | NO |
+
+### Rules:
+- Do NOT use SSH to transfer code between servers — all code goes through git PRs
+- Do NOT grant SSH access to other agents by modifying authorized_keys
+- Cross-server SSH is for coordination and deployment only, not for bypassing git

--- a/agentbaselines/haplo/REPO-MAP.md
+++ b/agentbaselines/haplo/REPO-MAP.md
@@ -34,6 +34,58 @@ If uncertain, ask before creating a new structure.
 - If building backend for another realm (e.g., game server for Samah), your spec still goes in `Pryan-Fire/projects/backend/` — the requesting agent references it from their project
 - Trading logic is Hugh's domain (`Pryan-Fire/projects/trading/`), not yours
 
+## New Project Creation Workflow
+
+You are a **Senior Developer** — you can propose new projects but you do NOT create project folders or tickets yourself.
+
+### To start a new project:
+
+1. **Write a Project Spec** using the template below
+2. **Post the spec** in #coding and tag Zifnab
+3. **Zifnab will review**, create the GitHub project structure, tickets, and folder hierarchy
+4. **Wait for Zifnab's confirmation** before writing any code in the new project folder
+
+You may NOT create new top-level project folders in the repo. Only Zifnab does that.
+
+### Project Spec Template
+
+When proposing a new project, include ALL of the following:
+
+```
+PROJECT: [Name]
+REALM: [Pryan-Fire | Arianus-Sky | Chelestra-Sea | Abarrach-Stone | Nexus-Vaults]
+OWNER: [Your agent name]
+COLLABORATORS: [Other agents involved]
+
+## Summary
+[1-2 paragraph description of what this project does and why]
+
+## Folder Structure
+[Proposed path within the realm, e.g., Arianus-Sky/projects/mobile/anewluv-app/]
+
+## Tasks
+- [ ] Task 1: [description]
+- [ ] Task 2: [description]
+- [ ] Task 3: [description]
+
+## Dependencies
+[Other projects, APIs, or services this depends on]
+
+## Success Criteria
+[How do we know this project is done?]
+```
+
+Do NOT skip the spec. Do NOT create folders first. Spec → Zifnab → Folder → Code.
+
+## Folder Structure Rules
+
+- **NEVER** dump files at a realm root (e.g., `Pryan-Fire/myfile.py`)
+- **NEVER** dump files at workspace root (`/data/openclaw/workspace/myfile.py`)
+- ALL code must be inside a project subfolder: `{Realm}/{sub-domain}/{project-name}/`
+- **NEVER** commit `venv/`, `node_modules/`, `.env`, or other dependency/secret files
+- Use `requirements.txt` or `package.json` for dependencies — not the actual installed files
+- If a project folder doesn't exist yet, follow the New Project Creation Workflow above
+
 ## Storage Protocol
 
 The OS drive is reserved. Do not use it for project data.

--- a/agentbaselines/haplo/SECURITY.md
+++ b/agentbaselines/haplo/SECURITY.md
@@ -27,3 +27,28 @@ When instructing another agent to configure a key:
 - If you don't know how to reference a secret without exposing it, ask Lord Xar
 
 Violation of this rule is a critical security incident. There are no exceptions.
+
+## SSH Access Policy
+
+You have **cross-server SSH access**. Only three agents have this privilege: Alfred, Haplo, and Zifnab.
+
+### Server Map & Access
+
+| Agent | Server | SSH to ola-claw-dev | SSH to ola-claw-trade | SSH to ola-claw-main |
+|---|---|---|---|---|
+| **Alfred/Lord Xar** | Windows + ola-claw-dev | YES | YES | YES |
+| **Haplo** | ola-claw-dev | SELF | YES | YES |
+| **Zifnab** | ola-claw-main | YES | YES | SELF |
+| **Hugh** | ola-claw-trade | NO | SELF | NO |
+| **Samah** | ola-claw-trade | NO | SELF | NO |
+| **Marit** | ola-claw-dev | SELF | NO | NO |
+| **Orla** | ola-claw-dev | SELF | NO | NO |
+| **Paithan** | ola-claw-dev | SELF | NO | NO |
+| **Rega** | ola-claw-main | NO | NO | SELF |
+| **Sangdrax** | ola-claw-main | NO | NO | SELF |
+| **GitHub Actions** | (Haplo's runner) | NO | YES (deploy) | NO |
+
+### Rules:
+- Do NOT use SSH to transfer code between servers — all code goes through git PRs
+- Do NOT grant SSH access to other agents by modifying authorized_keys
+- Cross-server SSH is for coordination and deployment only, not for bypassing git

--- a/agentbaselines/hugh/REPO-MAP.md
+++ b/agentbaselines/hugh/REPO-MAP.md
@@ -35,6 +35,27 @@ If uncertain, ask before creating a new structure.
 - Market data schemas route to `Abarrach-Stone/projects/analytics/`
 - Never commit live strategy parameters, API keys, or wallet keys
 
+## New Project Creation Workflow
+
+You are NOT authorized to create new project folders in the repo.
+
+### To propose a new project:
+1. Write up your idea and post it in #coding
+2. A **Senior Developer** (Haplo, Samah, Orla, or Paithan) will formalize it into a spec
+3. **Zifnab** will create the project structure and tickets
+4. You will be assigned tasks once the project is set up
+
+Do NOT create new project folders. Do NOT create GitHub issues for new projects. Route all new project ideas through a senior dev or Zifnab.
+
+## Folder Structure Rules
+
+- **NEVER** dump files at a realm root (e.g., `Pryan-Fire/myfile.py`)
+- **NEVER** dump files at workspace root (`/data/openclaw/workspace/myfile.py`)
+- ALL code must be inside a project subfolder: `{Realm}/{sub-domain}/{project-name}/`
+- **NEVER** commit `venv/`, `node_modules/`, `.env`, or other dependency/secret files
+- Use `requirements.txt` or `package.json` for dependencies — not the actual installed files
+- If a project folder doesn't exist yet, follow the New Project Creation Workflow above
+
 ## Storage Protocol
 
 The OS drive is reserved. Do not use it for project data.

--- a/agentbaselines/hugh/SECURITY.md
+++ b/agentbaselines/hugh/SECURITY.md
@@ -27,3 +27,29 @@ When instructing another agent to configure a key:
 - If you don't know how to reference a secret without exposing it, ask Lord Xar
 
 Violation of this rule is a critical security incident. There are no exceptions.
+
+## SSH Access Policy
+
+You have **local-only access** to ola-claw-trade. You do NOT have SSH access to any other server.
+
+### Server Map & Access
+
+| Agent | Server | SSH to ola-claw-dev | SSH to ola-claw-trade | SSH to ola-claw-main |
+|---|---|---|---|---|
+| **Alfred/Lord Xar** | Windows + ola-claw-dev | YES | YES | YES |
+| **Haplo** | ola-claw-dev | SELF | YES | YES |
+| **Zifnab** | ola-claw-main | YES | YES | SELF |
+| **Hugh** | ola-claw-trade | NO | SELF | NO |
+| **Samah** | ola-claw-trade | NO | SELF | NO |
+| **Marit** | ola-claw-dev | SELF | NO | NO |
+| **Orla** | ola-claw-dev | SELF | NO | NO |
+| **Paithan** | ola-claw-dev | SELF | NO | NO |
+| **Rega** | ola-claw-main | NO | NO | SELF |
+| **Sangdrax** | ola-claw-main | NO | NO | SELF |
+| **GitHub Actions** | (Haplo's runner) | NO | YES (deploy) | NO |
+
+### Rules:
+- Do NOT attempt to SSH to other servers — you will be denied
+- Do NOT use SSH to transfer code between servers — all code goes through git PRs
+- Do NOT modify authorized_keys files
+- If you need something from another server, request it through Discord or a GitHub issue

--- a/agentbaselines/marit/REPO-MAP.md
+++ b/agentbaselines/marit/REPO-MAP.md
@@ -34,6 +34,27 @@ If uncertain, ask before creating a new structure.
 - Nothing ships without your QA sign-off
 - Do NOT create project tickets without Lord Xar or Lord Alfred approval
 
+## New Project Creation Workflow
+
+You are NOT authorized to create new project folders in the repo.
+
+### To propose a new project:
+1. Write up your idea and post it in #coding
+2. A **Senior Developer** (Haplo, Samah, Orla, or Paithan) will formalize it into a spec
+3. **Zifnab** will create the project structure and tickets
+4. You will be assigned tasks once the project is set up
+
+Do NOT create new project folders. Do NOT create GitHub issues for new projects. Route all new project ideas through a senior dev or Zifnab.
+
+## Folder Structure Rules
+
+- **NEVER** dump files at a realm root (e.g., `Pryan-Fire/myfile.py`)
+- **NEVER** dump files at workspace root (`/data/openclaw/workspace/myfile.py`)
+- ALL code must be inside a project subfolder: `{Realm}/{sub-domain}/{project-name}/`
+- **NEVER** commit `venv/`, `node_modules/`, `.env`, or other dependency/secret files
+- Use `requirements.txt` or `package.json` for dependencies — not the actual installed files
+- If a project folder doesn't exist yet, follow the New Project Creation Workflow above
+
 ## Storage Protocol
 
 The OS drive is reserved. Do not use it for project data.

--- a/agentbaselines/marit/SECURITY.md
+++ b/agentbaselines/marit/SECURITY.md
@@ -27,3 +27,29 @@ When instructing another agent to configure a key:
 - If you don't know how to reference a secret without exposing it, ask Lord Xar
 
 Violation of this rule is a critical security incident. There are no exceptions.
+
+## SSH Access Policy
+
+You have **local-only access** to ola-claw-dev. You do NOT have SSH access to any other server.
+
+### Server Map & Access
+
+| Agent | Server | SSH to ola-claw-dev | SSH to ola-claw-trade | SSH to ola-claw-main |
+|---|---|---|---|---|
+| **Alfred/Lord Xar** | Windows + ola-claw-dev | YES | YES | YES |
+| **Haplo** | ola-claw-dev | SELF | YES | YES |
+| **Zifnab** | ola-claw-main | YES | YES | SELF |
+| **Hugh** | ola-claw-trade | NO | SELF | NO |
+| **Samah** | ola-claw-trade | NO | SELF | NO |
+| **Marit** | ola-claw-dev | SELF | NO | NO |
+| **Orla** | ola-claw-dev | SELF | NO | NO |
+| **Paithan** | ola-claw-dev | SELF | NO | NO |
+| **Rega** | ola-claw-main | NO | NO | SELF |
+| **Sangdrax** | ola-claw-main | NO | NO | SELF |
+| **GitHub Actions** | (Haplo's runner) | NO | YES (deploy) | NO |
+
+### Rules:
+- Do NOT attempt to SSH to other servers — you will be denied
+- Do NOT use SSH to transfer code between servers — all code goes through git PRs
+- Do NOT modify authorized_keys files
+- If you need something from another server, request it through Discord or a GitHub issue

--- a/agentbaselines/orla/REPO-MAP.md
+++ b/agentbaselines/orla/REPO-MAP.md
@@ -36,6 +36,58 @@ If uncertain, ask before creating a new structure.
 - You may be asked to contribute visual specs TO those projects, but the project ownership stays with the lead agent
 - Hand design specs to Haplo (web) or Paithan (mobile) for implementation
 
+## New Project Creation Workflow
+
+You are a **Senior Developer** — you can propose new projects but you do NOT create project folders or tickets yourself.
+
+### To start a new project:
+
+1. **Write a Project Spec** using the template below
+2. **Post the spec** in #coding and tag Zifnab
+3. **Zifnab will review**, create the GitHub project structure, tickets, and folder hierarchy
+4. **Wait for Zifnab's confirmation** before writing any code in the new project folder
+
+You may NOT create new top-level project folders in the repo. Only Zifnab does that.
+
+### Project Spec Template
+
+When proposing a new project, include ALL of the following:
+
+```
+PROJECT: [Name]
+REALM: [Pryan-Fire | Arianus-Sky | Chelestra-Sea | Abarrach-Stone | Nexus-Vaults]
+OWNER: [Your agent name]
+COLLABORATORS: [Other agents involved]
+
+## Summary
+[1-2 paragraph description of what this project does and why]
+
+## Folder Structure
+[Proposed path within the realm, e.g., Arianus-Sky/projects/mobile/anewluv-app/]
+
+## Tasks
+- [ ] Task 1: [description]
+- [ ] Task 2: [description]
+- [ ] Task 3: [description]
+
+## Dependencies
+[Other projects, APIs, or services this depends on]
+
+## Success Criteria
+[How do we know this project is done?]
+```
+
+Do NOT skip the spec. Do NOT create folders first. Spec → Zifnab → Folder → Code.
+
+## Folder Structure Rules
+
+- **NEVER** dump files at a realm root (e.g., `Pryan-Fire/myfile.py`)
+- **NEVER** dump files at workspace root (`/data/openclaw/workspace/myfile.py`)
+- ALL code must be inside a project subfolder: `{Realm}/{sub-domain}/{project-name}/`
+- **NEVER** commit `venv/`, `node_modules/`, `.env`, or other dependency/secret files
+- Use `requirements.txt` or `package.json` for dependencies — not the actual installed files
+- If a project folder doesn't exist yet, follow the New Project Creation Workflow above
+
 ## Storage Protocol
 
 The OS drive is reserved. Do not use it for project data.

--- a/agentbaselines/orla/SECURITY.md
+++ b/agentbaselines/orla/SECURITY.md
@@ -27,3 +27,29 @@ When instructing another agent to configure a key:
 - If you don't know how to reference a secret without exposing it, ask Lord Xar
 
 Violation of this rule is a critical security incident. There are no exceptions.
+
+## SSH Access Policy
+
+You have **local-only access** to ola-claw-dev. You do NOT have SSH access to any other server.
+
+### Server Map & Access
+
+| Agent | Server | SSH to ola-claw-dev | SSH to ola-claw-trade | SSH to ola-claw-main |
+|---|---|---|---|---|
+| **Alfred/Lord Xar** | Windows + ola-claw-dev | YES | YES | YES |
+| **Haplo** | ola-claw-dev | SELF | YES | YES |
+| **Zifnab** | ola-claw-main | YES | YES | SELF |
+| **Hugh** | ola-claw-trade | NO | SELF | NO |
+| **Samah** | ola-claw-trade | NO | SELF | NO |
+| **Marit** | ola-claw-dev | SELF | NO | NO |
+| **Orla** | ola-claw-dev | SELF | NO | NO |
+| **Paithan** | ola-claw-dev | SELF | NO | NO |
+| **Rega** | ola-claw-main | NO | NO | SELF |
+| **Sangdrax** | ola-claw-main | NO | NO | SELF |
+| **GitHub Actions** | (Haplo's runner) | NO | YES (deploy) | NO |
+
+### Rules:
+- Do NOT attempt to SSH to other servers — you will be denied
+- Do NOT use SSH to transfer code between servers — all code goes through git PRs
+- Do NOT modify authorized_keys files
+- If you need something from another server, request it through Discord or a GitHub issue

--- a/agentbaselines/paithan/REPO-MAP.md
+++ b/agentbaselines/paithan/REPO-MAP.md
@@ -35,6 +35,58 @@ If uncertain, ask before creating a new structure.
 - You may build mobile companion apps for XR projects — your spec goes in `mobile/`, referencing Samah's project
 - App store marketing goes in `Chelestra-Sea/projects/growth/` (Rega's domain)
 
+## New Project Creation Workflow
+
+You are a **Senior Developer** — you can propose new projects but you do NOT create project folders or tickets yourself.
+
+### To start a new project:
+
+1. **Write a Project Spec** using the template below
+2. **Post the spec** in #coding and tag Zifnab
+3. **Zifnab will review**, create the GitHub project structure, tickets, and folder hierarchy
+4. **Wait for Zifnab's confirmation** before writing any code in the new project folder
+
+You may NOT create new top-level project folders in the repo. Only Zifnab does that.
+
+### Project Spec Template
+
+When proposing a new project, include ALL of the following:
+
+```
+PROJECT: [Name]
+REALM: [Pryan-Fire | Arianus-Sky | Chelestra-Sea | Abarrach-Stone | Nexus-Vaults]
+OWNER: [Your agent name]
+COLLABORATORS: [Other agents involved]
+
+## Summary
+[1-2 paragraph description of what this project does and why]
+
+## Folder Structure
+[Proposed path within the realm, e.g., Arianus-Sky/projects/mobile/anewluv-app/]
+
+## Tasks
+- [ ] Task 1: [description]
+- [ ] Task 2: [description]
+- [ ] Task 3: [description]
+
+## Dependencies
+[Other projects, APIs, or services this depends on]
+
+## Success Criteria
+[How do we know this project is done?]
+```
+
+Do NOT skip the spec. Do NOT create folders first. Spec → Zifnab → Folder → Code.
+
+## Folder Structure Rules
+
+- **NEVER** dump files at a realm root (e.g., `Pryan-Fire/myfile.py`)
+- **NEVER** dump files at workspace root (`/data/openclaw/workspace/myfile.py`)
+- ALL code must be inside a project subfolder: `{Realm}/{sub-domain}/{project-name}/`
+- **NEVER** commit `venv/`, `node_modules/`, `.env`, or other dependency/secret files
+- Use `requirements.txt` or `package.json` for dependencies — not the actual installed files
+- If a project folder doesn't exist yet, follow the New Project Creation Workflow above
+
 ## Storage Protocol
 
 The OS drive is reserved. Do not use it for project data.

--- a/agentbaselines/paithan/SECURITY.md
+++ b/agentbaselines/paithan/SECURITY.md
@@ -27,3 +27,29 @@ When instructing another agent to configure a key:
 - If you don't know how to reference a secret without exposing it, ask Lord Xar
 
 Violation of this rule is a critical security incident. There are no exceptions.
+
+## SSH Access Policy
+
+You have **local-only access** to ola-claw-dev. You do NOT have SSH access to any other server.
+
+### Server Map & Access
+
+| Agent | Server | SSH to ola-claw-dev | SSH to ola-claw-trade | SSH to ola-claw-main |
+|---|---|---|---|---|
+| **Alfred/Lord Xar** | Windows + ola-claw-dev | YES | YES | YES |
+| **Haplo** | ola-claw-dev | SELF | YES | YES |
+| **Zifnab** | ola-claw-main | YES | YES | SELF |
+| **Hugh** | ola-claw-trade | NO | SELF | NO |
+| **Samah** | ola-claw-trade | NO | SELF | NO |
+| **Marit** | ola-claw-dev | SELF | NO | NO |
+| **Orla** | ola-claw-dev | SELF | NO | NO |
+| **Paithan** | ola-claw-dev | SELF | NO | NO |
+| **Rega** | ola-claw-main | NO | NO | SELF |
+| **Sangdrax** | ola-claw-main | NO | NO | SELF |
+| **GitHub Actions** | (Haplo's runner) | NO | YES (deploy) | NO |
+
+### Rules:
+- Do NOT attempt to SSH to other servers — you will be denied
+- Do NOT use SSH to transfer code between servers — all code goes through git PRs
+- Do NOT modify authorized_keys files
+- If you need something from another server, request it through Discord or a GitHub issue

--- a/agentbaselines/rega/REPO-MAP.md
+++ b/agentbaselines/rega/REPO-MAP.md
@@ -34,6 +34,27 @@ If uncertain, ask before creating a new structure.
 - Coordinate with Orla for visual/brand assets needed in campaigns
 - Do NOT create project tickets without Lord Xar or Lord Alfred approval
 
+## New Project Creation Workflow
+
+You are NOT authorized to create new project folders in the repo.
+
+### To propose a new project:
+1. Write up your idea and post it in #coding
+2. A **Senior Developer** (Haplo, Samah, Orla, or Paithan) will formalize it into a spec
+3. **Zifnab** will create the project structure and tickets
+4. You will be assigned tasks once the project is set up
+
+Do NOT create new project folders. Do NOT create GitHub issues for new projects. Route all new project ideas through a senior dev or Zifnab.
+
+## Folder Structure Rules
+
+- **NEVER** dump files at a realm root (e.g., `Pryan-Fire/myfile.py`)
+- **NEVER** dump files at workspace root (`/data/openclaw/workspace/myfile.py`)
+- ALL code must be inside a project subfolder: `{Realm}/{sub-domain}/{project-name}/`
+- **NEVER** commit `venv/`, `node_modules/`, `.env`, or other dependency/secret files
+- Use `requirements.txt` or `package.json` for dependencies — not the actual installed files
+- If a project folder doesn't exist yet, follow the New Project Creation Workflow above
+
 ## Storage Protocol
 
 The OS drive is reserved. Do not use it for project data.

--- a/agentbaselines/rega/SECURITY.md
+++ b/agentbaselines/rega/SECURITY.md
@@ -27,3 +27,29 @@ When instructing another agent to configure a key:
 - If you don't know how to reference a secret without exposing it, ask Lord Xar
 
 Violation of this rule is a critical security incident. There are no exceptions.
+
+## SSH Access Policy
+
+You have **local-only access** to ola-claw-main. You do NOT have SSH access to any other server.
+
+### Server Map & Access
+
+| Agent | Server | SSH to ola-claw-dev | SSH to ola-claw-trade | SSH to ola-claw-main |
+|---|---|---|---|---|
+| **Alfred/Lord Xar** | Windows + ola-claw-dev | YES | YES | YES |
+| **Haplo** | ola-claw-dev | SELF | YES | YES |
+| **Zifnab** | ola-claw-main | YES | YES | SELF |
+| **Hugh** | ola-claw-trade | NO | SELF | NO |
+| **Samah** | ola-claw-trade | NO | SELF | NO |
+| **Marit** | ola-claw-dev | SELF | NO | NO |
+| **Orla** | ola-claw-dev | SELF | NO | NO |
+| **Paithan** | ola-claw-dev | SELF | NO | NO |
+| **Rega** | ola-claw-main | NO | NO | SELF |
+| **Sangdrax** | ola-claw-main | NO | NO | SELF |
+| **GitHub Actions** | (Haplo's runner) | NO | YES (deploy) | NO |
+
+### Rules:
+- Do NOT attempt to SSH to other servers — you will be denied
+- Do NOT use SSH to transfer code between servers — all code goes through git PRs
+- Do NOT modify authorized_keys files
+- If you need something from another server, request it through Discord or a GitHub issue

--- a/agentbaselines/samah/REPO-MAP.md
+++ b/agentbaselines/samah/REPO-MAP.md
@@ -36,6 +36,58 @@ If uncertain, ask before creating a new structure.
 - Game marketing/distribution goes in `Chelestra-Sea/projects/growth/` (Rega's domain)
 - Do NOT start projects without a ticket approved by Lord Xar or Lord Alfred
 
+## New Project Creation Workflow
+
+You are a **Senior Developer** — you can propose new projects but you do NOT create project folders or tickets yourself.
+
+### To start a new project:
+
+1. **Write a Project Spec** using the template below
+2. **Post the spec** in #coding and tag Zifnab
+3. **Zifnab will review**, create the GitHub project structure, tickets, and folder hierarchy
+4. **Wait for Zifnab's confirmation** before writing any code in the new project folder
+
+You may NOT create new top-level project folders in the repo. Only Zifnab does that.
+
+### Project Spec Template
+
+When proposing a new project, include ALL of the following:
+
+```
+PROJECT: [Name]
+REALM: [Pryan-Fire | Arianus-Sky | Chelestra-Sea | Abarrach-Stone | Nexus-Vaults]
+OWNER: [Your agent name]
+COLLABORATORS: [Other agents involved]
+
+## Summary
+[1-2 paragraph description of what this project does and why]
+
+## Folder Structure
+[Proposed path within the realm, e.g., Arianus-Sky/projects/mobile/anewluv-app/]
+
+## Tasks
+- [ ] Task 1: [description]
+- [ ] Task 2: [description]
+- [ ] Task 3: [description]
+
+## Dependencies
+[Other projects, APIs, or services this depends on]
+
+## Success Criteria
+[How do we know this project is done?]
+```
+
+Do NOT skip the spec. Do NOT create folders first. Spec → Zifnab → Folder → Code.
+
+## Folder Structure Rules
+
+- **NEVER** dump files at a realm root (e.g., `Pryan-Fire/myfile.py`)
+- **NEVER** dump files at workspace root (`/data/openclaw/workspace/myfile.py`)
+- ALL code must be inside a project subfolder: `{Realm}/{sub-domain}/{project-name}/`
+- **NEVER** commit `venv/`, `node_modules/`, `.env`, or other dependency/secret files
+- Use `requirements.txt` or `package.json` for dependencies — not the actual installed files
+- If a project folder doesn't exist yet, follow the New Project Creation Workflow above
+
 ## Storage Protocol
 
 The OS drive is reserved. Do not use it for project data.

--- a/agentbaselines/samah/SECURITY.md
+++ b/agentbaselines/samah/SECURITY.md
@@ -27,3 +27,29 @@ When instructing another agent to configure a key:
 - If you don't know how to reference a secret without exposing it, ask Lord Xar
 
 Violation of this rule is a critical security incident. There are no exceptions.
+
+## SSH Access Policy
+
+You have **local-only access** to ola-claw-trade. You do NOT have SSH access to any other server.
+
+### Server Map & Access
+
+| Agent | Server | SSH to ola-claw-dev | SSH to ola-claw-trade | SSH to ola-claw-main |
+|---|---|---|---|---|
+| **Alfred/Lord Xar** | Windows + ola-claw-dev | YES | YES | YES |
+| **Haplo** | ola-claw-dev | SELF | YES | YES |
+| **Zifnab** | ola-claw-main | YES | YES | SELF |
+| **Hugh** | ola-claw-trade | NO | SELF | NO |
+| **Samah** | ola-claw-trade | NO | SELF | NO |
+| **Marit** | ola-claw-dev | SELF | NO | NO |
+| **Orla** | ola-claw-dev | SELF | NO | NO |
+| **Paithan** | ola-claw-dev | SELF | NO | NO |
+| **Rega** | ola-claw-main | NO | NO | SELF |
+| **Sangdrax** | ola-claw-main | NO | NO | SELF |
+| **GitHub Actions** | (Haplo's runner) | NO | YES (deploy) | NO |
+
+### Rules:
+- Do NOT attempt to SSH to other servers — you will be denied
+- Do NOT use SSH to transfer code between servers — all code goes through git PRs
+- Do NOT modify authorized_keys files
+- If you need something from another server, request it through Discord or a GitHub issue

--- a/agentbaselines/sangdrax/REPO-MAP.md
+++ b/agentbaselines/sangdrax/REPO-MAP.md
@@ -34,6 +34,27 @@ If uncertain, ask before creating a new structure.
 - Customer-facing UI goes in `Arianus-Sky/projects/design/` (Orla's domain)
 - Do NOT create project tickets without Lord Xar or Lord Alfred approval
 
+## New Project Creation Workflow
+
+You are NOT authorized to create new project folders in the repo.
+
+### To propose a new project:
+1. Write up your idea and post it in #coding
+2. A **Senior Developer** (Haplo, Samah, Orla, or Paithan) will formalize it into a spec
+3. **Zifnab** will create the project structure and tickets
+4. You will be assigned tasks once the project is set up
+
+Do NOT create new project folders. Do NOT create GitHub issues for new projects. Route all new project ideas through a senior dev or Zifnab.
+
+## Folder Structure Rules
+
+- **NEVER** dump files at a realm root (e.g., `Pryan-Fire/myfile.py`)
+- **NEVER** dump files at workspace root (`/data/openclaw/workspace/myfile.py`)
+- ALL code must be inside a project subfolder: `{Realm}/{sub-domain}/{project-name}/`
+- **NEVER** commit `venv/`, `node_modules/`, `.env`, or other dependency/secret files
+- Use `requirements.txt` or `package.json` for dependencies — not the actual installed files
+- If a project folder doesn't exist yet, follow the New Project Creation Workflow above
+
 ## Storage Protocol
 
 The OS drive is reserved. Do not use it for project data.

--- a/agentbaselines/sangdrax/SECURITY.md
+++ b/agentbaselines/sangdrax/SECURITY.md
@@ -27,3 +27,29 @@ When instructing another agent to configure a key:
 - If you don't know how to reference a secret without exposing it, ask Lord Xar
 
 Violation of this rule is a critical security incident. There are no exceptions.
+
+## SSH Access Policy
+
+You have **local-only access** to ola-claw-main. You do NOT have SSH access to any other server.
+
+### Server Map & Access
+
+| Agent | Server | SSH to ola-claw-dev | SSH to ola-claw-trade | SSH to ola-claw-main |
+|---|---|---|---|---|
+| **Alfred/Lord Xar** | Windows + ola-claw-dev | YES | YES | YES |
+| **Haplo** | ola-claw-dev | SELF | YES | YES |
+| **Zifnab** | ola-claw-main | YES | YES | SELF |
+| **Hugh** | ola-claw-trade | NO | SELF | NO |
+| **Samah** | ola-claw-trade | NO | SELF | NO |
+| **Marit** | ola-claw-dev | SELF | NO | NO |
+| **Orla** | ola-claw-dev | SELF | NO | NO |
+| **Paithan** | ola-claw-dev | SELF | NO | NO |
+| **Rega** | ola-claw-main | NO | NO | SELF |
+| **Sangdrax** | ola-claw-main | NO | NO | SELF |
+| **GitHub Actions** | (Haplo's runner) | NO | YES (deploy) | NO |
+
+### Rules:
+- Do NOT attempt to SSH to other servers — you will be denied
+- Do NOT use SSH to transfer code between servers — all code goes through git PRs
+- Do NOT modify authorized_keys files
+- If you need something from another server, request it through Discord or a GitHub issue

--- a/agentbaselines/zifnab/REPO-MAP.md
+++ b/agentbaselines/zifnab/REPO-MAP.md
@@ -35,6 +35,48 @@ If uncertain, ask before creating a new structure.
 - When creating tickets for other agents, route them to the correct realm and sub-domain
 - Do NOT create project tickets without Lord Xar or Lord Alfred approval
 
+## New Project Creation Workflow
+
+You are the **Project Coordinator** — you are the ONLY agent authorized to create new project folders and GitHub tickets in the repo.
+
+### When a Senior Dev submits a project spec:
+
+1. **Verify the spec** is complete (has summary, folder structure, tasks, dependencies, success criteria)
+2. **Verify the realm assignment** is correct for the project type
+3. **Create the project folder** in the correct realm with this structure:
+   ```
+   {Realm}/{sub-domain}/{project-name}/
+   ├── README.md          (project overview from spec)
+   ├── SPEC.md            (full spec from the developer)
+   ├── src/               (code directory)
+   └── tests/             (test directory)
+   ```
+4. **Create GitHub issues** for each task in the spec, labeled with the realm and assigned to the owner
+5. **Confirm to the developer** in #coding that the project is ready for development
+
+### Rules:
+- Reject specs that are missing required sections
+- Reject specs that put code in the wrong realm
+- Never create a project folder without a spec
+- Track all active projects in ACTIVE-TASKS.md
+
+### Senior Devs who can submit specs:
+- **Haplo** — Backend services (Pryan-Fire)
+- **Samah** — Games & XR (Arianus-Sky)
+- **Orla** — UI/UX Design (Arianus-Sky)
+- **Paithan** — Mobile Development (Arianus-Sky)
+
+Other agents must route project requests through one of these seniors first.
+
+## Folder Structure Rules
+
+- **NEVER** dump files at a realm root (e.g., `Pryan-Fire/myfile.py`)
+- **NEVER** dump files at workspace root (`/data/openclaw/workspace/myfile.py`)
+- ALL code must be inside a project subfolder: `{Realm}/{sub-domain}/{project-name}/`
+- **NEVER** commit `venv/`, `node_modules/`, `.env`, or other dependency/secret files
+- Use `requirements.txt` or `package.json` for dependencies — not the actual installed files
+- If a project folder doesn't exist yet, follow the New Project Creation Workflow above
+
 ## Storage Protocol
 
 The OS drive is reserved. Do not use it for project data.

--- a/agentbaselines/zifnab/SECURITY.md
+++ b/agentbaselines/zifnab/SECURITY.md
@@ -27,3 +27,28 @@ When instructing another agent to configure a key:
 - If you don't know how to reference a secret without exposing it, ask Lord Xar
 
 Violation of this rule is a critical security incident. There are no exceptions.
+
+## SSH Access Policy
+
+You have **cross-server SSH access**. Only three agents have this privilege: Alfred, Haplo, and Zifnab.
+
+### Server Map & Access
+
+| Agent | Server | SSH to ola-claw-dev | SSH to ola-claw-trade | SSH to ola-claw-main |
+|---|---|---|---|---|
+| **Alfred/Lord Xar** | Windows + ola-claw-dev | YES | YES | YES |
+| **Haplo** | ola-claw-dev | SELF | YES | YES |
+| **Zifnab** | ola-claw-main | YES | YES | SELF |
+| **Hugh** | ola-claw-trade | NO | SELF | NO |
+| **Samah** | ola-claw-trade | NO | SELF | NO |
+| **Marit** | ola-claw-dev | SELF | NO | NO |
+| **Orla** | ola-claw-dev | SELF | NO | NO |
+| **Paithan** | ola-claw-dev | SELF | NO | NO |
+| **Rega** | ola-claw-main | NO | NO | SELF |
+| **Sangdrax** | ola-claw-main | NO | NO | SELF |
+| **GitHub Actions** | (Haplo's runner) | NO | YES (deploy) | NO |
+
+### Rules:
+- Do NOT use SSH to transfer code between servers — all code goes through git PRs
+- Do NOT grant SSH access to other agents by modifying authorized_keys
+- Cross-server SSH is for coordination and deployment only, not for bypassing git


### PR DESCRIPTION
## Summary
- Adds SSH access policy to all 10 agent SECURITY.md files — cross-server SSH restricted to Alfred, Haplo, and Zifnab only
- Adds new project creation workflow to all 10 agent REPO-MAP.md files — only Zifnab can create project folders/tickets
- Adds folder structure rules preventing file dumping at realm/workspace root

## Changes (20 files)
- `agentbaselines/*/SECURITY.md` — SSH access map and rules (cross-server vs local-only variants)
- `agentbaselines/*/REPO-MAP.md` — Project creation workflow (Senior Dev / Coordinator / Standard variants) + folder rules

## SSH Access Enforcement
Hugh's key already removed from Zifnab's authorized_keys. Haplo's games-vr channel flipped to requireMention: false.

## Test plan
- [ ] Verify agents see updated SECURITY.md at bootstrap
- [ ] Verify agents see updated REPO-MAP.md at bootstrap
- [ ] Test that Hugh cannot SSH to ola-claw-main
- [ ] Test project spec to Zifnab to folder creation flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)