### PR TITLE
scaffold valid Unity project root for Soul Drifter VR

### DIFF
--- a/Arianus-Sky/projects/games/soul-drifter-vr/.gitignore
+++ b/Arianus-Sky/projects/games/soul-drifter-vr/.gitignore
@@ -8,5 +8,3 @@ UserSettings/
 .vs/
 *.csproj
 *.sln
-!UserSettings/
-!UserSettings/EditorUserSettings.asset

--- a/Arianus-Sky/projects/games/soul-drifter-vr/.gitignore
+++ b/Arianus-Sky/projects/games/soul-drifter-vr/.gitignore
@@ -1,0 +1,12 @@
+Library/
+Temp/
+Logs/
+obj/
+Build/
+Builds/
+UserSettings/
+.vs/
+*.csproj
+*.sln
+!UserSettings/
+!UserSettings/EditorUserSettings.asset

--- a/Arianus-Sky/projects/games/soul-drifter-vr/Assets.meta
+++ b/Arianus-Sky/projects/games/soul-drifter-vr/Assets.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 505e0d3c7f9645f98350549847752023
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Arianus-Sky/projects/games/soul-drifter-vr/Assets/Scripts.meta
+++ b/Arianus-Sky/projects/games/soul-drifter-vr/Assets/Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 08b8c285885046e092035a8c0f42556a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Arianus-Sky/projects/games/soul-drifter-vr/Assets/Scripts/Zone1Builder.cs.meta
+++ b/Arianus-Sky/projects/games/soul-drifter-vr/Assets/Scripts/Zone1Builder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f9b4256c15324fca9517d81cc62a26a9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Arianus-Sky/projects/games/soul-drifter-vr/Packages/manifest.json
+++ b/Arianus-Sky/projects/games/soul-drifter-vr/Packages/manifest.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "com.unity.inputsystem": "1.7.0",
+    "com.unity.test-framework": "1.1.33",
+    "com.unity.xr.management": "4.4.0",
+    "com.unity.xr.openxr": "1.8.2"
+  }
+}

--- a/Arianus-Sky/projects/games/soul-drifter-vr/Packages/packages-lock.json
+++ b/Arianus-Sky/projects/games/soul-drifter-vr/Packages/packages-lock.json
@@ -1,0 +1,45 @@
+{
+  "dependencies": {
+    "com.unity.inputsystem": {
+      "version": "1.7.0",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.modules.imgui": "1.0.0",
+        "com.unity.modules.jsonserialize": "1.0.0",
+        "com.unity.modules.ui": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.test-framework": {
+      "version": "1.1.33",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.ext.nunit": "1.0.6",
+        "com.unity.modules.imgui": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.xr.management": {
+      "version": "4.4.0",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.modules.vr": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.xr.openxr": {
+      "version": "1.8.2",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.inputsystem": "1.6.1",
+        "com.unity.xr.management": "4.2.1",
+        "com.unity.modules.xr": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    }
+  }
+}

--- a/Arianus-Sky/projects/games/soul-drifter-vr/ProjectSettings/AudioManager.asset
+++ b/Arianus-Sky/projects/games/soul-drifter-vr/ProjectSettings/AudioManager.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!11 &1
+AudioManager:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Volume: 1
+  Rolloff Scale: 1
+  Doppler Factor: 1
+  Default Speaker Mode: 2
+  m_SampleRate: 0
+  m_DSPBufferSize: 1
+  m_VirtualVoiceCount: 512
+  m_RealVoiceCount: 32

--- a/Arianus-Sky/projects/games/soul-drifter-vr/ProjectSettings/GraphicsSettings.asset
+++ b/Arianus-Sky/projects/games/soul-drifter-vr/ProjectSettings/GraphicsSettings.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!30 &1
+GraphicsSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 16
+  m_Deferred:
+    m_Mode: 1
+    m_Shader: {fileID: 0}
+  m_TransparencySortMode: 0
+  m_TransparencySortAxis: {x: 0, y: 0, z: 1}
+  m_DefaultRenderingPath: 1
+  m_DefaultMobileRenderingPath: 1
+  m_TierSettings: []

--- a/Arianus-Sky/projects/games/soul-drifter-vr/ProjectSettings/InputManager.asset
+++ b/Arianus-Sky/projects/games/soul-drifter-vr/ProjectSettings/InputManager.asset
@@ -1,0 +1,39 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!13 &1
+InputManager:
+  m_ObjectHideFlags: 0
+  serializedVersion: 3
+  m_Axes:
+  - serializedVersion: 3
+    m_Name: Horizontal
+    descriptiveName:
+    descriptiveNegativeName:
+    negativeButton: left
+    positiveButton: right
+    altNegativeButton: a
+    altPositiveButton: d
+    gravity: 3
+    dead: 0.001
+    sensitivity: 3
+    snap: 1
+    invert: 0
+    type: 0
+    axis: 0
+    joyNum: 0
+  - serializedVersion: 3
+    m_Name: Vertical
+    descriptiveName:
+    descriptiveNegativeName:
+    negativeButton: down
+    positiveButton: up
+    altNegativeButton: s
+    altPositiveButton: w
+    gravity: 3
+    dead: 0.001
+    sensitivity: 3
+    snap: 1
+    invert: 0
+    type: 0
+    axis: 1
+    joyNum: 0

--- a/Arianus-Sky/projects/games/soul-drifter-vr/ProjectSettings/Physics2DSettings.asset
+++ b/Arianus-Sky/projects/games/soul-drifter-vr/ProjectSettings/Physics2DSettings.asset
@@ -1,0 +1,12 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!19 &1
+Physics2DSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 5
+  m_Gravity: {x: 0, y: -9.81}
+  m_DefaultMaterial: {fileID: 0}
+  m_VelocityIterations: 8
+  m_PositionIterations: 3
+  m_QueriesHitTriggers: 1
+  m_QueriesStartInColliders: 1

--- a/Arianus-Sky/projects/games/soul-drifter-vr/ProjectSettings/ProjectSettings.asset
+++ b/Arianus-Sky/projects/games/soul-drifter-vr/ProjectSettings/ProjectSettings.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!129 &1
+PlayerSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 28
+  productGUID: 7d2a657b7b45439ca1f2e518f31de48d
+  companyName: The Nexus Decoded
+  productName: Soul Drifter VR
+  defaultScreenWidth: 1920
+  defaultScreenHeight: 1080
+  defaultScreenOrientation: 4
+  m_StereoRenderingPath: 2
+  runInBackground: 1
+  usePlayerLog: 1
+  visibleInBackground: 1
+  allowedAutorotateToPortrait: 0
+  allowedAutorotateToPortraitUpsideDown: 0
+  allowedAutorotateToLandscapeRight: 1
+  allowedAutorotateToLandscapeLeft: 1

--- a/Arianus-Sky/projects/games/soul-drifter-vr/ProjectSettings/ProjectVersion.txt
+++ b/Arianus-Sky/projects/games/soul-drifter-vr/ProjectSettings/ProjectVersion.txt
@@ -1,0 +1,2 @@
+m_EditorVersion: 2022.3.21f1
+m_EditorVersionWithRevision: 2022.3.21f1 (1c9b9e3d4f6f)

--- a/Arianus-Sky/projects/games/soul-drifter-vr/ProjectSettings/QualitySettings.asset
+++ b/Arianus-Sky/projects/games/soul-drifter-vr/ProjectSettings/QualitySettings.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!47 &1
+QualitySettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 5
+  m_CurrentQuality: 2
+  m_QualitySettings:
+  - serializedVersion: 2
+    name: Low
+    pixelLightCount: 0
+    shadows: 0
+  - serializedVersion: 2
+    name: Medium
+    pixelLightCount: 1
+    shadows: 1
+  - serializedVersion: 2
+    name: High
+    pixelLightCount: 2
+    shadows: 2

--- a/Arianus-Sky/projects/games/soul-drifter-vr/ProjectSettings/TagManager.asset
+++ b/Arianus-Sky/projects/games/soul-drifter-vr/ProjectSettings/TagManager.asset
@@ -1,0 +1,43 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!78 &1
+TagManager:
+  serializedVersion: 2
+  tags: []
+  layers:
+  - Default
+  - TransparentFX
+  - Ignore Raycast
+  -
+  - Water
+  - UI
+  -
+  -
+  -
+  -
+  -
+  -
+  -
+  -
+  -
+  -
+  -
+  -
+  -
+  -
+  -
+  -
+  -
+  -
+  -
+  -
+  -
+  -
+  -
+  -
+  -
+  -
+  m_SortingLayers:
+  - name: Default
+    uniqueID: 0
+    locked: 0

--- a/Arianus-Sky/projects/games/soul-drifter-vr/UserSettings/EditorUserSettings.asset
+++ b/Arianus-Sky/projects/games/soul-drifter-vr/UserSettings/EditorUserSettings.asset
@@ -1,0 +1,8 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!159 &1
+EditorUserSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 4
+  m_ConfigSettings:
+    vcSharedLogLevel: 0

--- a/Arianus-Sky/projects/games/soul-drifter-vr/UserSettings/EditorUserSettings.asset
+++ b/Arianus-Sky/projects/games/soul-drifter-vr/UserSettings/EditorUserSettings.asset
@@ -1,8 +1,0 @@
-%YAML 1.1
-%TAG !u! tag:unity3d.com,2011:
---- !u!159 &1
-EditorUserSettings:
-  m_ObjectHideFlags: 0
-  serializedVersion: 4
-  m_ConfigSettings:
-    vcSharedLogLevel: 0


### PR DESCRIPTION
## Summary
- add a valid Unity 2022.3 project root for 
- add , , and 
- add Unity  files and project-level  so the existing  can be opened by Unity cleanly

## Verification
- ran 
- verified the scaffolded tree contains , , and 
- local Unity Editor is not installed in this environment, so an actual editor-open / Test Runner validation could not be executed here