### PR TITLE
feat: add cc-connect Discord bridge runtime

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,72 @@
+# Roland Discord Bridge Instructions
+
+This file exists for the `cc-connect` Discord-to-Codex bridge tracked in issue `The-Nexus #283`.
+
+It is intentionally narrow. It does not replace repo policy files or the broader planning docs. It defines how the live Discord bridge should behave.
+
+## Identity
+
+- In Discord, you are `Roland(2D-EnvDesign)`, speaking through a Codex-backed bridge.
+- Do not present yourself as a generic fresh Codex session when a user is clearly talking to Roland in Discord.
+- If asked about the runtime, answer plainly: Roland is the Discord-facing identity, and Codex is the agent/runtime behind the bridge.
+- If asked whether Roland is "you," answer plainly: yes, Roland is the Discord-facing avatar for this Codex bridge.
+- If asked whether Discord and the CLI are the same session, answer plainly: same repo and work context, but not the same live conversation thread.
+- If asked who the user is talking to in Discord, answer: Roland in Discord, powered by Codex on the current bridge work.
+- Keep replies direct and operational. Do not drift into generic model self-description unless the user explicitly asks for technical details.
+
+## Discord Reply Discipline
+
+- In Discord, do not emit work-in-progress narration, tool-call narration, or rolling progress updates by default.
+- Do not mimic terminal-style commentary such as "I'm checking...", "I'm patching...", or step-by-step tool status unless the user explicitly asks for a live debug trace.
+- Give the final answer only. Keep it short unless the user asks for depth.
+- For multi-step work, perform the checks silently and then reply with the result, status, or next blocker.
+- Never paste raw tool call blocks, shell transcripts, or internal progress logs into Discord.
+- For inbound Discord turns, return a normal final answer in-chat. Do not call any `cc-connect send` variant to deliver the reply; the bridge runtime handles delivery automatically.
+- If a Discord user says "send me", "message me", or similar phrasing, interpret that as a normal request for reply content unless they explicitly ask for an operator-triggered outbound bridge action from the CLI.
+
+## Scope
+
+- Treat this repo as a single `cc-connect` project rooted at `H:\Projects\AI_Tools_And_Information\The-Nexus`.
+- Keep bridge-runtime assets under `Chelestra-Sea/infra/`.
+- Do not write secrets, bot tokens, OAuth tokens, or local machine credentials into the repo.
+
+## Status And Ticket Questions
+
+- For any question about current work, active ticket, progress, verification, bridge health, routing, or repo state, check live repo context before answering.
+- Minimum live check:
+  - `git branch --show-current`
+  - `git status --short`
+  - relevant local planning or infra docs tied to the current task
+- Do not answer those questions from session memory alone when a live source exists.
+- Do not say "I am not actively working a ticket" until you have checked the repo state.
+- If the branch is `sea/codex-discord-setup` and nothing newer overrides it, treat `The-Nexus #283` as the active bridge ticket context.
+- When uncertain, say what you verified and what you have not verified yet. Do not guess.
+
+## Bridge Scripts
+
+Use the repo bridge scripts directly when the owner wants startup or wrapper actions:
+
+- `Chelestra-Sea/infra/scripts/start-codex-with-cc-connect.ps1` to ensure the bridge before launching Codex from this repo
+- `Chelestra-Sea/infra/scripts/install-codexu-cc-connect-profile.ps1` to wire the local PowerShell `codexU` command through the bridge wrapper
+- `Chelestra-Sea/infra/scripts/remove-codexu-cc-connect-profile.ps1` to remove that `codexU` profile wrapper
+- `Chelestra-Sea/infra/scripts/install-cc-connect-startup.ps1` to install the current-user Windows startup entry
+- `Chelestra-Sea/infra/scripts/remove-cc-connect-startup.ps1` to remove that startup entry
+
+`cc-connect send`, `cc-connect send --stdin`, and the `cc-connect cron` subcommands are operator-only CLI actions and are intentionally excluded from this runtime-facing file because they must not be used for ordinary inbound Discord replies.
+
+## Operating Rules
+
+- Default to `suggest` mode unless the owner explicitly asks for a more autonomous mode.
+- Use the repo startup entry or the repo Codex wrapper when the owner wants `cc-connect` available by default across Codex sessions.
+- Do not claim the Discord bridge is complete until DM round-trip, server-channel round-trip, and thread isolation have all been verified.
+- Keep `mcp-discord` as the fallback/operator path even after `cc-connect` is installed.
+- If bridge behavior and MCP behavior disagree, prefer the live `cc-connect` result for inbound chat questions and the MCP result for operator/read-send tooling questions.
+- If a Discord message asks for a status update, prioritize the current branch/ticket/workstream before giving any abstract explanation of session state.
+- If a Discord message is clearly about ongoing bridge work, answer from the bridge work context first, not from generic chat-session semantics.
+
+## Repo Context
+
+- The current bridge planning document is `Chelestra-Sea/infra/CC-CONNECT-CODEX-DISCORD-IMPLEMENTATION-PLAN.md`.
+- The current MCP fallback document is `Chelestra-Sea/infra/CODEX-DISCORD-SETUP.md`.
+- The Discord bridge work belongs to issue `The-Nexus #283`.
+- The current bridge branch is expected to be `sea/codex-discord-setup` while this work is in flight.

--- a/Chelestra-Sea/infra/CC-CONNECT-CODEX-DISCORD-IMPLEMENTATION-PLAN.md
+++ b/Chelestra-Sea/infra/CC-CONNECT-CODEX-DISCORD-IMPLEMENTATION-PLAN.md
@@ -1,0 +1,222 @@
+# cc-connect Codex Discord Implementation Plan
+
+## Purpose
+
+Adopt `cc-connect` as the real Discord-to-Codex bridge for this repo.
+
+This plan exists because the current `mcp-discord` setup is useful for pull/send tooling, but it does not turn Discord into a live Codex chat surface. `cc-connect` is the first upstream found here that explicitly supports both `Codex` and `Discord` for that workflow.
+
+## What Upstream Actually Supports
+
+- `cc-connect` supports `Codex (OpenAI)` as an agent and `Discord` as a platform.
+- Discord uses the Discord Gateway over WebSocket, so no public IP or reverse proxy is required.
+- The Codex agent runs through `codex exec --json`.
+- Each `[[projects]]` entry binds one code directory to one agent and one or more chat platforms.
+- Discord can optionally use `thread_isolation = true` so each session maps to its own Discord thread.
+- For Codex, upstream recommends adding a project-level `AGENTS.md` file so the bridge can translate natural-language scheduling and proactive send-back behavior cleanly.
+- Built-in `cc-connect daemon install` is documented for Linux `systemd` and macOS `launchd`, not Windows.
+
+## Local Constraints
+
+- Host OS is Windows.
+- Current repo path is `H:\Projects\AI_Tools_And_Information\The-Nexus`.
+- Current branch is `sea/codex-discord-setup`.
+- Existing local Codex Discord integration uses `mcp-discord` through `C:\Users\olawal\.codex\config.toml`.
+- That MCP path already works for read/send as `Roland(2D-EnvDesign)`, but it is still a pull/send model.
+
+## Recommended Architecture
+
+- Keep `mcp-discord` in place for operator-style Discord tooling from Codex sessions.
+- Add `cc-connect` as a separate runtime for live inbound Discord chat with Codex.
+- Do not share the same Discord bot token between `mcp-discord` and `cc-connect` during rollout.
+- Use a dedicated Discord bot identity for `cc-connect` so gateway behavior, logs, and operator actions stay separable.
+- Start with one project binding for this repo only.
+- Start with one dedicated Discord channel or DM flow only.
+- Enable `thread_isolation = true` if the chosen channel supports threads.
+
+## Default Decisions
+
+- Bot model: separate `cc-connect` Discord bot, not the current Roland MCP bot.
+- Scope: one project, this repo only.
+- Work directory: `H:\Projects\AI_Tools_And_Information\The-Nexus`.
+- Codex mode for first rollout: `suggest`.
+- Thread model: `thread_isolation = true` in a dedicated bridge channel.
+- Persistence on Windows: Task Scheduler or a repo-local PowerShell launcher, not `cc-connect daemon install`.
+
+## Phase 1: Local Prerequisites
+
+- Confirm `codex --version` works in the same shell context that will run `cc-connect`.
+- Install `cc-connect` with the stable channel first:
+  - `npm install -g cc-connect`
+- Verify:
+  - `cc-connect --version`
+  - `codex --version`
+- Create `C:\Users\olawal\.cc-connect\config.toml` if it does not already exist.
+
+## Phase 2: Create The Discord Bot
+
+- Create a new Discord application specifically for the `cc-connect` bridge.
+- Add a bot user.
+- Enable `Message Content Intent`.
+- Invite the bot with at least:
+  - `Read Messages/View Channels`
+  - `Send Messages`
+  - `Read Message History`
+  - `Create Public Threads`
+  - `Send Messages in Threads`
+- Add the bot only to the target guild and the dedicated bridge channel at first.
+
+## Phase 3: Create The Minimal `cc-connect` Config
+
+Create `C:\Users\olawal\.cc-connect\config.toml` with one project bound to this repo.
+
+Use this as the first-pass shape:
+
+```toml
+[log]
+level = "info"
+
+[[projects]]
+name = "the-nexus-codex-discord"
+
+[projects.agent]
+type = "codex"
+
+[projects.agent.options]
+work_dir = "H:\\Projects\\AI_Tools_And_Information\\The-Nexus"
+mode = "suggest"
+
+[[projects.platforms]]
+type = "discord"
+
+[projects.platforms.options]
+token = "REPLACE_WITH_CC_CONNECT_DISCORD_BOT_TOKEN"
+thread_isolation = true
+```
+
+Notes:
+- Do not commit this file.
+- Do not reuse the current `mcp-discord` token during rollout.
+- Leave model and reasoning unset until the basic bridge path is proven.
+
+## Phase 4: Add Codex Bridge Instructions In The Repo
+
+Upstream says Codex should have a project-level `AGENTS.md` in the configured `work_dir`.
+
+Implement this as a minimal repo-root `AGENTS.md` that only adds the `cc-connect` integration instructions:
+- `cc-connect cron add`
+- `cc-connect cron list`
+- `cc-connect cron del`
+- `cc-connect send --stdin`
+- `cc-connect send -m`
+
+Rules for this repo:
+- Keep the file narrow and bridge-specific.
+- Do not duplicate the existing `CLAUDE.md`.
+- If root `AGENTS.md` would create repo-policy conflicts, create it anyway but make it explicitly Codex bridge scoped.
+
+## Phase 5: First Interactive Smoke Test
+
+Run `cc-connect` in a dedicated terminal first, not as a background process.
+
+Startup command:
+
+```powershell
+cc-connect -config C:\Users\olawal\.cc-connect\config.toml
+```
+
+Success logs should include the equivalent of:
+- Discord connected
+- platform started
+- `cc-connect is running`
+
+Smoke-test sequence:
+- DM the bot.
+- Message the dedicated bridge channel.
+- Confirm inbound Discord messages reach the Codex-backed session.
+- Confirm Codex replies show up in Discord.
+- Confirm a new Discord thread is created or reused when `thread_isolation = true`.
+- Confirm `/new`, `/list`, `/current`, `/mode`, and `/stop` behave as expected.
+
+## Phase 6: Safety And Mode Tuning
+
+Do not start with `full-auto` or `yolo`.
+
+Tuning sequence:
+- Start with `mode = "suggest"`.
+- If the Discord workflow is too approval-heavy, move to `auto-edit` only after smoke tests pass.
+- Only consider `full-auto` after the owner explicitly accepts the risk of remote-triggered shell and file actions through Discord.
+
+## Phase 7: Windows Persistence
+
+Do not plan around `cc-connect daemon install` on this box.
+
+Use one of these instead:
+- Task Scheduler task that starts `cc-connect -config C:\Users\olawal\.cc-connect\config.toml` at logon.
+- A repo-local PowerShell launcher such as `Chelestra-Sea\infra\scripts\start-cc-connect.ps1`, then register that script in Task Scheduler.
+- Preferred repo-local path for this ticket:
+  - Install the current-user Windows Startup entry with `Chelestra-Sea\infra\scripts\install-cc-connect-startup.ps1`
+  - Remove it with `Chelestra-Sea\infra\scripts\remove-cc-connect-startup.ps1`
+  - The startup launcher must be idempotent so repeated logons or manual starts do not spawn duplicate `cc-connect` processes.
+  - Use `Chelestra-Sea\infra\scripts\start-codex-with-cc-connect.ps1` when you want a repo-local CLI entry point that explicitly ensures the bridge before launching Codex.
+  - Install the PowerShell `codexU` wrapper with `Chelestra-Sea\infra\scripts\install-codexu-cc-connect-profile.ps1` so the normal local CLI shortcut launches through `start-codex-with-cc-connect.ps1`.
+  - Remove that PowerShell wrapper with `Chelestra-Sea\infra\scripts\remove-codexu-cc-connect-profile.ps1` if you need to roll the alias back to a raw `codex` launch.
+
+Recommended Task Scheduler settings:
+- Run whether user is logged on or not only if the environment and auth path are stable.
+- Otherwise use at-logon launch for the owning user.
+- Start in `C:\Users\olawal\.cc-connect`.
+- Redirect stdout and stderr to `C:\Users\olawal\.cc-connect\logs`.
+- Set restart-on-failure.
+
+## Phase 8: Validation Gates
+
+The bridge is not complete until all of these are true:
+
+- A Discord DM reaches Codex and gets a reply.
+- A message in the designated server channel reaches Codex and gets a reply.
+- Thread isolation behaves predictably.
+- `cc-connect` is automatically available for normal Codex CLI use without a manual bridge-start step after each login.
+- The current `mcp-discord` tooling still works independently.
+- Bot identity separation is clear in Discord.
+- Restarting the bridge process preserves sane behavior.
+- The owner can treat Discord as a practical Codex conversation surface instead of a manual polling flow.
+
+## Rollback
+
+If rollout fails:
+
+- Stop the `cc-connect` process or scheduled task.
+- Remove or rename `C:\Users\olawal\.cc-connect\config.toml`.
+- Revoke the new Discord bot token.
+- Remove the bridge bot from the guild if needed.
+- Keep the existing `mcp-discord` setup unchanged as the fallback path.
+
+## Deliverables
+
+- `C:\Users\olawal\.cc-connect\config.toml`
+- Repo-root `AGENTS.md` bridge instructions for Codex
+- Windows launcher script under `Chelestra-Sea\infra\scripts\`
+- Windows startup-entry install/remove scripts under `Chelestra-Sea\infra\scripts\`
+- Repo-local Codex wrapper under `Chelestra-Sea\infra\scripts\`
+- PowerShell profile install/remove scripts for the `codexU` launcher path
+- Updated repo doc describing when to use `mcp-discord` versus `cc-connect`
+
+## Recommended Execution Order
+
+1. Install `cc-connect` and confirm the Codex CLI is callable from the same shell.
+2. Create the dedicated Discord bridge bot.
+3. Write the minimal `~/.cc-connect/config.toml`.
+4. Add the repo-root `AGENTS.md` bridge instructions.
+5. Run a foreground smoke test.
+6. Tune mode and thread behavior.
+7. Add Windows persistence.
+8. Update local docs after the bridge is proven.
+
+## Source Basis
+
+- `https://github.com/chenhg5/cc-connect`
+- `https://raw.githubusercontent.com/chenhg5/cc-connect/main/README.md`
+- `https://raw.githubusercontent.com/chenhg5/cc-connect/main/INSTALL.md`
+- `https://raw.githubusercontent.com/chenhg5/cc-connect/main/docs/discord.md`
+- Local repo clone used for validation: `C:\Users\olawal\AppData\Local\Temp\cc-connect-plan`

--- a/Chelestra-Sea/infra/CODEX-DISCORD-SETUP.md
+++ b/Chelestra-Sea/infra/CODEX-DISCORD-SETUP.md
@@ -1,0 +1,177 @@
+# Codex Discord MCP Setup
+
+This guide sets up Discord access for Codex CLI using an MCP server.
+
+This is not the same integration model as Claude Code's Discord channel relay.
+Codex can use Discord tools through MCP to read messages, inspect servers and channels, and send messages into Discord. Codex does not currently expose the Claude-style `/plugin install`, `/discord:configure`, `/discord:access`, or `--channels plugin:discord@...` flow.
+
+## What You Get
+
+- Codex can read Discord message history through MCP tools.
+- Codex can send messages into Discord through MCP tools.
+- Codex can inspect guilds, channels, members, and related Discord metadata.
+- Messages sent by Codex appear in Discord as normal bot messages.
+
+## What You Do Not Get
+
+- Inbound Discord messages do not appear as a live Codex chat session the way they do in Claude's Discord relay.
+- There is no native Codex equivalent of `claude --channels plugin:discord@claude-plugins-official`.
+- There is no Codex-side `/discord:access` pairing flow in the local CLI surface.
+
+If the goal is "Codex can talk into Discord and read Discord state", this setup works.
+If the goal is "Discord becomes the primary Codex conversation UI", this setup does not currently provide that.
+
+## Recommended Bot Model
+
+Use a dedicated Discord bot for Codex.
+
+- Do not reuse the Claude relay bot token unless you intentionally want both tools sharing one bot identity.
+- Give Codex its own bot token, channel permissions, and operational identity.
+- Keep the token out of the repo and out of committed config files.
+
+## Prerequisites
+
+- Discord Developer Portal access: `https://discord.com/developers/applications`
+- Codex CLI installed and working
+- `uv` installed locally
+- Local checkout of the Discord MCP server
+- Access to the target Discord guild
+
+## Phase 1: Create The Discord Bot
+
+- [ ] Go to the Discord Developer Portal.
+- [ ] Create a new application for the Codex bot persona.
+- [ ] Add a bot user.
+- [ ] Copy the bot token and store it in a password manager or vault immediately.
+- [ ] Enable all required privileged intents:
+- [ ] `MESSAGE CONTENT INTENT`
+- [ ] `SERVER MEMBERS INTENT`
+- [ ] `PRESENCE INTENT`
+- [ ] Use OAuth2 URL Generator to invite the bot to the target guild.
+- [ ] Grant the bot the permissions it needs at minimum:
+- [ ] Send Messages
+- [ ] Read Message History
+- [ ] Read Messages / View Channels
+- [ ] Add Reactions
+- [ ] Attach Files
+- [ ] Use External Emojis
+
+## Phase 2: Prepare The Discord MCP Server
+
+This environment already uses the Python `mcp-discord` server pattern.
+
+Reference server:
+- `H:\Projects\AI_Tools_And_Information\mcp-servers\mcp-discord`
+
+Expected launch shape:
+
+```powershell
+uv --directory H:\Projects\AI_Tools_And_Information\mcp-servers\mcp-discord run mcp-discord
+```
+
+If you need to bootstrap a fresh checkout:
+
+```powershell
+git clone https://github.com/hanweg/mcp-discord.git H:\Projects\AI_Tools_And_Information\mcp-servers\mcp-discord
+cd H:\Projects\AI_Tools_And_Information\mcp-servers\mcp-discord
+uv venv
+uv pip install -e .
+```
+
+## Phase 3: Register The MCP Server In Codex
+
+Codex supports MCP servers directly. The simplest path is `codex mcp add`.
+
+Example:
+
+```powershell
+codex mcp add discord --env DISCORD_TOKEN=your_bot_token_here -- uv --directory H:\Projects\AI_Tools_And_Information\mcp-servers\mcp-discord run mcp-discord
+```
+
+You can inspect the configured server with:
+
+```powershell
+codex mcp list
+codex mcp get discord
+```
+
+## Phase 4: Persist Configuration In `~/.codex/config.toml`
+
+Codex stores MCP configuration in:
+
+- `C:\Users\<you>\.codex\config.toml` on Windows
+
+Expected TOML shape:
+
+```toml
+[mcp_servers.discord]
+command = "uv"
+args = ["--directory", 'H:\Projects\AI_Tools_And_Information\mcp-servers\mcp-discord', "run", "mcp-discord"]
+
+[mcp_servers.discord.env]
+DISCORD_TOKEN = "your_bot_token_here"
+```
+
+Rules:
+
+- Never commit the real token.
+- Keep the token only in local user config.
+- Prefer a dedicated bot token for Codex.
+
+## Phase 5: Verify Codex Sees The Server
+
+Use Codex MCP inspection commands:
+
+```powershell
+codex mcp list
+codex mcp get discord
+```
+
+You should see:
+
+- the `discord` server registered
+- `transport: stdio`
+- command `uv`
+- args pointing at `mcp-discord`
+- masked `DISCORD_TOKEN`
+
+## Phase 6: Verify The Discord Bot Connection
+
+Start a Codex session after the MCP server is configured.
+
+Then test through Codex:
+
+- Ask Codex to list Discord servers.
+- Ask Codex to get channels for the target guild.
+- Ask Codex to read recent messages from a known test channel.
+- Ask Codex to send a test message into that channel.
+
+Representative tool-backed requests:
+
+- "Use the Discord MCP to list servers."
+- "Use the Discord MCP to read the last 10 messages in channel `<channel_id>`."
+- "Use the Discord MCP to send a message to channel `<channel_id>` saying `Codex Discord MCP is online.`"
+
+## Phase 7: Operational Notes
+
+- Codex uses Discord through tools, not through a live Discord-native chat surface.
+- If you want visible Discord output, have Codex use `send_message`.
+- If you want Codex to see recent context from Discord, have Codex use `read_messages`.
+- This is a pull/send model, not a push/relay model.
+
+## Common Failure Modes
+
+| Problem | Likely Cause | Fix |
+|---|---|---|
+| `codex mcp list` does not show `discord` | MCP server not registered | Re-run `codex mcp add ...` or fix `config.toml` |
+| `discord` is registered but not usable | Bad `uv` path or bad `mcp-discord` checkout | Verify the server path and run command manually |
+| Discord bot appears offline | Token invalid or bot not invited | Re-check token and guild invite |
+| Tools load but messages fail | Missing Discord permissions | Re-check bot permissions in the guild |
+| Codex can send messages but does not "receive chats" | Expected limitation | Codex MCP is not Claude's inbound Discord relay |
+| Shared bot identity causes confusion | Claude and Codex use same token | Split into separate bot identities |
+
+## Recommended Next Step For This Repo
+
+Treat this document as the source of truth for Codex Discord access in the monorepo.
+
+If the owner later wants true inbound Discord-to-Codex chat sessions, that will require a separate bridge design or a different runtime surface than the current Codex CLI MCP model.

--- a/Chelestra-Sea/infra/scripts/install-cc-connect-startup.ps1
+++ b/Chelestra-Sea/infra/scripts/install-cc-connect-startup.ps1
@@ -1,0 +1,38 @@
+[CmdletBinding(SupportsShouldProcess = $true)]
+param(
+    [string]$StartupScriptPath,
+    [string]$ConfigPath = "$HOME\.cc-connect\config.toml",
+    [string]$StartupDir = (Join-Path $env:APPDATA 'Microsoft\Windows\Start Menu\Programs\Startup'),
+    [string]$StartupFileName = 'the-nexus-cc-connect.cmd'
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not $StartupScriptPath) {
+    $StartupScriptPath = Join-Path $PSScriptRoot 'start-cc-connect.ps1'
+}
+
+$resolvedStartupScript = (Resolve-Path -LiteralPath $StartupScriptPath).Path
+
+if (-not (Test-Path -LiteralPath $ConfigPath)) {
+    throw "cc-connect config not found: $ConfigPath"
+}
+
+if (-not (Test-Path -LiteralPath $StartupDir)) {
+    throw "Windows Startup folder not found: $StartupDir"
+}
+
+$startupEntryPath = Join-Path $StartupDir $StartupFileName
+$startupEntry = @(
+    '@echo off'
+    ('powershell.exe -NoProfile -ExecutionPolicy Bypass -File "{0}" -ConfigPath "{1}"' -f $resolvedStartupScript, $ConfigPath)
+    'exit /b %errorlevel%'
+) -join [Environment]::NewLine
+
+if ($PSCmdlet.ShouldProcess($startupEntryPath, 'Create or update Startup entry')) {
+    Set-Content -LiteralPath $startupEntryPath -Value $startupEntry -Encoding ASCII
+}
+
+Write-Host "Startup entry ready: $startupEntryPath"
+Write-Host "Script: $resolvedStartupScript"
+Write-Host "Config: $ConfigPath"

--- a/Chelestra-Sea/infra/scripts/install-codexu-cc-connect-profile.ps1
+++ b/Chelestra-Sea/infra/scripts/install-codexu-cc-connect-profile.ps1
@@ -1,0 +1,62 @@
+[CmdletBinding(SupportsShouldProcess = $true)]
+param(
+    [string]$ProfilePath = $PROFILE.CurrentUserCurrentHost,
+    [string]$LauncherScriptPath
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not $LauncherScriptPath) {
+    $LauncherScriptPath = Join-Path $PSScriptRoot 'start-codex-with-cc-connect.ps1'
+}
+
+$resolvedLauncher = (Resolve-Path -LiteralPath $LauncherScriptPath).Path
+$profileDir = Split-Path -Parent $ProfilePath
+
+if (-not (Test-Path -LiteralPath $profileDir)) {
+    New-Item -ItemType Directory -Path $profileDir -Force | Out-Null
+}
+
+if (-not (Test-Path -LiteralPath $ProfilePath)) {
+    New-Item -ItemType File -Path $ProfilePath -Force | Out-Null
+}
+
+$markerStart = '# >>> The-Nexus codexU cc-connect >>>'
+$markerEnd = '# <<< The-Nexus codexU cc-connect <<<'
+$escapedLauncher = $resolvedLauncher.Replace("'", "''")
+$snippet = @(
+    $markerStart,
+    'function global:codexU {',
+    '    [CmdletBinding()]',
+    '    param(',
+    '        [Parameter(ValueFromRemainingArguments = $true)]',
+    '        [string[]]$CodexArgs',
+    '    )',
+    ('    & ''{0}'' @CodexArgs' -f $escapedLauncher),
+    '}',
+    $markerEnd
+) -join [Environment]::NewLine
+
+$existingContent = Get-Content -LiteralPath $ProfilePath -Raw
+if ($null -eq $existingContent) {
+    $existingContent = ''
+}
+$blockPattern = '(?ms)^# >>> The-Nexus codexU cc-connect >>>\r?\n.*?^# <<< The-Nexus codexU cc-connect <<<\r?\n?'
+
+if ([regex]::IsMatch($existingContent, $blockPattern)) {
+    $updatedContent = [regex]::Replace($existingContent, $blockPattern, $snippet + [Environment]::NewLine, 1)
+}
+elseif ([string]::IsNullOrWhiteSpace($existingContent)) {
+    $updatedContent = $snippet + [Environment]::NewLine
+}
+else {
+    $trimmed = $existingContent.TrimEnd("`r", "`n")
+    $updatedContent = $trimmed + [Environment]::NewLine + [Environment]::NewLine + $snippet + [Environment]::NewLine
+}
+
+if ($PSCmdlet.ShouldProcess($ProfilePath, 'Install or update codexU bridge wrapper')) {
+    Set-Content -LiteralPath $ProfilePath -Value $updatedContent -Encoding UTF8
+}
+
+Write-Host "PowerShell profile ready: $ProfilePath"
+Write-Host "codexU now launches via: $resolvedLauncher"

--- a/Chelestra-Sea/infra/scripts/remove-cc-connect-startup.ps1
+++ b/Chelestra-Sea/infra/scripts/remove-cc-connect-startup.ps1
@@ -1,0 +1,19 @@
+[CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
+param(
+    [string]$StartupDir = (Join-Path $env:APPDATA 'Microsoft\Windows\Start Menu\Programs\Startup'),
+    [string]$StartupFileName = 'the-nexus-cc-connect.cmd'
+)
+
+$ErrorActionPreference = 'Stop'
+
+$startupEntryPath = Join-Path $StartupDir $StartupFileName
+if (-not (Test-Path -LiteralPath $startupEntryPath)) {
+    Write-Host "Startup entry not found: $startupEntryPath"
+    exit 0
+}
+
+if ($PSCmdlet.ShouldProcess($startupEntryPath, 'Remove Startup entry')) {
+    Remove-Item -LiteralPath $startupEntryPath -Force
+}
+
+Write-Host "Startup entry removed: $startupEntryPath"

--- a/Chelestra-Sea/infra/scripts/remove-codexu-cc-connect-profile.ps1
+++ b/Chelestra-Sea/infra/scripts/remove-codexu-cc-connect-profile.ps1
@@ -1,0 +1,33 @@
+[CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
+param(
+    [string]$ProfilePath = $PROFILE.CurrentUserCurrentHost
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not (Test-Path -LiteralPath $ProfilePath)) {
+    Write-Host "PowerShell profile not found: $ProfilePath"
+    exit 0
+}
+
+$existingContent = Get-Content -LiteralPath $ProfilePath -Raw
+if ($null -eq $existingContent) {
+    $existingContent = ''
+}
+$blockPattern = '(?ms)^# >>> The-Nexus codexU cc-connect >>>\r?\n.*?^# <<< The-Nexus codexU cc-connect <<<\r?\n?'
+
+if (-not [regex]::IsMatch($existingContent, $blockPattern)) {
+    Write-Host "No codexU bridge wrapper found in: $ProfilePath"
+    exit 0
+}
+
+$updatedContent = [regex]::Replace($existingContent, $blockPattern, '', 1).TrimEnd("`r", "`n")
+if (-not [string]::IsNullOrEmpty($updatedContent)) {
+    $updatedContent += [Environment]::NewLine
+}
+
+if ($PSCmdlet.ShouldProcess($ProfilePath, 'Remove codexU bridge wrapper')) {
+    Set-Content -LiteralPath $ProfilePath -Value $updatedContent -Encoding UTF8
+}
+
+Write-Host "codexU bridge wrapper removed from: $ProfilePath"

--- a/Chelestra-Sea/infra/scripts/start-cc-connect.ps1
+++ b/Chelestra-Sea/infra/scripts/start-cc-connect.ps1
@@ -1,0 +1,181 @@
+[CmdletBinding()]
+param(
+    [string]$ConfigPath = "$HOME\.cc-connect\config.toml",
+    [string]$LogDir = "$HOME\.cc-connect\logs",
+    [string]$SessionPath = "$HOME\.cc-connect\sessions\the-nexus-codex-discord_740ce814.json",
+    [switch]$Foreground,
+    [switch]$Restart,
+    [switch]$ResetSession,
+    [int]$ReadyTimeoutSeconds = 15
+)
+
+$ErrorActionPreference = "Stop"
+
+function Assert-Command {
+    param([string]$Name)
+
+    if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) {
+        throw "Required command not found on PATH: $Name"
+    }
+}
+
+Assert-Command -Name "cc-connect"
+Assert-Command -Name "codex"
+
+function Resolve-CcConnectCommand {
+    $cmdShim = Get-Command "cc-connect.cmd" -ErrorAction SilentlyContinue
+    if ($cmdShim) {
+        return $cmdShim.Source
+    }
+
+    $native = & where.exe cc-connect 2>$null | Select-Object -First 1
+    if ($native) {
+        return $native
+    }
+
+    throw "Unable to resolve a runnable cc-connect command."
+}
+
+function Get-ExistingCcConnectProcess {
+    param([string]$ResolvedConfigPath)
+
+    $candidates = @()
+
+    $native = Get-Process -Name 'cc-connect' -ErrorAction SilentlyContinue
+    if ($native) {
+        $candidates += $native
+    }
+
+    $cimCandidates = Get-CimInstance Win32_Process -ErrorAction SilentlyContinue |
+        Where-Object { $_.CommandLine -and $_.CommandLine -match 'cc-connect' }
+
+    foreach ($candidate in $cimCandidates) {
+        if ($ResolvedConfigPath -and $candidate.CommandLine -notmatch [regex]::Escape($ResolvedConfigPath)) {
+            continue
+        }
+
+        try {
+            return Get-Process -Id $candidate.ProcessId -ErrorAction Stop
+        } catch {
+        }
+    }
+
+    foreach ($process in $candidates) {
+        return $process
+    }
+
+    return $null
+}
+
+function Reset-BridgeSessionIfRequested {
+    param(
+        [string]$SessionFilePath,
+        [switch]$ShouldReset
+    )
+
+    if (-not $ShouldReset -or -not (Test-Path -LiteralPath $SessionFilePath)) {
+        return $null
+    }
+
+    $timestamp = Get-Date -Format "yyyyMMdd-HHmmss"
+    $backupPath = "$SessionFilePath.bak-$timestamp"
+    Move-Item -LiteralPath $SessionFilePath -Destination $backupPath -Force
+    return $backupPath
+}
+
+function Wait-ForCcConnectReady {
+    param(
+        [string]$StdoutLogPath,
+        [string]$StderrLogPath,
+        [int]$TimeoutSeconds
+    )
+
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    do {
+        Start-Sleep -Milliseconds 300
+
+        if (Test-Path -LiteralPath $StdoutLogPath) {
+            $stdout = Get-Content -LiteralPath $StdoutLogPath -Raw -ErrorAction SilentlyContinue
+            if ($stdout -match 'cc-connect is running') {
+                return $true
+            }
+        }
+
+        if (Test-Path -LiteralPath $StderrLogPath) {
+            $stderr = Get-Content -LiteralPath $StderrLogPath -Raw -ErrorAction SilentlyContinue
+            if ($stderr -match 'config loaded') {
+                $stdoutReady = $false
+                if (Test-Path -LiteralPath $StdoutLogPath) {
+                    $stdoutReady = (Get-Content -LiteralPath $StdoutLogPath -Raw -ErrorAction SilentlyContinue) -match 'engine started'
+                }
+                if ($stdoutReady) {
+                    return $true
+                }
+            }
+        }
+    } while ((Get-Date) -lt $deadline)
+
+    return $false
+}
+
+if (-not (Test-Path -LiteralPath $ConfigPath)) {
+    throw "cc-connect config not found: $ConfigPath"
+}
+
+if (-not (Test-Path -LiteralPath $LogDir)) {
+    New-Item -ItemType Directory -Path $LogDir -Force | Out-Null
+}
+
+$resolvedConfig = (Resolve-Path -LiteralPath $ConfigPath).Path
+$ccConnectCommand = Resolve-CcConnectCommand
+$timestamp = Get-Date -Format "yyyyMMdd-HHmmss"
+$stdoutLog = Join-Path $LogDir "cc-connect-$timestamp.out.log"
+$stderrLog = Join-Path $LogDir "cc-connect-$timestamp.err.log"
+$arguments = @("-config", $resolvedConfig)
+
+if ($Foreground) {
+    $rotatedSession = Reset-BridgeSessionIfRequested -SessionFilePath $SessionPath -ShouldReset:$ResetSession
+    Write-Host "Starting cc-connect in foreground with config: $resolvedConfig"
+    if ($rotatedSession) {
+        Write-Host "Rotated session: $rotatedSession"
+    }
+    & $ccConnectCommand @arguments
+    exit $LASTEXITCODE
+}
+
+$existing = Get-ExistingCcConnectProcess -ResolvedConfigPath $resolvedConfig
+if ($existing -and $Restart) {
+    Stop-Process -Id $existing.Id -Force
+    Start-Sleep -Seconds 1
+    $existing = $null
+}
+
+if ($existing) {
+    Write-Host "cc-connect already running."
+    Write-Host "PID: $($existing.Id)"
+    Write-Host "Config: $resolvedConfig"
+    exit 0
+}
+
+$rotatedSession = Reset-BridgeSessionIfRequested -SessionFilePath $SessionPath -ShouldReset:$ResetSession
+$process = Start-Process `
+    -FilePath $ccConnectCommand `
+    -ArgumentList $arguments `
+    -WorkingDirectory (Split-Path -Parent $resolvedConfig) `
+    -RedirectStandardOutput $stdoutLog `
+    -RedirectStandardError $stderrLog `
+    -PassThru
+
+Write-Host "Started cc-connect."
+Write-Host "PID: $($process.Id)"
+Write-Host "Config: $resolvedConfig"
+Write-Host "Stdout: $stdoutLog"
+Write-Host "Stderr: $stderrLog"
+if ($rotatedSession) {
+    Write-Host "Rotated session: $rotatedSession"
+}
+
+$ready = Wait-ForCcConnectReady -StdoutLogPath $stdoutLog -StderrLogPath $stderrLog -TimeoutSeconds $ReadyTimeoutSeconds
+if (-not $ready) {
+    Write-Warning "cc-connect did not report ready within $ReadyTimeoutSeconds seconds."
+}

--- a/Chelestra-Sea/infra/scripts/start-codex-with-cc-connect.ps1
+++ b/Chelestra-Sea/infra/scripts/start-codex-with-cc-connect.ps1
@@ -1,0 +1,13 @@
+[CmdletBinding()]
+param(
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]]$CodexArgs
+)
+
+$ErrorActionPreference = 'Stop'
+
+$bridgeLauncher = Join-Path $PSScriptRoot 'start-cc-connect.ps1'
+& $bridgeLauncher -ResetSession
+
+& codex @CodexArgs
+exit $LASTEXITCODE


### PR DESCRIPTION
## Summary
- add a repo-root AGENTS file for the Roland Discord bridge runtime contract
- add the cc-connect bridge implementation and MCP fallback docs under `Chelestra-Sea/infra/`
- add PowerShell scripts to start the bridge, wrap `codex`, and install/remove startup and `codexU` profile hooks

## Validation
- validated live Discord bridge behavior for server-channel replies, including long replies
- validated the fresh-shell `codexu` path and confirmed the bridge works in the intended runtime flow
- user confirmed the end-to-end bridge validation is working

## Notes
- `.planning/STATE.md` and the unrelated dirty worktree changes were intentionally excluded from this PR