### PR TITLE
fix(security): redact exposed API keys

### DIFF
--- a/.claude/handoffs/session-2026-03-05-infra-fixes.md
+++ b/.claude/handoffs/session-2026-03-05-infra-fixes.md
@@ -93,7 +93,7 @@ systemctl --user status openclaw-gateway
 
 ### Fallback: OpenRouter (free models via Rate Guard proxy)
 - **Proxy URL**: `http://localhost:8788/v1` (Rate Guard v2 budget proxy running on each server)
-- **API Key**: `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`
+- **API Key**: `[REDACTED — rotate this key]`
 - **Free models available**:
   - `stepfun/step-3.5-flash:free`
   - `arcee-ai/trinity-mini:free`
@@ -224,7 +224,7 @@ OpenClaw Gateway (port 18789)
 - **Budget tracking**: `/data/openclaw/rate-guard-v2/openrouter-budget.json`
 - **What it does**: Reverse proxy for OpenRouter with per-model daily spend caps ($5/day per model), balance checking, and budget enforcement
 - **OpenClaw config**: Set OpenRouter provider `baseUrl` to `http://localhost:8788/v1`
-- **API key**: `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` (stored in openrouter-limits.json)
+- **API key**: `[REDACTED — rotate this key]` (stored in openrouter-limits.json)
 - **Balance guard**: Polls OpenRouter credits, blocks paid models when balance drops below $6
 - **Analytics**: Logs to `rate-guard-analytics.db` (SQLite) for fleet reporting
 

--- a/.claude/handoffs/session-2026-03-06-zifnab-fix.md
+++ b/.claude/handoffs/session-2026-03-06-zifnab-fix.md
@@ -33,7 +33,7 @@ Leave #jarvis (`1475082997027049584`) unchanged.
 Replace entire file with ONLY:
 ```
 [Service]
-Environment="GEMINI_API_KEY=AIzaSyCByvtJUxWRbmQ23TJG266jq0tyq8PsbJc"
+Environment="GEMINI_API_KEY=[REDACTED — rotate this key]"
 ```
 Then: `systemctl --user daemon-reload && systemctl --user restart openclaw-gateway.service`
 

--- a/.gemini/memory/openclaw-models.md
+++ b/.gemini/memory/openclaw-models.md
@@ -3,14 +3,14 @@
 ## API Accounts
 - Google Paid Tier 1 account — $300 free credits (~$80 used)
 - SEPARATE Google Cloud projects per server (FIXED 2026-02-26):
-  - ola-claw-main: project `ola-claw-main`, key `AIzaSyDd...FSN3os`
-  - ola-claw-trade: project `ola-claw-trade`, key `AIzaSyCy...Kzz9s`
-  - ola-claw-dev: project `ola-claw-dev`, key `AIzaSyCO...a4Nvg`
+  - ola-claw-main: project `ola-claw-main`, key `[REDACTED]`
+  - ola-claw-trade: project `ola-claw-trade`, key `[REDACTED]`
+  - ola-claw-dev: project `ola-claw-dev`, key `[REDACTED]`
 - Each server gets own 1M TPM quota (3M total vs old shared 1M)
 - TPM limit: ~1M per PROJECT on Tier 1 (rate limits are PER PROJECT, not per key!)
 - Google API rate limits are PER PROJECT. Multiple projects = multiplied quota.
 - Auth-profiles path: `/data/openclaw/agents/main/agent/auth-profiles.json`
-- OpenRouter key: `sk-or-v1-ad8eb96b...` — $9 added 2026-03-01. Now PRIMARY provider via budget proxy.
+- OpenRouter key: `[REDACTED]` — $9 added 2026-03-01. Now PRIMARY provider via budget proxy.
 - Budget proxy at localhost:8788 enforces $5/day per model hard cap
 - DO NOT put claude-sonnet on any fallback chain — expensive and unnecessary
 

--- a/.gemini/memory/openclaw-server-config.md
+++ b/.gemini/memory/openclaw-server-config.md
@@ -35,7 +35,7 @@
 
 ## Google API Key Location
 - Stored in: `/home/openclaw/.openclaw/agents/main/agent/auth-profiles.json`
-- Key prefix: `AIzaSyAy...`
+- Key prefix: `[REDACTED]`
 - This is a PAID Tier 1 Google account
 
 ## Ollama (on ola-claw-dev)

--- a/.gemini/memory/rate-guard-ops.md
+++ b/.gemini/memory/rate-guard-ops.md
@@ -155,9 +155,9 @@ To fully remove a model from the fleet, you must clean ALL of these locations on
 ### Primary Keys (existing, per-server)
 | Server  | Project        | Key Prefix       |
 |---------|---------------|------------------|
-| Zifnab  | ola-claw-main | AIzaSyDd...FSN3os |
-| Hugh    | ola-claw-trade| AIzaSyCy...Kzz9s |
-| Haplo   | ola-claw-dev  | AIzaSyCO...a4Nvg |
+| Zifnab  | ola-claw-main | [REDACTED] |
+| Hugh    | ola-claw-trade| [REDACTED] |
+| Haplo   | ola-claw-dev  | [REDACTED] |
 
 ### Cascade Design (UPDATED 2026-02-28 — per-model key rotation)
 Each rate guard has ALL keys. Router tries ALL keys for each model before falling to next model:

--- a/Nexus-Vaults/memory/openclaw-models.md
+++ b/Nexus-Vaults/memory/openclaw-models.md
@@ -3,14 +3,14 @@
 ## API Accounts
 - Google Paid Tier 1 account — $300 free credits (~$80 used)
 - SEPARATE Google Cloud projects per server (FIXED 2026-02-26):
-  - ola-claw-main: project `ola-claw-main`, key `AIzaSyDd...FSN3os`
-  - ola-claw-trade: project `ola-claw-trade`, key `AIzaSyCy...Kzz9s`
-  - ola-claw-dev: project `ola-claw-dev`, key `AIzaSyCO...a4Nvg`
+  - ola-claw-main: project `ola-claw-main`, key `[REDACTED]`
+  - ola-claw-trade: project `ola-claw-trade`, key `[REDACTED]`
+  - ola-claw-dev: project `ola-claw-dev`, key `[REDACTED]`
 - Each server gets own 1M TPM quota (3M total vs old shared 1M)
 - TPM limit: ~1M per PROJECT on Tier 1 (rate limits are PER PROJECT, not per key!)
 - Google API rate limits are PER PROJECT. Multiple projects = multiplied quota.
 - Auth-profiles path: `/data/openclaw/agents/main/agent/auth-profiles.json`
-- OpenRouter key: `sk-or-v1-ad8eb96b...` — $9 added 2026-03-01. Now PRIMARY provider via budget proxy.
+- OpenRouter key: `[REDACTED]` — $9 added 2026-03-01. Now PRIMARY provider via budget proxy.
 - Budget proxy at localhost:8788 enforces $5/day per model hard cap
 - DO NOT put claude-sonnet on any fallback chain — expensive and unnecessary
 

--- a/Nexus-Vaults/memory/openclaw-server-config.md
+++ b/Nexus-Vaults/memory/openclaw-server-config.md
@@ -35,7 +35,7 @@
 
 ## Google API Key Location
 - Stored in: `/home/openclaw/.openclaw/agents/main/agent/auth-profiles.json`
-- Key prefix: `AIzaSyAy...`
+- Key prefix: `[REDACTED]`
 - This is a PAID Tier 1 Google account
 
 ## Ollama (on ola-claw-dev)

--- a/Nexus-Vaults/memory/rate-guard-ops.md
+++ b/Nexus-Vaults/memory/rate-guard-ops.md
@@ -155,9 +155,9 @@ To fully remove a model from the fleet, you must clean ALL of these locations on
 ### Primary Keys (existing, per-server)
 | Server  | Project        | Key Prefix       |
 |---------|---------------|------------------|
-| Zifnab  | ola-claw-main | AIzaSyDd...FSN3os |
-| Hugh    | ola-claw-trade| AIzaSyCy...Kzz9s |
-| Haplo   | ola-claw-dev  | AIzaSyCO...a4Nvg |
+| Zifnab  | ola-claw-main | [REDACTED] |
+| Hugh    | ola-claw-trade| [REDACTED] |
+| Haplo   | ola-claw-dev  | [REDACTED] |
 
 ### Cascade Design (UPDATED 2026-02-28 — per-model key rotation)
 Each rate guard has ALL keys. Router tries ALL keys for each model before falling to next model:


### PR DESCRIPTION
## Summary
- Redacted Gemini API key (full, for ola-claw-main) exposed in `.claude/handoffs/session-2026-03-06-zifnab-fix.md`
- Redacted OpenRouter API key (full) exposed in `.claude/handoffs/session-2026-03-05-infra-fixes.md`
- Redacted partial key prefixes in `.gemini/memory/` and `Nexus-Vaults/memory/` files

## Keys that need rotation
- **Gemini API key for ola-claw-main project** — full key was committed in the zifnab-fix handoff
- **OpenRouter API key** — full key was committed in the infra-fixes handoff

## Root cause
Claude handoff files from sessions on 2026-03-05 and 2026-03-06 included plaintext API keys as part of server config documentation. These were committed in `ab595cb` and `b6698ad`.

## Note
Keys remain in git history even after this redaction. Rotation is required.

Generated with [Claude Code](https://claude.com/claude-code)