### PR TITLE
fix: wire DLMM position close automation

### DIFF
--- a/Pryan-Fire/hughs-forge/config/mainnet/position_monitor_config.json
+++ b/Pryan-Fire/hughs-forge/config/mainnet/position_monitor_config.json
@@ -45,6 +45,8 @@
   "execution": {
     "swap_to_mint": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
     "swap_slippage_bps": 100,
-    "dry_run": true
+    "dry_run": true,
+    "close_timeout_seconds": 180,
+    "swap_after_close": false
   }
 }

--- a/Pryan-Fire/hughs-forge/scripts/automation_engine.py
+++ b/Pryan-Fire/hughs-forge/scripts/automation_engine.py
@@ -1,14 +1,16 @@
 #!/usr/bin/env python3
 """
 Automation Engine — SL/TP automation for DLMM positions
-Evaluates triggers and executes close/swap actions based on wallet config.
+Evaluates triggers and executes close actions based on wallet config.
 """
 import requests
 import json
 import os
 import logging
 import subprocess
+import shlex
 from datetime import datetime
+from pathlib import Path
 from typing import Dict, Any, List, Optional
 
 logging.basicConfig(
@@ -25,6 +27,20 @@ AUTOMATION_DRY_RUN = os.getenv("AUTOMATION_DRY_RUN", "true").lower() == "true"
 # Constants
 USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
 SOL_MINT = "So11111111111111111111111111111111111111112"
+
+# Retry / cooldown constants. These keep a bad live close from hammering the
+# wallet, RPC, or Discord forever after an SL/TP trigger.
+MAX_EXECUTE_RETRIES = 3
+BACKOFF_MULTIPLIER = 2.0
+MAX_ALERT_INTERVAL = 3600
+COOLDOWN_DURATION_SECONDS = 7200
+
+
+def _position_fee_value(pos: Dict[str, Any]) -> float:
+    """Return the best per-position fee value available for PnL math."""
+    # fees_claimed_usd is per-position from Meteora. fees_24h is currently
+    # pool-level in health_server, so only use it as legacy fallback.
+    return float(pos.get("fees_claimed_usd", pos.get("fees_24h", 0)) or 0)
 
 
 def evaluate_triggers(wallet_name: str, positions: List[Dict], wallet_config: Dict, state: Dict) -> List[Dict]:
@@ -48,6 +64,15 @@ def evaluate_triggers(wallet_name: str, positions: List[Dict], wallet_config: Di
         pubkey = pos.get("position", "")
         if not pubkey:
             continue
+
+        current_value = float(pos.get("liquidity_usd", 0) or 0)
+        fees = _position_fee_value(pos)
+
+        # If the upstream feed reports a dead/empty position, do not turn that
+        # into a fake -100% stop-loss. Closed/stale positions should not fire.
+        if current_value <= 0 and fees <= 0:
+            logger.debug(f"[{wallet_name}] Skipping stale position {pubkey} (zero liquidity + zero fees)")
+            continue
         
         # Get entry value from state
         pos_state = state_positions.get(pubkey, {})
@@ -55,9 +80,6 @@ def evaluate_triggers(wallet_name: str, positions: List[Dict], wallet_config: Di
         
         if entry_value <= 0:
             continue  # No entry value recorded yet, skip
-        
-        current_value = pos.get("liquidity_usd", 0)
-        fees = pos.get("fees_24h", 0)
         
         # Calculate PnL percentage
         pnl_usd = (current_value + fees) - entry_value
@@ -125,6 +147,24 @@ def handle_alert_owner(wallet_name: str, trigger: Dict, config: Dict, state: Dic
     # Get or create alerts state for this wallet
     automation_state = state.setdefault("automation", {}).setdefault(wallet_name, {})
     active_alerts = automation_state.setdefault("active_alerts", {})
+
+    # Failed live closes enter cooldown instead of spamming retries forever.
+    cooldowns = automation_state.get("cooldowns", {})
+    if pubkey in cooldowns:
+        cooldown_info = cooldowns[pubkey]
+        cooldown_until = cooldown_info.get("cooldown_until", "")
+        if cooldown_until:
+            try:
+                until = datetime.fromisoformat(cooldown_until.rstrip("Z"))
+                if datetime.utcnow() < until:
+                    remaining = (until - datetime.utcnow()).total_seconds()
+                    logger.info(f"[{wallet_name}] Position {pubkey} in cooldown ({remaining:.0f}s remaining) — skipping")
+                    return False
+                logger.info(f"[{wallet_name}] Position {pubkey} cooldown expired — resuming alerts")
+                del cooldowns[pubkey]
+                active_alerts.pop(pubkey, None)
+            except (ValueError, TypeError):
+                del cooldowns[pubkey]
     
     if pubkey not in active_alerts:
         # First time seeing this trigger
@@ -132,6 +172,7 @@ def handle_alert_owner(wallet_name: str, trigger: Dict, config: Dict, state: Dic
             "trigger_type": trigger_type,
             "trigger_pnl_pct": pnl_pct,
             "alerts_sent": 0,
+            "execute_attempts": 0,
             "first_alert_at": datetime.utcnow().isoformat() + "Z",
             "last_alert_at": None,
             "escalation_state": "alerting",
@@ -140,12 +181,18 @@ def handle_alert_owner(wallet_name: str, trigger: Dict, config: Dict, state: Dic
     
     alert = active_alerts[pubkey]
     
-    # Check if enough time has passed since last alert
+    # Check if enough time has passed since last alert. After failed execution
+    # attempts, back off before the next alert/attempt.
+    effective_interval = alert_interval
+    execute_attempts = alert.get("execute_attempts", 0)
+    if execute_attempts > 0:
+        effective_interval = min(alert_interval * (BACKOFF_MULTIPLIER ** execute_attempts), MAX_ALERT_INTERVAL)
+
     if alert.get("last_alert_at"):
         last = datetime.fromisoformat(alert["last_alert_at"].rstrip("Z"))
         elapsed = (datetime.utcnow() - last).total_seconds()
-        if elapsed < alert_interval:
-            logger.debug(f"Alert for {pubkey[:12]}... not due yet (elapsed: {elapsed:.0f}s < {alert_interval}s)")
+        if elapsed < effective_interval:
+            logger.debug(f"Alert for {pubkey} not due yet (elapsed: {elapsed:.0f}s < {effective_interval:.0f}s)")
             return False
     
     if alert["alerts_sent"] < alert_count:
@@ -156,64 +203,209 @@ def handle_alert_owner(wallet_name: str, trigger: Dict, config: Dict, state: Dic
         alert_num = alert["alerts_sent"] + 1
         
         remaining = alert_count - alert_num
+        entry_val = trigger.get("entry_value", 0)
+        current_val = trigger.get("current_value", 0)
+        fees_val = trigger.get("fees", 0)
+        token_x = pos.get("token_x_symbol", pos.get("mint_x", "?")[:8])
+        token_y = pos.get("token_y_symbol", pos.get("mint_y", "?")[:8])
         
         msg = {
             "content": f"{emoji} <@{sterol_id}> **{trigger_type.upper().replace('_', ' ')}** triggered!\n"
-                       f"**Pool**: {pool_name}\n"
-                       f"**Position**: `{pubkey[:12]}...`\n"
-                       f"**PnL**: {pnl_pct:+.1f}%\n"
+                       f"**Pool**: {pool_name} ({token_x}/{token_y})\n"
+                       f"**Position**: `{pubkey}`\n"
+                       f"**PnL**: {pnl_pct:+.1f}% (${entry_val:,.2f} → ${current_val:,.2f})\n"
+                       f"**Fees**: ${fees_val:,.2f}\n"
                        f"Alert {alert_num}/{alert_count}" +
                        (f" — Auto-close in {remaining} more alert{'s' if remaining > 1 else ''} if no response." if remaining > 0 else " — FINAL WARNING!"),
         }
         
-        
-        # Log what would be sent (for verification)
-        logger.info(f"[{wallet_name}] ALERT WOULD BE SENT: {trigger_type.upper()} {pool_name} PnL={pnl_pct:+.1f}% (alert {alert_num}/{alert_count})")
+        logger.info(f"[{wallet_name}] ALERT: {trigger_type.upper()} {pool_name} Position={pubkey} PnL={pnl_pct:+.1f}% (alert {alert_num}/{alert_count})")
         if _post_to_discord_alerts(msg):
             alert["alerts_sent"] += 1
             alert["last_alert_at"] = datetime.utcnow().isoformat() + "Z"
             return True
     
     elif auto_execute_after and alert.get("escalation_state") == "alerting":
-        # All alerts sent, no response — auto execute
-        logger.info(f"[{wallet_name}] All {alert_count} alerts sent for {pubkey[:12]}... — executing auto-close")
+        # All alerts sent, no response — auto execute with bounded retries.
+        execute_attempts = alert.get("execute_attempts", 0)
+        if execute_attempts >= MAX_EXECUTE_RETRIES:
+            cooldown_until = datetime.utcnow().timestamp() + COOLDOWN_DURATION_SECONDS
+            cooldown_until_iso = datetime.utcfromtimestamp(cooldown_until).isoformat() + "Z"
+            automation_state.setdefault("cooldowns", {})[pubkey] = {
+                "cooldown_at": datetime.utcnow().isoformat() + "Z",
+                "cooldown_until": cooldown_until_iso,
+                "reason": f"Failed {execute_attempts} auto-close attempts",
+                "trigger_type": trigger_type,
+                "pnl_pct": pnl_pct,
+                "pool_name": pool_name,
+            }
+            alert["escalation_state"] = "cooldown"
+            sterol_id = DISCORD_STEROL_USER_ID or "Sterol"
+            _post_to_discord_alerts({
+                "content": f"⏸️ <@{sterol_id}> Position entering cooldown after {execute_attempts} failed auto-close attempts.\n"
+                           f"**Pool**: {pool_name}\n"
+                           f"**Position**: `{pubkey}`\n"
+                           f"**PnL**: {pnl_pct:+.1f}%\n"
+                           f"Manual close recommended; alerts resume after cooldown."
+            })
+            return True
+
+        logger.info(f"[{wallet_name}] All {alert_count} alerts sent for {pubkey} — executing auto-close (attempt {execute_attempts + 1}/{MAX_EXECUTE_RETRIES})")
         alert["escalation_state"] = "executing"
+        alert["execute_attempts"] = execute_attempts + 1
+        alert["last_alert_at"] = datetime.utcnow().isoformat() + "Z"
         
         success = execute_position_close(wallet_name, trigger, config)
         
-        alert["escalation_state"] = "executed" if success else "failed"
-        alert["executed_at"] = datetime.utcnow().isoformat() + "Z"
+        if success:
+            alert["escalation_state"] = "executed"
+            alert["executed_at"] = datetime.utcnow().isoformat() + "Z"
+        else:
+            alert["escalation_state"] = "alerting"
+            logger.warning(f"[{wallet_name}] Auto-close attempt {alert['execute_attempts']}/{MAX_EXECUTE_RETRIES} FAILED for {pubkey}")
         
         return True
     
     return False
 
 
-def handle_auto_execute(wallet_name: str, trigger: Dict, config: Dict) -> bool:
+def handle_auto_execute(wallet_name: str, trigger: Dict, config: Dict, state: Dict) -> bool:
     """
     Immediately close position and swap to USDC.
-    No human notification required.
+    Tracks retries and fails closed after repeated execution failures.
     """
     pos = trigger["position"]
     pubkey = pos.get("position", "")
     pool_name = pos.get("pool_name", "Unknown")
     trigger_type = trigger["trigger_type"]
     pnl_pct = trigger["pnl_pct"]
+    entry_val = trigger.get("entry_value", 0)
+    current_val = trigger.get("current_value", 0)
+    token_x = pos.get("token_x_symbol", pos.get("mint_x", "?")[:8])
+    token_y = pos.get("token_y_symbol", pos.get("mint_y", "?")[:8])
+    automation_state = state.setdefault("automation", {}).setdefault(wallet_name, {})
+    exec_tracker = automation_state.setdefault("exec_attempts", {})
+    tracker = exec_tracker.setdefault(pubkey, {"attempts": 0, "first_attempt_at": datetime.utcnow().isoformat() + "Z"})
+
+    if tracker["attempts"] >= MAX_EXECUTE_RETRIES:
+        logger.warning(f"[{wallet_name}] Position {pubkey} failed {tracker['attempts']} auto-execute attempts — blacklisting")
+        automation_state.setdefault("blacklist", {})[pubkey] = {
+            "blacklisted_at": datetime.utcnow().isoformat() + "Z",
+            "reason": f"Failed {tracker['attempts']} auto-execute attempts",
+            "trigger_type": trigger_type,
+            "pnl_pct": pnl_pct,
+            "pool_name": pool_name,
+        }
+        _post_to_discord_alerts({
+            "content": f"⚠️ Auto-execute blacklisted a position after {tracker['attempts']} failures.\n"
+                       f"**Pool**: {pool_name} ({token_x}/{token_y})\n"
+                       f"**Position**: `{pubkey}`\n"
+                       f"**PnL**: {pnl_pct:+.1f}%\n"
+                       f"Manual intervention required."
+        })
+        return True
+
+    if tracker.get("last_attempt_at"):
+        last = datetime.fromisoformat(tracker["last_attempt_at"].rstrip("Z"))
+        backoff_secs = min(60 * (BACKOFF_MULTIPLIER ** tracker["attempts"]), MAX_ALERT_INTERVAL)
+        elapsed = (datetime.utcnow() - last).total_seconds()
+        if elapsed < backoff_secs:
+            logger.debug(f"[{wallet_name}] Auto-execute backoff for {pubkey}: {elapsed:.0f}s < {backoff_secs:.0f}s")
+            return False
     
     emoji = "🔴" if trigger_type == "stop_loss" else "🟢"
+    attempt_num = tracker["attempts"] + 1
     
     # Post notification (non-blocking, just info)
     if DISCORD_WEBHOOK_ALERTS:
         msg = {
             "content": f"{emoji} **[AUTO-EXECUTE]** {trigger_type.upper().replace('_', ' ')} triggered!\n"
-                       f"**Pool**: {pool_name}\n"
-                       f"**Position**: `{pubkey[:12]}...`\n"
-                       f"**PnL**: {pnl_pct:+.1f}%\n"
-                       f"Closing position and swapping to USDC...",
+                       f"**Pool**: {pool_name} ({token_x}/{token_y})\n"
+                       f"**Position**: `{pubkey}`\n"
+                       f"**PnL**: {pnl_pct:+.1f}% (${entry_val:,.2f} → ${current_val:,.2f})\n"
+                       f"Attempt {attempt_num}/{MAX_EXECUTE_RETRIES} — closing DLMM position...",
         }
         _post_to_discord_alerts(msg)
     
-    return execute_position_close(wallet_name, trigger, config)
+    tracker["attempts"] = attempt_num
+    tracker["last_attempt_at"] = datetime.utcnow().isoformat() + "Z"
+    success = execute_position_close(wallet_name, trigger, config)
+    if success:
+        tracker["executed_at"] = datetime.utcnow().isoformat() + "Z"
+        del exec_tracker[pubkey]
+    return success
+
+
+def _default_dlmm_close_command() -> Optional[List[str]]:
+    script_path = Path(__file__).resolve().parents[1] / "services" / "meteora-trader" / "scripts" / "close-position.mjs"
+    if script_path.exists():
+        return ["node", str(script_path)]
+    return None
+
+
+def _resolve_dlmm_close_command(execution: Dict[str, Any]) -> Optional[List[str]]:
+    command = execution.get("dlmm_close_command") or os.getenv("DLMM_CLOSE_COMMAND")
+    if isinstance(command, list):
+        return [str(part) for part in command]
+    if isinstance(command, str) and command.strip():
+        return shlex.split(command)
+    return _default_dlmm_close_command()
+
+
+def _run_dlmm_close_command(wallet_name: str, trigger: Dict, config: Dict, pool_pubkey: str) -> Dict[str, Any]:
+    """Run the configured DLMM close executor and return its JSON result."""
+    execution = config.get("execution", {})
+    command = _resolve_dlmm_close_command(execution)
+    if not command:
+        return {"success": False, "error": "dlmm_close_command_not_configured"}
+
+    payload = {
+        "wallet_name": wallet_name,
+        "wallet": config.get("wallets", {}).get(wallet_name, {}),
+        "trigger": trigger,
+        "position": trigger.get("position", {}),
+        "pool": pool_pubkey,
+        "execution": execution,
+    }
+    payload_json = json.dumps(payload)
+    env = os.environ.copy()
+    env["DLMM_CLOSE_PAYLOAD"] = payload_json
+    timeout = int(execution.get("close_timeout_seconds", 180))
+
+    try:
+        completed = subprocess.run(
+            command,
+            input=payload_json,
+            text=True,
+            capture_output=True,
+            timeout=timeout,
+            env=env,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        return {"success": False, "error": "dlmm_close_timeout"}
+    except Exception as exc:
+        return {"success": False, "error": "dlmm_close_command_error", "message": str(exc)}
+
+    stdout = (completed.stdout or "").strip()
+    stderr = (completed.stderr or "").strip()
+    result: Dict[str, Any] = {}
+    if stdout:
+        try:
+            result = json.loads(stdout.splitlines()[-1])
+        except json.JSONDecodeError:
+            result = {"success": False, "error": "dlmm_close_invalid_json", "stdout": stdout[-500:]}
+
+    if completed.returncode != 0:
+        result.setdefault("success", False)
+        result.setdefault("error", "dlmm_close_command_failed")
+        if stderr:
+            result["stderr"] = stderr[-500:]
+        return result
+
+    if not result:
+        result = {"success": False, "error": "dlmm_close_no_result"}
+    return result
 
 
 def execute_position_close(wallet_name: str, trigger: Dict, config: Dict) -> bool:
@@ -222,13 +414,13 @@ def execute_position_close(wallet_name: str, trigger: Dict, config: Dict) -> boo
     1. Claim unclaimed fees
     2. Remove all liquidity
     3. Close the position
-    4. Swap non-USDC/SOL tokens to USDC via Jupiter
+    4. Optionally hand off post-close swaps to a configured executor
     5. Post confirmation to Discord
     """
     pos = trigger["position"]
     pubkey = pos.get("position", "")
     pool_name = pos.get("pool_name", "Unknown")
-    pool_pubkey = pos.get("pool", "")
+    pool_pubkey = pos.get("pool") or pos.get("lb_pair", "")
     token_x_mint = pos.get("mint_x", "")
     token_y_mint = pos.get("mint_y", "")
     token_x_symbol = pos.get("token_x_symbol", "X")
@@ -239,7 +431,6 @@ def execute_position_close(wallet_name: str, trigger: Dict, config: Dict) -> boo
     # Get execution config
     execution = config.get("execution", {})
     dry_run = execution.get("dry_run", AUTOMATION_DRY_RUN)
-    swap_slippage = execution.get("swap_slippage_bps", 100)
     
     logger.info(f"{'[DRY RUN] ' if dry_run else ''}Executing position close: {pubkey} ({pool_name})")
     
@@ -247,79 +438,75 @@ def execute_position_close(wallet_name: str, trigger: Dict, config: Dict) -> boo
         logger.info(f"DRY RUN: Would close position {pubkey}, claim fees, swap tokens to USDC")
         _post_execution_notification(wallet_name, trigger, dry_run=True)
         return True
+
+    if not pool_pubkey:
+        logger.error(f"Cannot close DLMM position {pubkey}: missing pool/lb_pair")
+        _post_execution_notification(wallet_name, trigger, dry_run=False, success=False, error="missing_pool")
+        return False
     
     # === REAL EXECUTION ===
-    # Use Jupiter API to generate swap transaction
+    # Close the DLMM position first. Previous code skipped this and jumped
+    # directly to Jupiter, creating a dangerous false-success path.
     try:
-        # Determine which token to swap (token_x or token_y)
-        swap_from_mint = token_x_mint if token_x_mint != USDC_MINT else token_y_mint
-        swap_from_symbol = token_x_symbol if token_x_mint != USDC_MINT else token_y_symbol
-        
-        # For DLMM positions, we need to first remove liquidity then swap
-        # This is a simplified version - generates a basic SOL/USDC swap for now
-        # Full implementation would call DLMM SDK to withdraw position first
-        
-        logger.info(f"Initiating Jupiter swap: {swap_from_symbol} -> USDC")
-        
-        # Get swap quote from Jupiter
-        quote = _get_jupiter_quote(swap_from_mint, USDC_MINT, 1000000)  # 1 unit min
-        if not quote:
-            logger.error("Failed to get Jupiter quote")
-            _post_execution_notification(wallet_name, trigger, dry_run=False, success=False)
+        close_result = _run_dlmm_close_command(wallet_name, trigger, config, pool_pubkey)
+        if not close_result.get("success"):
+            error = close_result.get("error", "dlmm_close_failed")
+            logger.error(f"DLMM close failed for {pubkey}: {error}")
+            _post_execution_notification(wallet_name, trigger, dry_run=False, success=False, error=error)
             return False
-        
-        logger.info(f"Jupiter quote received: {quote.get('outAmount')} USDC")
-        
-        # Get swap transaction
-        swap_tx = _get_jupiter_swap_transaction(quote, swap_from_mint, USDC_MINT, swap_slippage)
-        if not swap_tx:
-            logger.error("Failed to build Jupiter transaction")
-            _post_execution_notification(wallet_name, trigger, dry_run=False, success=False)
-            return False
-        
-        # Post transaction to Discord for manual approval
-        _post_swap_transaction_to_discord(wallet_name, trigger, swap_tx, quote)
-        
-        logger.info("Swap transaction generated and posted to Discord for approval")
-        _post_execution_notification(wallet_name, trigger, dry_run=False, success=True)
+
+        signatures = close_result.get("signatures", [])
+        logger.info(f"DLMM close completed for {pubkey}: {signatures}")
+
+        if execution.get("swap_after_close", False):
+            logger.warning("swap_after_close is configured but not implemented in automation_engine; DLMM close succeeded, swap skipped")
+
+        _post_execution_notification(wallet_name, trigger, dry_run=False, success=True, signatures=signatures)
         return True
         
     except Exception as e:
         logger.error(f"Execution error: {e}")
-        _post_execution_notification(wallet_name, trigger, dry_run=False, success=False)
+        _post_execution_notification(wallet_name, trigger, dry_run=False, success=False, error=str(e))
         return False
 
 
 def _get_jupiter_quote(input_mint: str, output_mint: str, amount: int) -> Optional[Dict]:
-    """Get swap quote from Jupiter API."""
+    """Get swap quote from Jupiter v6 API."""
     try:
-        url = f"https://quote-api.jup.ag/v6/quote?inputMint={input_mint}&outputMint={output_mint}&amount={amount}&slippage=0.5"
-        resp = requests.get(url, timeout=10)
+        params = {
+            "inputMint": input_mint,
+            "outputMint": output_mint,
+            "amount": str(amount),
+            "slippageBps": 50,
+        }
+        resp = requests.get("https://quote-api.jup.ag/v6/quote", params=params, timeout=10)
         if resp.status_code != 200:
             logger.error(f"Jupiter API error: {resp.status_code}")
             return None
         
-        quotes = resp.json()
-        if not quotes or len(quotes) == 0:
+        quote = resp.json()
+        if not quote:
             logger.error("No quotes returned from Jupiter")
             return None
         
-        # Return best quote (first one)
-        return quotes[0]
+        return quote
     except Exception as e:
         logger.error(f"Failed to get Jupiter quote: {e}")
         return None
 
 
-def _get_jupiter_swap_transaction(quote: Dict, input_mint: str, output_mint: str, slippage_bps: int) -> Optional[str]:
+def _get_jupiter_swap_transaction(quote: Dict, input_mint: str, output_mint: str, slippage_bps: int, user_public_key: Optional[str] = None) -> Optional[str]:
     """Get swap transaction from Jupiter API."""
     try:
         url = "https://quote-api.jup.ag/v6/swap"
         payload = {
             "quoteResponse": quote,
-            "userPublicKey": "74QXtqTiM9w1D9WM8ArPEggHPRVUWggeQn3KxvR4ku5x",  # bot wallet
+            "userPublicKey": user_public_key or os.getenv("TRADING_WALLET_PUBLIC_KEY", ""),
             "slippageBps": slippage_bps,
         }
+        if not payload["userPublicKey"]:
+            logger.error("No user public key configured for Jupiter swap transaction")
+            return None
         resp = requests.post(url, json=payload, timeout=15)
         if resp.status_code != 200:
             logger.error(f"Jupiter swap API error: {resp.status_code}")
@@ -343,22 +530,30 @@ def _post_swap_transaction_to_discord(wallet_name: str, trigger: Dict, swap_tx: 
     pnl_pct = trigger["pnl_pct"]
     
     out_amount = int(quote.get("outAmount", 0)) / 1_000_000  # USDC has 6 decimals
+    sterol_id = DISCORD_STEROL_USER_ID or "Sterol"
     
     msg = {
         "content": f"⚠️ **SWAP TRANSACTION READY**\n"
                    f"**Wallet**: {wallet_name}\n"
                    f"**Pool**: {pool_name}\n"
-                   f"**Position**: `{pubkey[:12]}...`\n"
+                   f"**Position**: `{pubkey}`\n"
                    f"**Output**: ~{out_amount:.2f} USDC\n"
                    f"**Transaction**: `Base64 encoded - use Solana CLI or Phantom to sign`\n"
                    f"```\n{swap_tx[:200]}...\n```\n"
-                   f"@Ola Lawal please sign this transaction to complete the take-profit."
+                   f"<@{sterol_id}> please sign this transaction to complete the take-profit."
     }
     
     _post_to_discord_alerts(msg)
 
 
-def _post_execution_notification(wallet_name: str, trigger: Dict, dry_run: bool, success: bool = True):
+def _post_execution_notification(
+    wallet_name: str,
+    trigger: Dict,
+    dry_run: bool,
+    success: bool = True,
+    error: Optional[str] = None,
+    signatures: Optional[List[str]] = None,
+):
     """Post execution notification to Discord."""
     if not DISCORD_WEBHOOK_ALERTS:
         return
@@ -372,16 +567,20 @@ def _post_execution_notification(wallet_name: str, trigger: Dict, dry_run: bool,
     emoji = "🔴" if trigger_type == "stop_loss" else "🟢"
     status = "DRY RUN" if dry_run else ("SUCCESS" if success else "FAILED")
     
-    msg = {
-        "content": f"{emoji} **AUTOMATION {status}**\n"
-                   f"**Wallet**: {wallet_name}\n"
-                   f"**Pool**: {pool_name}\n"
-                   f"**Position**: `{pubkey[:12]}...`\n"
-                   f"**Trigger**: {trigger_type.upper().replace('_', ' ')}\n"
-                   f"**PnL**: {pnl_pct:+.1f}%",
-    }
-    
-    _post_to_discord_alerts(msg)
+    content = (
+        f"{emoji} **AUTOMATION {status}**\n"
+        f"**Wallet**: {wallet_name}\n"
+        f"**Pool**: {pool_name}\n"
+        f"**Position**: `{pubkey}`\n"
+        f"**Trigger**: {trigger_type.upper().replace('_', ' ')}\n"
+        f"**PnL**: {pnl_pct:+.1f}%"
+    )
+    if error:
+        content += f"\n**Error**: `{error}`"
+    if signatures:
+        content += "\n**Tx**: " + ", ".join(f"`{sig}`" for sig in signatures[:3])
+
+    _post_to_discord_alerts({"content": content})
 
 
 def run_automation_checks(wallets_config: Dict, wallets_data: Dict, state: Dict, config: Dict):
@@ -421,7 +620,7 @@ def run_automation_checks(wallets_config: Dict, wallets_data: Dict, state: Dict,
         
         for trigger in triggers:
             if notification_mode == "auto_execute":
-                handle_auto_execute(wallet_name, trigger, config)
+                handle_auto_execute(wallet_name, trigger, config, state)
             elif notification_mode == "alert_owner":
                 handle_alert_owner(wallet_name, trigger, config, state)
             else:

--- a/Pryan-Fire/hughs-forge/scripts/automation_engine.py
+++ b/Pryan-Fire/hughs-forge/scripts/automation_engine.py
@@ -68,10 +68,12 @@ def evaluate_triggers(wallet_name: str, positions: List[Dict], wallet_config: Di
         current_value = float(pos.get("liquidity_usd", 0) or 0)
         fees = _position_fee_value(pos)
 
-        # If the upstream feed reports a dead/empty position, do not turn that
-        # into a fake -100% stop-loss. Closed/stale positions should not fire.
-        if current_value <= 0 and fees <= 0:
-            logger.debug(f"[{wallet_name}] Skipping stale position {pubkey} (zero liquidity + zero fees)")
+        # Closed/stale positions should not fire. Do not infer staleness from
+        # zero value alone: a live position can collapse to zero and still needs
+        # stop-loss handling. Upstream must mark closed/stale explicitly.
+        is_stale = bool(pos.get("stale") or pos.get("closed") or pos.get("pnl", {}).get("stale"))
+        if is_stale:
+            logger.debug(f"[{wallet_name}] Skipping stale position {pubkey}")
             continue
         
         # Get entry value from state
@@ -284,18 +286,24 @@ def handle_auto_execute(wallet_name: str, trigger: Dict, config: Dict, state: Di
     token_x = pos.get("token_x_symbol", pos.get("mint_x", "?")[:8])
     token_y = pos.get("token_y_symbol", pos.get("mint_y", "?")[:8])
     automation_state = state.setdefault("automation", {}).setdefault(wallet_name, {})
+    blacklist = automation_state.setdefault("blacklist", {})
+    if pubkey in blacklist:
+        logger.info(f"[{wallet_name}] Position {pubkey} is blacklisted — skipping auto-execute")
+        return False
+
     exec_tracker = automation_state.setdefault("exec_attempts", {})
     tracker = exec_tracker.setdefault(pubkey, {"attempts": 0, "first_attempt_at": datetime.utcnow().isoformat() + "Z"})
 
     if tracker["attempts"] >= MAX_EXECUTE_RETRIES:
         logger.warning(f"[{wallet_name}] Position {pubkey} failed {tracker['attempts']} auto-execute attempts — blacklisting")
-        automation_state.setdefault("blacklist", {})[pubkey] = {
+        blacklist[pubkey] = {
             "blacklisted_at": datetime.utcnow().isoformat() + "Z",
             "reason": f"Failed {tracker['attempts']} auto-execute attempts",
             "trigger_type": trigger_type,
             "pnl_pct": pnl_pct,
             "pool_name": pool_name,
         }
+        exec_tracker.pop(pubkey, None)
         _post_to_discord_alerts({
             "content": f"⚠️ Auto-execute blacklisted a position after {tracker['attempts']} failures.\n"
                        f"**Pool**: {pool_name} ({token_x}/{token_y})\n"

--- a/Pryan-Fire/hughs-forge/scripts/position_monitor.py
+++ b/Pryan-Fire/hughs-forge/scripts/position_monitor.py
@@ -134,10 +134,15 @@ def get_dexscreener_url(mint_address: str) -> str:
     return f"https://dexscreener.com/solana/{mint_address}"
 
 
+def _position_fee_value(current_data: Dict[str, Any]) -> float:
+    """Return the best per-position fee value available for PnL math."""
+    return float(current_data.get("fees_claimed_usd", current_data.get("fees_24h", 0)) or 0)
+
+
 def calculate_pnl(state_wallet: Dict[str, Any], position_addr: str, current_data: Dict[str, Any]) -> Dict[str, float]:
     """Calculate PnL for a position."""
-    current_liquidity = current_data.get("liquidity_usd", 0)
-    fees_24h = current_data.get("fees_24h", 0)
+    current_liquidity = float(current_data.get("liquidity_usd", 0) or 0)
+    fees = _position_fee_value(current_data)
     
     # Initialize if first time seeing this position
     if position_addr not in state_wallet.get("positions", {}):
@@ -148,9 +153,22 @@ def calculate_pnl(state_wallet: Dict[str, Any], position_addr: str, current_data
     
     pos_state = state_wallet["positions"][position_addr]
     entry_value = pos_state.get("entry_value_usd", current_liquidity)
+
+    # Guard closed/stale positions. A zero-liquidity/zero-fee read should not
+    # display as a fresh -100% loss or fire stop-loss automation.
+    if current_liquidity <= 0 and fees <= 0:
+        return {
+            "pnl_usd": 0.0,
+            "pnl_pct": 0.0,
+            "pnl_24h": 0.0,
+            "entry_value_usd": entry_value,
+            "current_value_usd": 0.0,
+            "stale": True,
+            "last_known_value_usd": pos_state.get("last_known_value_usd", entry_value),
+        }
     
-    # Calculate total PnL
-    pnl_usd = (current_liquidity + fees_24h) - entry_value
+    # Calculate total PnL using per-position claimed fees when available.
+    pnl_usd = (current_liquidity + fees) - entry_value
     pnl_pct = (pnl_usd / entry_value * 100) if entry_value > 0 else 0
     
     # Update history (rolling 24h buffer)
@@ -173,6 +191,7 @@ def calculate_pnl(state_wallet: Dict[str, Any], position_addr: str, current_data
     
     # Update state
     pos_state["entry_value_usd"] = entry_value  # Keep original entry
+    pos_state["last_known_value_usd"] = current_liquidity
     pos_state["history"] = history
     
     return {
@@ -181,6 +200,7 @@ def calculate_pnl(state_wallet: Dict[str, Any], position_addr: str, current_data
         "pnl_24h": round(pnl_24h, 2),
         "entry_value_usd": entry_value,
         "current_value_usd": current_liquidity,
+        "stale": False,
     }
 
 
@@ -286,7 +306,7 @@ def build_position_embed(wallet_name: str, position: Dict[str, Any], pnl: Dict[s
             {"name": "Bin Range", "value": f"{lower_bin}-{upper_bin} (Active: {active_bin})", "inline": False},
             {"name": "Links", "value": f"[Meteora]({meteora_url}) | [DexScreener]({get_dexscreener_url(mint_x)})", "inline": False},
             {"name": "Automation", "value": automation_str, "inline": False},
-            {"name": "Position", "value": f"`{position_addr[:8]}...{position_addr[-6:]}`", "inline": False},
+            {"name": "Position", "value": f"`{position_addr}`", "inline": False},
         ],
     }
     

--- a/Pryan-Fire/hughs-forge/scripts/test_automation_engine.py
+++ b/Pryan-Fire/hughs-forge/scripts/test_automation_engine.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Tests for automation_engine.py - SL/TP automation and close boundaries."""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+import automation_engine
+from automation_engine import evaluate_triggers, execute_position_close, handle_auto_execute
+
+
+def test_evaluate_triggers_no_automation():
+    wallet_config = {"automation": {"enabled": False}}
+    positions = [{"position": "abc123", "liquidity_usd": 1000, "fees_24h": 10}]
+    assert evaluate_triggers("test_wallet", positions, wallet_config, {"wallets": {}}) == []
+
+
+def test_evaluate_triggers_stop_loss():
+    wallet_config = {"automation": {"enabled": True, "stop_loss_pct": 10.0, "take_profit_pct": 50.0}}
+    positions = [{"position": "pos123", "liquidity_usd": 900, "fees_claimed_usd": 0}]
+    state = {"wallets": {"test_wallet": {"positions": {"pos123": {"entry_value_usd": 1000}}}}}
+    triggers = evaluate_triggers("test_wallet", positions, wallet_config, state)
+    assert len(triggers) == 1
+    assert triggers[0]["trigger_type"] == "stop_loss"
+    assert triggers[0]["pnl_pct"] == -10.0
+
+
+def test_evaluate_triggers_take_profit():
+    wallet_config = {"automation": {"enabled": True, "stop_loss_pct": 10.0, "take_profit_pct": 50.0}}
+    positions = [{"position": "pos456", "liquidity_usd": 1500, "fees_claimed_usd": 0}]
+    state = {"wallets": {"test_wallet": {"positions": {"pos456": {"entry_value_usd": 1000}}}}}
+    triggers = evaluate_triggers("test_wallet", positions, wallet_config, state)
+    assert len(triggers) == 1
+    assert triggers[0]["trigger_type"] == "take_profit"
+    assert triggers[0]["pnl_pct"] == 50.0
+
+
+def test_evaluate_triggers_skips_stale_zero_position():
+    wallet_config = {"automation": {"enabled": True, "stop_loss_pct": 10.0, "take_profit_pct": 50.0}}
+    positions = [{"position": "closed", "liquidity_usd": 0, "fees_claimed_usd": 0}]
+    state = {"wallets": {"test_wallet": {"positions": {"closed": {"entry_value_usd": 1000}}}}}
+    assert evaluate_triggers("test_wallet", positions, wallet_config, state) == []
+
+
+def test_execute_position_close_live_fails_without_pool(monkeypatch):
+    monkeypatch.setattr(automation_engine, "DISCORD_WEBHOOK_ALERTS", None)
+    trigger = {
+        "trigger_type": "stop_loss",
+        "pnl_pct": -12.0,
+        "position": {"position": "pos123", "pool_name": "SOL-USDC"},
+    }
+    assert execute_position_close("bot", trigger, {"execution": {"dry_run": False}}) is False
+
+
+def test_execute_position_close_live_uses_dlmm_command(monkeypatch):
+    monkeypatch.setattr(automation_engine, "DISCORD_WEBHOOK_ALERTS", None)
+    called = {}
+
+    def fake_close(wallet_name, trigger, config, pool_pubkey):
+        called["pool"] = pool_pubkey
+        return {"success": True, "signatures": ["sig123"]}
+
+    monkeypatch.setattr(automation_engine, "_run_dlmm_close_command", fake_close)
+    trigger = {
+        "trigger_type": "take_profit",
+        "pnl_pct": 55.0,
+        "position": {"position": "pos123", "lb_pair": "pool123", "pool_name": "SOL-USDC"},
+    }
+    assert execute_position_close("bot", trigger, {"execution": {"dry_run": False}}) is True
+    assert called["pool"] == "pool123"
+
+
+def test_handle_auto_execute_tracks_failure_attempt(monkeypatch):
+    monkeypatch.setattr(automation_engine, "DISCORD_WEBHOOK_ALERTS", None)
+    monkeypatch.setattr(automation_engine, "execute_position_close", lambda *_: False)
+    state = {}
+    trigger = {
+        "trigger_type": "stop_loss",
+        "pnl_pct": -12.0,
+        "entry_value": 1000,
+        "current_value": 850,
+        "position": {"position": "pos123", "lb_pair": "pool123", "pool_name": "SOL-USDC"},
+    }
+    assert handle_auto_execute("bot", trigger, {"execution": {"dry_run": False}}, state) is False
+    assert state["automation"]["bot"]["exec_attempts"]["pos123"]["attempts"] == 1

--- a/Pryan-Fire/hughs-forge/scripts/test_automation_engine.py
+++ b/Pryan-Fire/hughs-forge/scripts/test_automation_engine.py
@@ -35,11 +35,21 @@ def test_evaluate_triggers_take_profit():
     assert triggers[0]["pnl_pct"] == 50.0
 
 
-def test_evaluate_triggers_skips_stale_zero_position():
+def test_evaluate_triggers_skips_explicit_stale_zero_position():
     wallet_config = {"automation": {"enabled": True, "stop_loss_pct": 10.0, "take_profit_pct": 50.0}}
-    positions = [{"position": "closed", "liquidity_usd": 0, "fees_claimed_usd": 0}]
+    positions = [{"position": "closed", "liquidity_usd": 0, "fees_claimed_usd": 0, "pnl": {"stale": True}}]
     state = {"wallets": {"test_wallet": {"positions": {"closed": {"entry_value_usd": 1000}}}}}
     assert evaluate_triggers("test_wallet", positions, wallet_config, state) == []
+
+
+def test_evaluate_triggers_zero_value_live_position_stop_loss():
+    wallet_config = {"automation": {"enabled": True, "stop_loss_pct": 10.0, "take_profit_pct": 50.0}}
+    positions = [{"position": "crashed", "liquidity_usd": 0, "fees_claimed_usd": 0}]
+    state = {"wallets": {"test_wallet": {"positions": {"crashed": {"entry_value_usd": 1000}}}}}
+    triggers = evaluate_triggers("test_wallet", positions, wallet_config, state)
+    assert len(triggers) == 1
+    assert triggers[0]["trigger_type"] == "stop_loss"
+    assert triggers[0]["pnl_pct"] == -100.0
 
 
 def test_execute_position_close_live_fails_without_pool(monkeypatch):
@@ -83,3 +93,21 @@ def test_handle_auto_execute_tracks_failure_attempt(monkeypatch):
     }
     assert handle_auto_execute("bot", trigger, {"execution": {"dry_run": False}}, state) is False
     assert state["automation"]["bot"]["exec_attempts"]["pos123"]["attempts"] == 1
+
+
+def test_handle_auto_execute_blacklist_is_idempotent(monkeypatch):
+    monkeypatch.setattr(automation_engine, "DISCORD_WEBHOOK_ALERTS", "https://discord.invalid/webhook")
+    posted = []
+    monkeypatch.setattr(automation_engine, "_post_to_discord_alerts", lambda msg: posted.append(msg) or True)
+    state = {"automation": {"bot": {"exec_attempts": {"pos123": {"attempts": automation_engine.MAX_EXECUTE_RETRIES}}}}}
+    trigger = {
+        "trigger_type": "stop_loss",
+        "pnl_pct": -12.0,
+        "entry_value": 1000,
+        "current_value": 850,
+        "position": {"position": "pos123", "lb_pair": "pool123", "pool_name": "SOL-USDC"},
+    }
+    assert handle_auto_execute("bot", trigger, {"execution": {"dry_run": False}}, state) is True
+    assert len(posted) == 1
+    assert handle_auto_execute("bot", trigger, {"execution": {"dry_run": False}}, state) is False
+    assert len(posted) == 1

--- a/Pryan-Fire/hughs-forge/scripts/test_position_monitor.py
+++ b/Pryan-Fire/hughs-forge/scripts/test_position_monitor.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Tests for position_monitor.py PnL calculation logic."""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+from position_monitor import calculate_pnl, build_position_embed
+
+
+def test_calculate_pnl_first_position():
+    state_wallet = {"positions": {}}
+    result = calculate_pnl(state_wallet, "pos123", {"liquidity_usd": 1000, "fees_claimed_usd": 50})
+    assert result["pnl_usd"] == 50
+    assert result["entry_value_usd"] == 1000
+    assert result["current_value_usd"] == 1000
+    assert result["pnl_24h"] == 0
+    assert result["stale"] is False
+
+
+def test_calculate_pnl_gain():
+    state_wallet = {"positions": {"pos456": {"entry_value_usd": 1000, "history": []}}}
+    result = calculate_pnl(state_wallet, "pos456", {"liquidity_usd": 1200, "fees_claimed_usd": 30})
+    assert result["pnl_usd"] == 230
+    assert result["pnl_pct"] == 23.0
+
+
+def test_calculate_pnl_loss():
+    state_wallet = {"positions": {"pos789": {"entry_value_usd": 1000, "history": []}}}
+    result = calculate_pnl(state_wallet, "pos789", {"liquidity_usd": 800, "fees_claimed_usd": 20})
+    assert result["pnl_usd"] == -180
+    assert result["pnl_pct"] == -18.0
+
+
+def test_calculate_pnl_stale_zero_does_not_show_loss():
+    state_wallet = {"positions": {"closed": {"entry_value_usd": 1000, "history": [], "last_known_value_usd": 900}}}
+    result = calculate_pnl(state_wallet, "closed", {"liquidity_usd": 0, "fees_claimed_usd": 0})
+    assert result["stale"] is True
+    assert result["pnl_usd"] == 0.0
+    assert result["pnl_pct"] == 0.0
+    assert result["last_known_value_usd"] == 900
+
+
+def test_build_position_embed_keeps_full_position(monkeypatch):
+    monkeypatch.setattr("position_monitor.get_dexscreener_url", lambda _mint: "https://dexscreener.example/token")
+    position_addr = "Position111111111111111111111111111111111111111"
+    embed = build_position_embed(
+        "bot",
+        {"pool_name": "SOL-USDC", "position": position_addr, "mint_x": "So111", "meteora_url": "https://app.meteora.ag/dlmm/pool"},
+        {"pnl_usd": 1, "pnl_pct": 1, "entry_value_usd": 100, "current_value_usd": 101, "pnl_24h": 1},
+        include_buttons=False,
+    )
+    position_field = next(field for field in embed["fields"] if field["name"] == "Position")
+    assert position_field["value"] == f"`{position_addr}`"

--- a/Pryan-Fire/hughs-forge/services/meteora-trader/scripts/close-position.mjs
+++ b/Pryan-Fire/hughs-forge/services/meteora-trader/scripts/close-position.mjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+/**
+ * Close a Meteora DLMM position.
+ *
+ * Input: JSON payload on stdin or DLMM_CLOSE_PAYLOAD env var.
+ * Output: single JSON object on stdout.
+ */
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+
+function loadSolanaDeps() {
+  const { Connection, Keypair, PublicKey, sendAndConfirmTransaction } = require('@solana/web3.js');
+  const { BN } = require('@coral-xyz/anchor');
+  const dlmmModule = require('@meteora-ag/dlmm');
+  const DLMM = dlmmModule.default || dlmmModule;
+  return { Connection, Keypair, PublicKey, sendAndConfirmTransaction, BN, DLMM };
+}
+
+function readPayload() {
+  const raw = process.env.DLMM_CLOSE_PAYLOAD || fs.readFileSync(0, 'utf8');
+  if (!raw || !raw.trim()) throw new Error('missing_payload');
+  return JSON.parse(raw);
+}
+
+function loadKeypair(walletPath, Keypair) {
+  const parsed = JSON.parse(fs.readFileSync(walletPath, 'utf8'));
+  const secret = Array.isArray(parsed) ? parsed : parsed.secretKey;
+  if (!Array.isArray(secret)) throw new Error('wallet_file_must_be_secret_key_array');
+  return Keypair.fromSecretKey(Uint8Array.from(secret));
+}
+
+function writeResult(result) {
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+}
+
+function asTxArray(txs) {
+  return Array.isArray(txs) ? txs : [txs];
+}
+
+try {
+  const payload = readPayload();
+  const positionData = payload.position || payload.trigger?.position || {};
+  const execution = payload.execution || {};
+
+  const positionAddress = positionData.position || payload.position_pubkey;
+  const poolAddress = payload.pool || positionData.pool || positionData.lb_pair || payload.pool_pubkey;
+  if (!positionAddress) throw new Error('missing_position');
+  if (!poolAddress) throw new Error('missing_pool');
+
+  const rpcUrl = execution.solana_rpc_url || process.env.SOLANA_RPC_URL || 'https://api.mainnet-beta.solana.com';
+  const walletPath = execution.wallet_path || process.env.TRADING_WALLET_PATH || process.env.WALLET_KEYPAIR_PATH;
+  if (!walletPath) throw new Error('missing_wallet_path');
+
+  const { Connection, Keypair, PublicKey, sendAndConfirmTransaction, BN, DLMM } = loadSolanaDeps();
+  const connection = new Connection(rpcUrl, 'confirmed');
+  const wallet = loadKeypair(walletPath, Keypair);
+
+  const expectedOwner = payload.wallet?.address || execution.owner_public_key || process.env.TRADING_WALLET_PUBLIC_KEY;
+  if (expectedOwner && expectedOwner !== String(wallet.publicKey)) {
+    throw new Error(`wallet_owner_mismatch:${wallet.publicKey}`);
+  }
+
+  const dlmmPool = await DLMM.create(connection, new PublicKey(poolAddress));
+  const positions = await dlmmPool.getPositionsByUserAndLbPair(wallet.publicKey);
+  const userPosition = positions.userPositions.find((pos) =>
+    pos.publicKey.equals(new PublicKey(positionAddress))
+  );
+
+  if (!userPosition) throw new Error('position_not_found_for_wallet_pool');
+
+  const binIds = (userPosition.positionData?.positionBinData || [])
+    .map((bin) => Number(bin.binId))
+    .filter((binId) => Number.isFinite(binId));
+
+  let transactions;
+  if (binIds.length > 0) {
+    transactions = await dlmmPool.removeLiquidity({
+      position: userPosition.publicKey,
+      user: wallet.publicKey,
+      fromBinId: Math.min(...binIds),
+      toBinId: Math.max(...binIds),
+      bps: new BN(10_000),
+      shouldClaimAndClose: true,
+    });
+  } else {
+    transactions = [await dlmmPool.closePosition({ owner: wallet.publicKey, position: userPosition })];
+  }
+
+  const signatures = [];
+  for (const tx of asTxArray(transactions)) {
+    const signature = await sendAndConfirmTransaction(
+      connection,
+      tx,
+      [wallet],
+      { skipPreflight: false, commitment: 'confirmed' }
+    );
+    signatures.push(signature);
+  }
+
+  writeResult({
+    success: true,
+    position: positionAddress,
+    pool: poolAddress,
+    wallet: String(wallet.publicKey),
+    signatures,
+  });
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(message);
+  writeResult({ success: false, error: message });
+  process.exit(1);
+}

--- a/Pryan-Fire/hughs-forge/services/trade-orchestrator/src/main.py
+++ b/Pryan-Fire/hughs-forge/services/trade-orchestrator/src/main.py
@@ -4,11 +4,14 @@ import threading
 import time
 import os
 import json
+from pathlib import Path
 
-# Add risk-manager src to Python path for direct imports (temporary unblock)
-RISK_MANAGER_SRC = "/data/openclaw/workspace/Pryan-Fire/hughs-forge/risk-manager/src"
-if RISK_MANAGER_SRC not in sys.path:
-    sys.path.insert(0, RISK_MANAGER_SRC)
+# Add risk-manager src to Python path for direct imports (temporary unblock).
+# Resolve from this file so the service does not depend on an old workspace path.
+HUGHS_FORGE_ROOT = Path(__file__).resolve().parents[3]
+RISK_MANAGER_SRC = HUGHS_FORGE_ROOT / "risk-manager" / "src"
+if str(RISK_MANAGER_SRC) not in sys.path:
+    sys.path.insert(0, str(RISK_MANAGER_SRC))
 
 from core.orchestrator import TradeOrchestrator
 from core.event_loop import EventLoop

--- a/Pryan-Fire/hughs-forge/services/trade-orchestrator/tests/test_rpc_integration.py
+++ b/Pryan-Fire/hughs-forge/services/trade-orchestrator/tests/test_rpc_integration.py
@@ -88,7 +88,7 @@ class TestExecuteJupiterTrade:
         assert result["error"] == "no_wallet"
 
     @patch("core.rpc_integration.httpx")
-    def test_quote_failure_returns_error(self, mock_httpx):
+    def test_ultra_order_failure_returns_error(self, mock_httpx):
         mock_resp = MagicMock()
         mock_resp.status_code = 500
         mock_resp.text = "Internal Server Error"
@@ -100,22 +100,16 @@ class TestExecuteJupiterTrade:
             1.0,
         )
         assert result["success"] is False
-        assert result["error"] == "quote_failed"
+        assert result["error"] == "order_failed"
 
     @patch("core.rpc_integration.httpx")
-    def test_swap_tx_failure_returns_error(self, mock_httpx):
-        # Quote succeeds
-        quote_resp = MagicMock()
-        quote_resp.status_code = 200
-        quote_resp.json.return_value = {"routes": []}
+    def test_invalid_ultra_order_returns_error(self, mock_httpx):
+        # Ultra order succeeds but is malformed
+        order_resp = MagicMock()
+        order_resp.status_code = 200
+        order_resp.json.return_value = {"routes": []}
 
-        # Swap fails
-        swap_resp = MagicMock()
-        swap_resp.status_code = 500
-        swap_resp.text = "Swap error"
-
-        mock_httpx.get.return_value = quote_resp
-        mock_httpx.post.return_value = swap_resp
+        mock_httpx.get.return_value = order_resp
 
         result = self.rpc.execute_jupiter_trade(
             "So11111111111111111111111111111111111111112",
@@ -123,7 +117,7 @@ class TestExecuteJupiterTrade:
             1.0,
         )
         assert result["success"] is False
-        assert result["error"] == "swap_tx_failed"
+        assert result["error"] == "invalid_order_response"
 
 
 class TestReturnSignature:


### PR DESCRIPTION
## Summary
- Fixes the false-success DLMM auto-close path: live mode no longer skips straight to Jupiter swap generation.
- Adds a Meteora DLMM close executor that removes 100% liquidity with `shouldClaimAndClose` and returns tx signatures to the Python automation layer.
- Adds bounded retry/backoff/cooldown handling for stop-loss/take-profit auto-execution so failed closes do not spam retries forever.
- Hardens PnL/alert display: skips stale zero-liquidity positions, uses per-position claimed fees when available, and shows full position IDs in alerts/embeds.
- Fixes stale trade-orchestrator risk-manager path and updates stale Jupiter Ultra tests.

## Issues
- Addresses #248
- Related to #277

## Verification
- `python3 -m py_compile Pryan-Fire/hughs-forge/scripts/automation_engine.py Pryan-Fire/hughs-forge/scripts/position_monitor.py Pryan-Fire/hughs-forge/services/risk-manager/discord_bot.py Pryan-Fire/hughs-forge/services/risk-manager/main.py Pryan-Fire/hughs-forge/services/trade-orchestrator/src/main.py Pryan-Fire/hughs-forge/services/trade-orchestrator/src/core/rpc_integration.py`
- `node --check Pryan-Fire/hughs-forge/services/meteora-trader/scripts/close-position.mjs`
- `python3 -m pytest Pryan-Fire/hughs-forge/scripts/test_automation_engine.py Pryan-Fire/hughs-forge/scripts/test_position_monitor.py Pryan-Fire/hughs-forge/services/trade-orchestrator/tests/test_rpc_integration.py -q` → 22 passed

## Notes
- `execution.dry_run` remains `true` in mainnet config.
- Post-close Jupiter swapping remains disabled behind `swap_after_close: false`; this PR closes/claims the DLMM position first and avoids claiming swap success before liquidity is actually withdrawn.
- Unrelated local untracked files were intentionally not included: `Arianus-Sky/projects/gallery-app/`, `Chelestra-Sea/infra/AGENT-RESET-RUNBOOK.md`.
