### PR TITLE
feat: scaffold mobile crypto ops dashboard

### DIFF
--- a/Arianus-Sky/projects/crypto-ops-dashboard/.gitignore
+++ b/Arianus-Sky/projects/crypto-ops-dashboard/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+.DS_Store

--- a/Arianus-Sky/projects/crypto-ops-dashboard/README.md
+++ b/Arianus-Sky/projects/crypto-ops-dashboard/README.md
@@ -33,7 +33,9 @@ npm run build
 
 ## Data integration contract
 
-The UI tries to load `/api/crypto-ops/summary.json` and falls back to safe fixture data. The backend/API facade should provide the same shape as `src/data/cryptoOps.js`.
+The UI first tries the read-only Pryan-Fire API facade endpoints under `/api/crypto/*`, then falls back to `/api/crypto-ops/summary.json`, then to safe fixture data.
+
+A fixture-backed stdlib facade lives at `Pryan-Fire/haplos-workshop/crypto-ops-api/` for Phase 2 validation.
 
 Live actions are disabled unless every gate is explicit:
 

--- a/Arianus-Sky/projects/crypto-ops-dashboard/README.md
+++ b/Arianus-Sky/projects/crypto-ops-dashboard/README.md
@@ -1,0 +1,57 @@
+# Pryan Fire Crypto Ops Dashboard
+
+Mobile-first Vue/PWA operator dashboard for the Pryan-Fire crypto tools requested in issue #296.
+
+## Scope
+
+This first cut is intentionally read-only / dry-run by default. It gives Hugh an application workflow to validate behavior instead of testing Python scripts directly.
+
+Surfaced modules:
+
+- Portfolio overview: equity, PnL, exposure, risk posture
+- DLMM manager: positions, pool IDs, close state, fees, tx status
+- Position monitor / SLTP: #277 validation chain evidence
+- Sniper tool: scanner status, candidates, rejected reasons
+- Top pool view: liquidity, volume, fees, risk signal
+- Kill feed / alerts: explicit tx submitted vs none submitted
+- Hugh validation panel: per-PR evidence checklist
+
+## Run locally
+
+```bash
+cd Arianus-Sky/projects/crypto-ops-dashboard
+npm install
+npm run dev
+```
+
+Build and validation test:
+
+```bash
+npm run test:validation
+npm run build
+```
+
+## Data integration contract
+
+The UI tries to load `/api/crypto-ops/summary.json` and falls back to safe fixture data. The backend/API facade should provide the same shape as `src/data/cryptoOps.js`.
+
+Live actions are disabled unless every gate is explicit:
+
+- `risk.liveTrading === true`
+- `risk.killSwitch === "CLEAR"`
+- `risk.walletAuth === "connected"`
+- every `risk.gates[].state === "passed"`
+
+Until those gates are visible and passing, the app must remain read-only/dry-run.
+
+## Hugh validation workflow
+
+For #277-style validation, Hugh should confirm the UI shows:
+
+1. monitor
+2. trigger
+3. close executor
+4. alert
+5. state persistence
+
+The UI must distinguish dry-run, failed attempt, submitted transaction, and confirmed transaction. The fixture currently proves the safe-mode path with `none submitted` transaction state.

--- a/Arianus-Sky/projects/crypto-ops-dashboard/README.md
+++ b/Arianus-Sky/projects/crypto-ops-dashboard/README.md
@@ -1,6 +1,6 @@
 # Pryan Fire Crypto Ops Dashboard
 
-Mobile-first Vue/PWA operator dashboard for the Pryan-Fire crypto tools requested in issue #296.
+Responsive Vue/PWA operator dashboard for the Pryan-Fire crypto tools requested in issue #296. Phone-friendly first, but not phone-only: tablet and desktop layouts are first-class.
 
 ## Scope
 
@@ -8,7 +8,7 @@ This first cut is intentionally read-only / dry-run by default. It gives Hugh an
 
 Surfaced modules:
 
-- Portfolio overview: equity, PnL, exposure, risk posture
+- Responsive overview: equity, PnL, exposure, risk posture
 - DLMM manager: positions, pool IDs, close state, fees, tx status
 - Position monitor / SLTP: #277 validation chain evidence
 - Sniper tool: scanner status, candidates, rejected reasons

--- a/Arianus-Sky/projects/crypto-ops-dashboard/README.md
+++ b/Arianus-Sky/projects/crypto-ops-dashboard/README.md
@@ -35,7 +35,9 @@ npm run build
 
 The UI first tries the read-only Pryan-Fire API facade endpoints under `/api/crypto/*`, then falls back to `/api/crypto-ops/summary.json`, then to safe fixture data.
 
-A fixture-backed stdlib facade lives at `Pryan-Fire/haplos-workshop/crypto-ops-api/` for Phase 2 validation.
+A fixture-backed stdlib facade lives at `Pryan-Fire/haplos-workshop/crypto-ops-api/` for Phase 2 validation. Run it on port 8787 while using Vite dev server; `vite.config.js` proxies `/api/crypto*` to the facade.
+
+Validation evidence posts to `POST /api/crypto/validation/:id/result` and accepts evidence fields only. Trading/tx fields are rejected server-side.
 
 Live actions are disabled unless every gate is explicit:
 

--- a/Arianus-Sky/projects/crypto-ops-dashboard/index.html
+++ b/Arianus-Sky/projects/crypto-ops-dashboard/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#0f172a" />
+    <link rel="manifest" href="/manifest.webmanifest" />
+    <title>Pryan Fire Crypto Ops</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.js"></script>
+  </body>
+</html>

--- a/Arianus-Sky/projects/crypto-ops-dashboard/package-lock.json
+++ b/Arianus-Sky/projects/crypto-ops-dashboard/package-lock.json
@@ -1,0 +1,1057 @@
+{
+  "name": "crypto-ops-dashboard",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "crypto-ops-dashboard",
+      "version": "0.1.0",
+      "dependencies": {
+        "@vitejs/plugin-vue": "^6.0.6",
+        "vite": "^8.0.10",
+        "vue": "^3.5.33"
+      },
+      "devDependencies": {}
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
+      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
+      "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
+      "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.13.tgz",
+      "integrity": "sha512-3ngTAv6F/Py35BsYbeeLeecvhMKdsKm4AoOETVhAA+Qc8nrA2I0kF7oa93mE9qnIurngOSpMnQ0x2nQY2FPviA==",
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-vue": {
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-6.0.6.tgz",
+      "integrity": "sha512-u9HHgfrq3AjXlysn0eINFnWQOJQLO9WN6VprZ8FXl7A2bYisv3Hui9Ij+7QZ41F/WYWarHjwBbXtD7dKg3uxbg==",
+      "license": "MIT",
+      "dependencies": {
+        "@rolldown/pluginutils": "1.0.0-rc.13"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
+        "vue": "^3.2.25"
+      }
+    },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.33.tgz",
+      "integrity": "sha512-3PZLQwFw4Za3TC8t0FvTy3wI16Kt+pmwcgNZca4Pj9iWL2E72a/gZlpBtAJvEdDMdCxdG/qq0C7PN0bsJuv0Rw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.2",
+        "@vue/shared": "3.5.33",
+        "entities": "^7.0.1",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.33.tgz",
+      "integrity": "sha512-PXq0yrfCLzzL07rbXO4awtXY1Z06LG2eu6Adg3RJFa/j3Cii217XxxLXG22N330gw7GmALCY0Z8RgXEviwgpjA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-core": "3.5.33",
+        "@vue/shared": "3.5.33"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.33.tgz",
+      "integrity": "sha512-UTUvRO9cY+rROrx/pvN9P5Z7FgA6QGfokUCfhQE4EnmUj3rVnK+CHI0LsEO1pg+I7//iRYMUfcNcCPe7tg0CoA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.2",
+        "@vue/compiler-core": "3.5.33",
+        "@vue/compiler-dom": "3.5.33",
+        "@vue/compiler-ssr": "3.5.33",
+        "@vue/shared": "3.5.33",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.21",
+        "postcss": "^8.5.10",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.33.tgz",
+      "integrity": "sha512-IErjYdnj1qIupG5xxiVIYiiRvDhGWV4zuh/RCrwfYpuL+HWQzeU6lCk/nF9r7olWMnjKxCAkOctT2qFWFkzb1A==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.33",
+        "@vue/shared": "3.5.33"
+      }
+    },
+    "node_modules/@vue/reactivity": {
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.33.tgz",
+      "integrity": "sha512-p8UfIqyIhb0rYGlSgSBV+lPhF2iUSBcRy7enhTmPqKWadHy9kcOFYF1AejYBP9P+avnd3OBbD49DU4pLWX/94A==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/shared": "3.5.33"
+      }
+    },
+    "node_modules/@vue/runtime-core": {
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.33.tgz",
+      "integrity": "sha512-UpFF45RI9//a7rvq7RdOQblb4tup7hHG9QsmIrxkFQLzQ7R8/iNQ5LE15NhLZ1/WcHMU2b47u6P33CPUelHyIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.33",
+        "@vue/shared": "3.5.33"
+      }
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.33.tgz",
+      "integrity": "sha512-IOxMsAOwquhfITgmOgaPYl7/j8gKUxUFoflRc+u4LxyD3+783xne8vNta1PONVCvCV9A0w7hkyEepINDqfO0tw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.33",
+        "@vue/runtime-core": "3.5.33",
+        "@vue/shared": "3.5.33",
+        "csstype": "^3.2.3"
+      }
+    },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.33.tgz",
+      "integrity": "sha512-0xylq/8/h44lVG0pZFknv1XIdEgymq2E9n59uTWJBG+dIgiT0TMCSsxrN7nO16Z0MU0MPjFcguBbZV8Itk52Hw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-ssr": "3.5.33",
+        "@vue/shared": "3.5.33"
+      },
+      "peerDependencies": {
+        "vue": "3.5.33"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.33.tgz",
+      "integrity": "sha512-5vR2QIlmaLG77Ygd4pMP6+SGQ5yox9VhtnbDWTy9DzMzdmeLxZ1QqxrywEZ9sa1AVubfIJyaCG3ytyWU81ufcQ==",
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "license": "MIT"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
+      "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.127.0",
+        "@rolldown/pluginutils": "1.0.0-rc.17"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
+      }
+    },
+    "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
+      "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
+      "license": "MIT"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/vite": {
+      "version": "8.0.10",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
+      "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.10",
+        "rolldown": "1.0.0-rc.17",
+        "tinyglobby": "^0.2.16"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue": {
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.33.tgz",
+      "integrity": "sha512-1AgChhx5w3ALgT4oK3acm2Es/7jyZhWSVUfs3rOBlGQC0rjEDkS7G4lWlJJGGNQD+BV3reCwbQrOe1mPNwKHBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.33",
+        "@vue/compiler-sfc": "3.5.33",
+        "@vue/runtime-dom": "3.5.33",
+        "@vue/server-renderer": "3.5.33",
+        "@vue/shared": "3.5.33"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/Arianus-Sky/projects/crypto-ops-dashboard/package.json
+++ b/Arianus-Sky/projects/crypto-ops-dashboard/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "crypto-ops-dashboard",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite --host 0.0.0.0",
+    "build": "vite build",
+    "preview": "vite preview --host 0.0.0.0",
+    "test:validation": "node tests/validation.test.mjs"
+  },
+  "dependencies": {
+    "@vitejs/plugin-vue": "^6.0.6",
+    "vite": "^8.0.10",
+    "vue": "^3.5.33"
+  },
+  "devDependencies": {}
+}

--- a/Arianus-Sky/projects/crypto-ops-dashboard/public/manifest.webmanifest
+++ b/Arianus-Sky/projects/crypto-ops-dashboard/public/manifest.webmanifest
@@ -1,0 +1,10 @@
+{
+  "name": "Pryan Fire Crypto Ops",
+  "short_name": "Crypto Ops",
+  "description": "Mobile operator dashboard for Pryan-Fire crypto tooling.",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#020617",
+  "theme_color": "#0f172a",
+  "icons": []
+}

--- a/Arianus-Sky/projects/crypto-ops-dashboard/src/App.vue
+++ b/Arianus-Sky/projects/crypto-ops-dashboard/src/App.vue
@@ -1,11 +1,20 @@
 <script setup>
 import { computed, onMounted, ref } from 'vue'
-import { hasLiveActionPermission, loadDashboard, validationSummary } from './data/cryptoOps.js'
+import { hasLiveActionPermission, loadDashboard, submitValidationResult, validationSummary } from './data/cryptoOps.js'
 
 const dashboard = ref(null)
+const validationSelection = ref('#296')
+const validationResult = ref('passed')
+const validationEvidence = ref('')
+const validationTester = ref('Hugh')
+const validationScreen = ref('Validation')
+const validationRiskNotes = ref('No live-money controls exercised.')
+const validationSubmitState = ref('idle')
+const validationSubmitMessage = ref('')
 
 onMounted(async () => {
   dashboard.value = await loadDashboard()
+  validationSelection.value = dashboard.value?.prValidation?.find((item) => item.result === 'pending')?.issue ?? dashboard.value?.prValidation?.[0]?.issue ?? '#296'
 })
 
 const liveAllowed = computed(() => hasLiveActionPermission(dashboard.value))
@@ -13,6 +22,25 @@ const chainSummary = computed(() => validationSummary(dashboard.value))
 
 const money = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 })
 const preciseMoney = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' })
+
+async function recordValidationEvidence() {
+  validationSubmitState.value = 'saving'
+  validationSubmitMessage.value = ''
+  try {
+    const response = await submitValidationResult(validationSelection.value, {
+      result: validationResult.value,
+      evidence: validationEvidence.value,
+      tester: validationTester.value,
+      screen: validationScreen.value,
+      riskNotes: validationRiskNotes.value,
+    })
+    validationSubmitState.value = 'saved'
+    validationSubmitMessage.value = `Evidence recorded for ${response.record.id}; live execution remains disabled.`
+  } catch (error) {
+    validationSubmitState.value = 'error'
+    validationSubmitMessage.value = error.message
+  }
+}
 </script>
 
 <template>
@@ -157,6 +185,49 @@ const preciseMoney = new Intl.NumberFormat('en-US', { style: 'currency', currenc
           <small>{{ item.evidence }}</small>
         </div>
       </div>
+
+      <form class="validation-form" @submit.prevent="recordValidationEvidence">
+        <div class="section-title compact">
+          <h3>Record validation evidence</h3>
+          <span>evidence only · no trading action</span>
+        </div>
+        <div class="form-grid">
+          <label>
+            PR / ticket
+            <select v-model="validationSelection">
+              <option v-for="item in dashboard.prValidation" :key="item.issue" :value="item.issue">{{ item.pr }} / {{ item.issue }}</option>
+            </select>
+          </label>
+          <label>
+            Result
+            <select v-model="validationResult">
+              <option value="passed">passed</option>
+              <option value="failed">failed</option>
+              <option value="blocked">blocked</option>
+            </select>
+          </label>
+          <label>
+            Tester
+            <input v-model="validationTester" autocomplete="off" />
+          </label>
+          <label>
+            Screen inspected
+            <input v-model="validationScreen" autocomplete="off" />
+          </label>
+        </div>
+        <label>
+          Evidence
+          <textarea v-model="validationEvidence" placeholder="What was inspected, expected behavior, actual behavior, links or log excerpt paths." required></textarea>
+        </label>
+        <label>
+          Risk notes
+          <textarea v-model="validationRiskNotes"></textarea>
+        </label>
+        <button class="evidence-action" :disabled="validationSubmitState === 'saving'">
+          {{ validationSubmitState === 'saving' ? 'Recording…' : 'Record evidence only' }}
+        </button>
+        <p v-if="validationSubmitMessage" class="form-message" :class="validationSubmitState">{{ validationSubmitMessage }}</p>
+      </form>
     </section>
   </main>
 </template>

--- a/Arianus-Sky/projects/crypto-ops-dashboard/src/App.vue
+++ b/Arianus-Sky/projects/crypto-ops-dashboard/src/App.vue
@@ -1,0 +1,162 @@
+<script setup>
+import { computed, onMounted, ref } from 'vue'
+import { hasLiveActionPermission, loadDashboard, validationSummary } from './data/cryptoOps.js'
+
+const dashboard = ref(null)
+
+onMounted(async () => {
+  dashboard.value = await loadDashboard()
+})
+
+const liveAllowed = computed(() => hasLiveActionPermission(dashboard.value))
+const chainSummary = computed(() => validationSummary(dashboard.value))
+
+const money = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 })
+const preciseMoney = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' })
+</script>
+
+<template>
+  <main v-if="dashboard" class="shell">
+    <section class="hero panel">
+      <div>
+        <p class="eyebrow">Pryan-Fire / Arianus-Sky</p>
+        <h1>Crypto Ops Dashboard</h1>
+        <p class="subtle">One mobile-first control surface for DLMM, positions, sniper, top pools, kill feeds, and Hugh validation.</p>
+      </div>
+      <div class="mode-card" :class="liveAllowed ? 'danger' : 'safe'">
+        <span>{{ dashboard.mode }}</span>
+        <strong>{{ liveAllowed ? 'LIVE ACTIONS ENABLED' : 'READ-ONLY / DRY-RUN' }}</strong>
+      </div>
+    </section>
+
+    <section class="grid cards-4">
+      <article class="panel metric">
+        <span>Portfolio</span>
+        <strong>{{ preciseMoney.format(dashboard.portfolio.equityUsd) }}</strong>
+        <small :class="dashboard.portfolio.pnl24hUsd >= 0 ? 'good' : 'bad'">24h {{ preciseMoney.format(dashboard.portfolio.pnl24hUsd) }} / {{ dashboard.portfolio.pnl24hPct }}%</small>
+      </article>
+      <article class="panel metric">
+        <span>Open exposure</span>
+        <strong>{{ preciseMoney.format(dashboard.portfolio.openExposureUsd) }}</strong>
+        <small>{{ dashboard.portfolio.riskPosture }}</small>
+      </article>
+      <article class="panel metric">
+        <span>Kill switch</span>
+        <strong>{{ dashboard.risk.killSwitch }}</strong>
+        <small>{{ dashboard.risk.liveTrading ? 'live trading on' : 'live trading off' }}</small>
+      </article>
+      <article class="panel metric">
+        <span>#277 chain</span>
+        <strong>{{ chainSummary.verified }}/{{ chainSummary.total }}</strong>
+        <small>{{ chainSummary.complete ? 'safe-mode complete' : 'pending gates' }}</small>
+      </article>
+    </section>
+
+    <section class="grid two-col">
+      <article class="panel">
+        <div class="section-title">
+          <h2>DLMM manager</h2>
+          <span>close state / fees / tx</span>
+        </div>
+        <div class="list">
+          <div v-for="position in dashboard.dlmmPositions" :key="position.id" class="row-card">
+            <div>
+              <strong>{{ position.pair }}</strong>
+              <small>{{ position.poolId }}</small>
+            </div>
+            <div class="right">
+              <span>{{ preciseMoney.format(position.liquidityUsd) }}</span>
+              <small>fees {{ preciseMoney.format(position.feesUsd) }} · {{ position.closeState }}</small>
+              <small>tx: {{ position.lastTx }}</small>
+            </div>
+          </div>
+        </div>
+      </article>
+
+      <article class="panel">
+        <div class="section-title">
+          <h2>Risk gates</h2>
+          <span>live controls locked by default</span>
+        </div>
+        <div class="gate" v-for="gate in dashboard.risk.gates" :key="gate.name">
+          <span>{{ gate.name }}</span>
+          <strong>{{ gate.state }}</strong>
+        </div>
+        <button class="disabled-action" disabled>Live execution disabled until all gates pass</button>
+      </article>
+    </section>
+
+    <section class="grid two-col">
+      <article class="panel">
+        <div class="section-title">
+          <h2>Position monitor / SLTP</h2>
+          <span>{{ dashboard.stopLossTakeProfit.issue }} · {{ dashboard.stopLossTakeProfit.status }}</span>
+        </div>
+        <ol class="chain">
+          <li v-for="item in dashboard.stopLossTakeProfit.chain" :key="item.step">
+            <span>{{ item.step }}</span>
+            <strong>{{ item.state }}</strong>
+          </li>
+        </ol>
+        <p class="evidence">{{ dashboard.stopLossTakeProfit.latestEvidence }}</p>
+      </article>
+
+      <article class="panel">
+        <div class="section-title">
+          <h2>Sniper tool</h2>
+          <span>{{ dashboard.sniper.status }}</span>
+        </div>
+        <h3>Candidates</h3>
+        <div class="pill-row" v-for="candidate in dashboard.sniper.candidates" :key="candidate.symbol">
+          <strong>{{ candidate.symbol }}</strong>
+          <span>score {{ candidate.score }}</span>
+          <small>{{ candidate.reason }}</small>
+        </div>
+        <h3>Rejected</h3>
+        <div class="pill-row muted" v-for="reject in dashboard.sniper.rejected" :key="reject.symbol">
+          <strong>{{ reject.symbol }}</strong>
+          <small>{{ reject.reason }}</small>
+        </div>
+      </article>
+    </section>
+
+    <section class="grid two-col">
+      <article class="panel">
+        <div class="section-title">
+          <h2>Top pools</h2>
+          <span>liquidity / volume / risk</span>
+        </div>
+        <div class="pool" v-for="pool in dashboard.topPools" :key="pool.pair">
+          <span>#{{ pool.rank }} {{ pool.pair }}</span>
+          <strong>{{ money.format(pool.liquidityUsd) }}</strong>
+          <small>vol {{ money.format(pool.volume24hUsd) }} · fees {{ money.format(pool.fees24hUsd) }} · risk {{ pool.risk }}</small>
+        </div>
+      </article>
+
+      <article class="panel">
+        <div class="section-title">
+          <h2>Kill feed / alerts</h2>
+          <span>tx submitted vs none submitted</span>
+        </div>
+        <div class="feed" v-for="event in dashboard.killFeed" :key="event.time + event.message" :class="event.severity">
+          <time>{{ event.time }}</time>
+          <span>{{ event.message }}</span>
+        </div>
+      </article>
+    </section>
+
+    <section class="panel">
+      <div class="section-title">
+        <h2>Hugh validation</h2>
+        <span>PR evidence checklist</span>
+      </div>
+      <div class="validation-grid">
+        <div v-for="item in dashboard.prValidation" :key="item.pr" class="validation-card">
+          <strong>{{ item.pr }} / {{ item.issue }}</strong>
+          <span>{{ item.result }}</span>
+          <small>{{ item.evidence }}</small>
+        </div>
+      </div>
+    </section>
+  </main>
+</template>

--- a/Arianus-Sky/projects/crypto-ops-dashboard/src/App.vue
+++ b/Arianus-Sky/projects/crypto-ops-dashboard/src/App.vue
@@ -49,7 +49,7 @@ async function recordValidationEvidence() {
       <div>
         <p class="eyebrow">Pryan-Fire / Arianus-Sky</p>
         <h1>Crypto Ops Dashboard</h1>
-        <p class="subtle">One mobile-first control surface for DLMM, positions, sniper, top pools, kill feeds, and Hugh validation.</p>
+        <p class="subtle">Responsive operator cockpit for DLMM, positions, sniper, top pools, kill feeds, and Hugh validation — phone-friendly, tablet-ready, desktop-comfortable.</p>
       </div>
       <div class="mode-card" :class="liveAllowed ? 'danger' : 'safe'">
         <span>{{ dashboard.mode }}</span>
@@ -57,7 +57,17 @@ async function recordValidationEvidence() {
       </div>
     </section>
 
-    <section class="grid cards-4">
+    <nav class="quick-nav panel" aria-label="Dashboard sections">
+      <a href="#overview">Overview</a>
+      <a href="#positions">Positions</a>
+      <a href="#monitor">Monitor</a>
+      <a href="#sniper">Sniper</a>
+      <a href="#pools">Pools</a>
+      <a href="#risk-feed">Risk feed</a>
+      <a href="#validation">Validation</a>
+    </nav>
+
+    <section id="overview" class="grid cards-4">
       <article class="panel metric">
         <span>Portfolio</span>
         <strong>{{ preciseMoney.format(dashboard.portfolio.equityUsd) }}</strong>
@@ -80,8 +90,8 @@ async function recordValidationEvidence() {
       </article>
     </section>
 
-    <section class="grid two-col">
-      <article class="panel">
+    <section id="positions" class="grid two-col split-wide">
+      <article class="panel span-7">
         <div class="section-title">
           <h2>DLMM manager</h2>
           <span>close state / fees / tx</span>
@@ -101,7 +111,7 @@ async function recordValidationEvidence() {
         </div>
       </article>
 
-      <article class="panel">
+      <article class="panel span-5">
         <div class="section-title">
           <h2>Risk gates</h2>
           <span>live controls locked by default</span>
@@ -114,8 +124,8 @@ async function recordValidationEvidence() {
       </article>
     </section>
 
-    <section class="grid two-col">
-      <article class="panel">
+    <section class="grid two-col split-wide">
+      <article id="monitor" class="panel span-6">
         <div class="section-title">
           <h2>Position monitor / SLTP</h2>
           <span>{{ dashboard.stopLossTakeProfit.issue }} · {{ dashboard.stopLossTakeProfit.status }}</span>
@@ -129,7 +139,7 @@ async function recordValidationEvidence() {
         <p class="evidence">{{ dashboard.stopLossTakeProfit.latestEvidence }}</p>
       </article>
 
-      <article class="panel">
+      <article id="sniper" class="panel span-6">
         <div class="section-title">
           <h2>Sniper tool</h2>
           <span>{{ dashboard.sniper.status }}</span>
@@ -148,8 +158,8 @@ async function recordValidationEvidence() {
       </article>
     </section>
 
-    <section class="grid two-col">
-      <article class="panel">
+    <section class="grid two-col split-wide">
+      <article id="pools" class="panel span-6">
         <div class="section-title">
           <h2>Top pools</h2>
           <span>liquidity / volume / risk</span>
@@ -161,7 +171,7 @@ async function recordValidationEvidence() {
         </div>
       </article>
 
-      <article class="panel">
+      <article id="risk-feed" class="panel span-6">
         <div class="section-title">
           <h2>Kill feed / alerts</h2>
           <span>tx submitted vs none submitted</span>
@@ -173,7 +183,7 @@ async function recordValidationEvidence() {
       </article>
     </section>
 
-    <section class="panel">
+    <section id="validation" class="panel validation-panel">
       <div class="section-title">
         <h2>Hugh validation</h2>
         <span>PR evidence checklist</span>

--- a/Arianus-Sky/projects/crypto-ops-dashboard/src/data/cryptoOps.js
+++ b/Arianus-Sky/projects/crypto-ops-dashboard/src/data/cryptoOps.js
@@ -105,12 +105,63 @@ export function validationSummary(dashboard = sampleDashboard) {
   }
 }
 
+export const apiEndpoints = {
+  health: '/api/crypto/health',
+  portfolio: '/api/crypto/portfolio',
+  positions: '/api/crypto/positions/dlmm',
+  monitor: '/api/crypto/positions/monitor',
+  closeState: '/api/crypto/close/state',
+  sniperStatus: '/api/crypto/sniper/status',
+  sniperCandidates: '/api/crypto/sniper/candidates',
+  topPools: '/api/crypto/pools/top',
+  riskFeed: '/api/crypto/risk/feed',
+  killSwitch: '/api/crypto/kill-switch',
+  validation: '/api/crypto/validation/prs',
+}
+
+async function fetchJson(path) {
+  const response = await fetch(path, { cache: 'no-store' })
+  if (!response.ok) throw new Error(`API request failed: ${path}`)
+  return response.json()
+}
+
+export function composeDashboardFromApiPayloads(payloads = {}) {
+  return {
+    generatedAt: payloads.health?.generatedAt ?? sampleDashboard.generatedAt,
+    mode: payloads.health?.mode ?? 'read-only-api',
+    portfolio: payloads.portfolio ?? sampleDashboard.portfolio,
+    risk: {
+      killSwitch: payloads.killSwitch?.state ?? sampleDashboard.risk.killSwitch,
+      liveTrading: payloads.killSwitch?.liveTrading ?? false,
+      walletAuth: payloads.killSwitch?.walletAuth ?? 'not-connected',
+      gates: payloads.killSwitch?.gates ?? sampleDashboard.risk.gates,
+    },
+    dlmmPositions: payloads.positions?.positions ?? sampleDashboard.dlmmPositions,
+    stopLossTakeProfit: payloads.monitor ?? sampleDashboard.stopLossTakeProfit,
+    sniper: {
+      status: payloads.sniperStatus?.status ?? sampleDashboard.sniper.status,
+      candidates: payloads.sniperCandidates?.candidates ?? sampleDashboard.sniper.candidates,
+      rejected: payloads.sniperStatus?.rejected ?? sampleDashboard.sniper.rejected,
+    },
+    topPools: payloads.topPools?.pools ?? sampleDashboard.topPools,
+    killFeed: payloads.riskFeed?.events ?? sampleDashboard.killFeed,
+    prValidation: payloads.validation?.records ?? sampleDashboard.prValidation,
+  }
+}
+
 export async function loadDashboard() {
   try {
-    const response = await fetch('/api/crypto-ops/summary.json', { cache: 'no-store' })
-    if (!response.ok) return sampleDashboard
-    return await response.json()
+    const entries = await Promise.all(
+      Object.entries(apiEndpoints).map(async ([key, path]) => [key, await fetchJson(path)]),
+    )
+    return composeDashboardFromApiPayloads(Object.fromEntries(entries))
   } catch {
-    return sampleDashboard
+    try {
+      const response = await fetch('/api/crypto-ops/summary.json', { cache: 'no-store' })
+      if (!response.ok) return sampleDashboard
+      return await response.json()
+    } catch {
+      return sampleDashboard
+    }
   }
 }

--- a/Arianus-Sky/projects/crypto-ops-dashboard/src/data/cryptoOps.js
+++ b/Arianus-Sky/projects/crypto-ops-dashboard/src/data/cryptoOps.js
@@ -1,0 +1,116 @@
+export const validationChain = [
+  'monitor',
+  'trigger',
+  'close executor',
+  'alert',
+  'state persistence',
+]
+
+export const sampleDashboard = {
+  generatedAt: '2026-04-29T05:20:00Z',
+  mode: 'safe-test',
+  portfolio: {
+    wallet: 'Hugh runtime wallet',
+    equityUsd: 12840.55,
+    pnl24hUsd: 316.42,
+    pnl24hPct: 2.53,
+    openExposureUsd: 4210.18,
+    riskPosture: 'SAFE_TEST_ONLY',
+  },
+  risk: {
+    killSwitch: 'ARMED',
+    liveTrading: false,
+    walletAuth: 'not-connected',
+    gates: [
+      { name: 'Hugh validation', state: 'passed-safe-mode' },
+      { name: 'Live executor', state: 'disabled' },
+      { name: 'Wallet authorization', state: 'blocked' },
+      { name: 'Kill switch visibility', state: 'visible' },
+    ],
+  },
+  dlmmPositions: [
+    {
+      id: 'dlmm-001',
+      pair: 'SOL/USDC',
+      poolId: 'pool-sol-usdc-demo',
+      liquidityUsd: 2480.12,
+      feesUsd: 41.82,
+      pnlUsd: 128.34,
+      state: 'open',
+      closeState: 'dry-run-ready',
+      lastTx: 'none submitted',
+    },
+    {
+      id: 'dlmm-002',
+      pair: 'BONK/SOL',
+      poolId: 'pool-bonk-sol-demo',
+      liquidityUsd: 1730.06,
+      feesUsd: 18.94,
+      pnlUsd: -22.7,
+      state: 'watching',
+      closeState: 'risk-gated',
+      lastTx: 'none submitted',
+    },
+  ],
+  stopLossTakeProfit: {
+    issue: '#277',
+    status: 'safe-mode-passed',
+    chain: validationChain.map((step) => ({ step, state: 'verified-safe-mode' })),
+    latestEvidence: 'Hugh validated PR #295 in clean runtime checkout; 17 regression tests passed.',
+  },
+  sniper: {
+    status: 'dry-run',
+    candidates: [
+      { symbol: 'DEMO1/SOL', score: 82, reason: 'liquidity rising; dry-run only' },
+      { symbol: 'DEMO2/USDC', score: 74, reason: 'fee velocity; blocked until risk gates pass' },
+    ],
+    rejected: [
+      { symbol: 'RUG/SOL', reason: 'authority risk' },
+      { symbol: 'THIN/USDC', reason: 'liquidity below threshold' },
+    ],
+  },
+  topPools: [
+    { rank: 1, pair: 'SOL/USDC', liquidityUsd: 12200000, volume24hUsd: 8400000, fees24hUsd: 18200, risk: 'low' },
+    { rank: 2, pair: 'JUP/SOL', liquidityUsd: 4100000, volume24hUsd: 2600000, fees24hUsd: 7400, risk: 'medium' },
+    { rank: 3, pair: 'BONK/SOL', liquidityUsd: 2200000, volume24hUsd: 1900000, fees24hUsd: 6100, risk: 'medium' },
+  ],
+  killFeed: [
+    { time: '00:17 CDT', severity: 'info', message: '#295 safe-mode validation passed; no live tx submitted.' },
+    { time: '00:13 CDT', severity: 'warn', message: 'Remote pytest unavailable on Hugh until pytest is installed.' },
+    { time: '00:11 CDT', severity: 'safe', message: 'Live-money automation remains disabled.' },
+  ],
+  prValidation: [
+    { pr: '#295', issue: '#277', result: 'passed-safe-mode', evidence: '17 tests passed; fake executor success/failure persisted.' },
+    { pr: 'next', issue: '#296', result: 'pending', evidence: 'Dashboard app shell and validation panel under construction.' },
+  ],
+}
+
+export function hasLiveActionPermission(dashboard = sampleDashboard) {
+  return Boolean(
+    dashboard?.risk?.liveTrading === true &&
+      dashboard?.risk?.killSwitch === 'CLEAR' &&
+      dashboard?.risk?.walletAuth === 'connected' &&
+      dashboard?.risk?.gates?.every((gate) => gate.state === 'passed'),
+  )
+}
+
+export function validationSummary(dashboard = sampleDashboard) {
+  const chain = dashboard?.stopLossTakeProfit?.chain ?? []
+  const verified = chain.filter((item) => item.state.includes('verified')).length
+  return {
+    issue: dashboard?.stopLossTakeProfit?.issue ?? 'unknown',
+    total: chain.length,
+    verified,
+    complete: chain.length > 0 && verified === chain.length,
+  }
+}
+
+export async function loadDashboard() {
+  try {
+    const response = await fetch('/api/crypto-ops/summary.json', { cache: 'no-store' })
+    if (!response.ok) return sampleDashboard
+    return await response.json()
+  } catch {
+    return sampleDashboard
+  }
+}

--- a/Arianus-Sky/projects/crypto-ops-dashboard/src/data/cryptoOps.js
+++ b/Arianus-Sky/projects/crypto-ops-dashboard/src/data/cryptoOps.js
@@ -149,6 +149,34 @@ export function composeDashboardFromApiPayloads(payloads = {}) {
   }
 }
 
+
+const validationResultFields = ['result', 'evidence', 'riskNotes', 'tester', 'screen', 'blockedReason']
+
+export function validationResultEndpoint(id) {
+  return `/api/crypto/validation/${encodeURIComponent(String(id).replace(/^#/, ''))}/result`
+}
+
+export async function submitValidationResult(id, result) {
+  const payload = Object.fromEntries(
+    validationResultFields
+      .filter((field) => result?.[field] !== undefined && result?.[field] !== '')
+      .map((field) => [field, result[field]]),
+  )
+
+  if (!payload.result || !payload.evidence) {
+    throw new Error('validation result and evidence are required')
+  }
+
+  const response = await fetch(validationResultEndpoint(id), {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(payload),
+  })
+  const body = await response.json().catch(() => ({}))
+  if (!response.ok) throw new Error(body.error ?? 'validation result failed')
+  return body
+}
+
 export async function loadDashboard() {
   try {
     const entries = await Promise.all(

--- a/Arianus-Sky/projects/crypto-ops-dashboard/src/main.js
+++ b/Arianus-Sky/projects/crypto-ops-dashboard/src/main.js
@@ -1,0 +1,5 @@
+import { createApp } from 'vue'
+import App from './App.vue'
+import './styles.css'
+
+createApp(App).mount('#app')

--- a/Arianus-Sky/projects/crypto-ops-dashboard/src/styles.css
+++ b/Arianus-Sky/projects/crypto-ops-dashboard/src/styles.css
@@ -8,11 +8,11 @@
 * { box-sizing: border-box; }
 body { margin: 0; min-width: 320px; background: radial-gradient(circle at top left, #1e3a8a55, transparent 34rem), #020617; }
 
-.shell { width: min(1180px, 100%); margin: 0 auto; padding: 16px; display: flex; flex-direction: column; gap: 16px; }
-.panel { background: rgba(15, 23, 42, 0.86); border: 1px solid rgba(148, 163, 184, 0.18); border-radius: 22px; box-shadow: 0 24px 80px rgba(0, 0, 0, 0.32); padding: 18px; }
-.hero { display: flex; justify-content: space-between; gap: 16px; align-items: stretch; }
+.shell { width: min(1440px, 100%); margin: 0 auto; padding: clamp(14px, 2vw, 28px); display: flex; flex-direction: column; gap: 16px; }
+.panel { background: rgba(15, 23, 42, 0.86); border: 1px solid rgba(148, 163, 184, 0.18); border-radius: 22px; box-shadow: 0 24px 80px rgba(0, 0, 0, 0.32); padding: clamp(16px, 1.7vw, 24px); }
+.hero { display: grid; grid-template-columns: minmax(0, 1fr) minmax(240px, 340px); gap: 16px; align-items: stretch; }
 h1, h2, h3, p { margin-top: 0; }
-h1 { margin-bottom: 8px; font-size: clamp(2rem, 8vw, 4.8rem); line-height: 0.9; letter-spacing: -0.07em; }
+h1 { margin-bottom: 8px; font-size: clamp(2rem, 7vw, 5.4rem); line-height: 0.9; letter-spacing: -0.07em; max-width: 11ch; }
 h2 { margin-bottom: 0; font-size: 1.08rem; }
 h3 { margin: 14px 0 8px; color: #94a3b8; font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.12em; }
 small, .subtle { color: #94a3b8; }
@@ -23,8 +23,15 @@ small, .subtle { color: #94a3b8; }
 .mode-card.safe { background: linear-gradient(135deg, #064e3b, #0f766e); }
 .mode-card.danger { background: linear-gradient(135deg, #7f1d1d, #be123c); }
 .grid { display: grid; gap: 16px; }
-.cards-4 { grid-template-columns: repeat(4, 1fr); }
-.two-col { grid-template-columns: repeat(2, 1fr); }
+.cards-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+.two-col { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.split-wide { grid-template-columns: repeat(12, minmax(0, 1fr)); }
+.span-5 { grid-column: span 5; }
+.span-6 { grid-column: span 6; }
+.span-7 { grid-column: span 7; }
+.quick-nav { position: sticky; top: 10px; z-index: 2; display: flex; gap: 8px; overflow-x: auto; padding: 10px; scrollbar-width: thin; }
+.quick-nav a { flex: 0 0 auto; border: 1px solid rgba(148, 163, 184, 0.18); border-radius: 999px; color: #bae6fd; font-size: 0.82rem; font-weight: 800; padding: 9px 12px; text-decoration: none; }
+.quick-nav a:hover { background: #0c4a6e88; }
 .metric { display: flex; flex-direction: column; gap: 8px; }
 .metric span, .section-title span { color: #94a3b8; font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.1em; }
 .metric strong { font-size: 1.55rem; }
@@ -49,13 +56,21 @@ small, .subtle { color: #94a3b8; }
 .validation-card { display: flex; flex-direction: column; gap: 8px; }
 .validation-card span { color: #34d399; font-weight: 800; }
 
+@media (max-width: 1100px) {
+  .cards-4 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .split-wide { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .span-5, .span-6, .span-7 { grid-column: span 1; }
+  .form-grid { grid-template-columns: repeat(2, 1fr); }
+}
+
 @media (max-width: 820px) {
-  .hero, .row-card, .section-title { flex-direction: column; }
-  .cards-4, .two-col, .validation-grid { grid-template-columns: 1fr; }
+  .hero, .row-card, .section-title { grid-template-columns: 1fr; flex-direction: column; }
+  .cards-4, .two-col, .split-wide, .validation-grid { grid-template-columns: 1fr; }
   .right { text-align: left; }
   .mode-card { min-width: 0; }
   .gate, .pool, .pill-row, .chain li { align-items: flex-start; flex-direction: column; }
   .form-grid { grid-template-columns: 1fr; }
+  .quick-nav { top: 0; margin-inline: -6px; border-radius: 0 0 18px 18px; }
 }
 
 .validation-form { margin-top: 16px; border-top: 1px solid rgba(148, 163, 184, 0.14); padding-top: 16px; display: flex; flex-direction: column; gap: 12px; }

--- a/Arianus-Sky/projects/crypto-ops-dashboard/src/styles.css
+++ b/Arianus-Sky/projects/crypto-ops-dashboard/src/styles.css
@@ -1,0 +1,58 @@
+:root {
+  color-scheme: dark;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: #020617;
+  color: #e2e8f0;
+}
+
+* { box-sizing: border-box; }
+body { margin: 0; min-width: 320px; background: radial-gradient(circle at top left, #1e3a8a55, transparent 34rem), #020617; }
+
+.shell { width: min(1180px, 100%); margin: 0 auto; padding: 16px; display: flex; flex-direction: column; gap: 16px; }
+.panel { background: rgba(15, 23, 42, 0.86); border: 1px solid rgba(148, 163, 184, 0.18); border-radius: 22px; box-shadow: 0 24px 80px rgba(0, 0, 0, 0.32); padding: 18px; }
+.hero { display: flex; justify-content: space-between; gap: 16px; align-items: stretch; }
+h1, h2, h3, p { margin-top: 0; }
+h1 { margin-bottom: 8px; font-size: clamp(2rem, 8vw, 4.8rem); line-height: 0.9; letter-spacing: -0.07em; }
+h2 { margin-bottom: 0; font-size: 1.08rem; }
+h3 { margin: 14px 0 8px; color: #94a3b8; font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.12em; }
+small, .subtle { color: #94a3b8; }
+.eyebrow { color: #38bdf8; text-transform: uppercase; letter-spacing: 0.18em; font-size: 0.76rem; font-weight: 800; }
+.mode-card { min-width: 220px; border-radius: 18px; padding: 18px; display: flex; flex-direction: column; justify-content: space-between; gap: 20px; }
+.mode-card span { color: #cbd5e1; text-transform: uppercase; letter-spacing: 0.16em; font-size: 0.72rem; }
+.mode-card strong { font-size: 1.25rem; }
+.mode-card.safe { background: linear-gradient(135deg, #064e3b, #0f766e); }
+.mode-card.danger { background: linear-gradient(135deg, #7f1d1d, #be123c); }
+.grid { display: grid; gap: 16px; }
+.cards-4 { grid-template-columns: repeat(4, 1fr); }
+.two-col { grid-template-columns: repeat(2, 1fr); }
+.metric { display: flex; flex-direction: column; gap: 8px; }
+.metric span, .section-title span { color: #94a3b8; font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.1em; }
+.metric strong { font-size: 1.55rem; }
+.good { color: #34d399; }
+.bad { color: #fb7185; }
+.section-title { display: flex; align-items: baseline; justify-content: space-between; gap: 12px; margin-bottom: 14px; }
+.list, .chain { display: flex; flex-direction: column; gap: 10px; padding: 0; margin: 0; }
+.row-card, .gate, .pool, .feed, .pill-row, .chain li, .validation-card { border: 1px solid rgba(148, 163, 184, 0.14); background: rgba(2, 6, 23, 0.42); border-radius: 16px; padding: 12px; }
+.row-card { display: flex; justify-content: space-between; gap: 12px; }
+.row-card small, .right { display: block; }
+.right { text-align: right; }
+.gate, .pool, .feed, .pill-row, .chain li { display: flex; justify-content: space-between; gap: 10px; align-items: center; margin-top: 8px; }
+.feed { justify-content: flex-start; }
+.feed time { color: #38bdf8; min-width: 76px; }
+.feed.warn { border-color: #f59e0b66; }
+.feed.safe { border-color: #34d39966; }
+.disabled-action { width: 100%; margin-top: 14px; border: 0; border-radius: 14px; padding: 13px; background: #334155; color: #cbd5e1; font-weight: 800; }
+.chain { list-style: none; counter-reset: chain; }
+.chain li::before { counter-increment: chain; content: counter(chain); display: grid; place-items: center; width: 28px; height: 28px; border-radius: 999px; background: #0ea5e9; color: #082f49; font-weight: 900; }
+.evidence { color: #bae6fd; background: #0c4a6e55; border-radius: 14px; padding: 12px; margin: 14px 0 0; }
+.validation-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 12px; }
+.validation-card { display: flex; flex-direction: column; gap: 8px; }
+.validation-card span { color: #34d399; font-weight: 800; }
+
+@media (max-width: 820px) {
+  .hero, .row-card, .section-title { flex-direction: column; }
+  .cards-4, .two-col, .validation-grid { grid-template-columns: 1fr; }
+  .right { text-align: left; }
+  .mode-card { min-width: 0; }
+  .gate, .pool, .pill-row, .chain li { align-items: flex-start; flex-direction: column; }
+}

--- a/Arianus-Sky/projects/crypto-ops-dashboard/src/styles.css
+++ b/Arianus-Sky/projects/crypto-ops-dashboard/src/styles.css
@@ -55,4 +55,18 @@ small, .subtle { color: #94a3b8; }
   .right { text-align: left; }
   .mode-card { min-width: 0; }
   .gate, .pool, .pill-row, .chain li { align-items: flex-start; flex-direction: column; }
+  .form-grid { grid-template-columns: 1fr; }
 }
+
+.validation-form { margin-top: 16px; border-top: 1px solid rgba(148, 163, 184, 0.14); padding-top: 16px; display: flex; flex-direction: column; gap: 12px; }
+.section-title.compact { margin-bottom: 0; }
+.form-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; }
+label { color: #94a3b8; display: flex; flex-direction: column; gap: 7px; font-size: 0.78rem; font-weight: 800; letter-spacing: 0.08em; text-transform: uppercase; }
+input, select, textarea { width: 100%; border: 1px solid rgba(148, 163, 184, 0.22); border-radius: 14px; background: rgba(2, 6, 23, 0.72); color: #e2e8f0; font: inherit; letter-spacing: 0; min-height: 42px; padding: 10px 12px; text-transform: none; }
+textarea { min-height: 88px; resize: vertical; }
+.evidence-action { align-self: flex-start; border: 0; border-radius: 14px; padding: 12px 16px; background: #0ea5e9; color: #082f49; font-weight: 900; }
+.evidence-action:disabled { opacity: 0.62; }
+.form-message { border-radius: 14px; margin: 0; padding: 12px; }
+.form-message.saved { background: #064e3b; color: #bbf7d0; }
+.form-message.error { background: #7f1d1d; color: #fecdd3; }
+

--- a/Arianus-Sky/projects/crypto-ops-dashboard/tests/validation.test.mjs
+++ b/Arianus-Sky/projects/crypto-ops-dashboard/tests/validation.test.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict'
-import { hasLiveActionPermission, sampleDashboard, validationSummary } from '../src/data/cryptoOps.js'
+import { composeDashboardFromApiPayloads, hasLiveActionPermission, sampleDashboard, validationSummary } from '../src/data/cryptoOps.js'
 
 assert.equal(hasLiveActionPermission(sampleDashboard), false, 'live actions must be disabled in sample safe mode')
 assert.equal(sampleDashboard.risk.liveTrading, false, 'sample dashboard must not imply live trading is active')
@@ -10,6 +10,22 @@ assert.equal(summary.issue, '#277')
 assert.equal(summary.total, 5)
 assert.equal(summary.verified, 5)
 assert.equal(summary.complete, true)
+
+
+const apiDashboard = composeDashboardFromApiPayloads({
+  health: { generatedAt: '2026-04-29T06:00:00Z', mode: 'read-only-fixture' },
+  portfolio: sampleDashboard.portfolio,
+  killSwitch: { state: 'ARMED', liveTrading: false, walletAuth: 'not-connected', gates: sampleDashboard.risk.gates },
+  positions: { positions: sampleDashboard.dlmmPositions },
+  monitor: sampleDashboard.stopLossTakeProfit,
+  sniperStatus: { status: 'dry-run', rejected: sampleDashboard.sniper.rejected },
+  sniperCandidates: { candidates: sampleDashboard.sniper.candidates },
+  topPools: { pools: sampleDashboard.topPools },
+  riskFeed: { events: sampleDashboard.killFeed },
+  validation: { records: sampleDashboard.prValidation },
+})
+assert.equal(apiDashboard.mode, 'read-only-fixture')
+assert.equal(hasLiveActionPermission(apiDashboard), false, 'API-composed dashboard must stay read-only by default')
 
 const liveCandidate = structuredClone(sampleDashboard)
 liveCandidate.risk.liveTrading = true

--- a/Arianus-Sky/projects/crypto-ops-dashboard/tests/validation.test.mjs
+++ b/Arianus-Sky/projects/crypto-ops-dashboard/tests/validation.test.mjs
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict'
+import { hasLiveActionPermission, sampleDashboard, validationSummary } from '../src/data/cryptoOps.js'
+
+assert.equal(hasLiveActionPermission(sampleDashboard), false, 'live actions must be disabled in sample safe mode')
+assert.equal(sampleDashboard.risk.liveTrading, false, 'sample dashboard must not imply live trading is active')
+assert.equal(sampleDashboard.dlmmPositions.every((position) => position.lastTx === 'none submitted'), true, 'safe sample positions must not claim submitted transactions')
+
+const summary = validationSummary(sampleDashboard)
+assert.equal(summary.issue, '#277')
+assert.equal(summary.total, 5)
+assert.equal(summary.verified, 5)
+assert.equal(summary.complete, true)
+
+const liveCandidate = structuredClone(sampleDashboard)
+liveCandidate.risk.liveTrading = true
+liveCandidate.risk.killSwitch = 'CLEAR'
+liveCandidate.risk.walletAuth = 'connected'
+liveCandidate.risk.gates = liveCandidate.risk.gates.map((gate) => ({ ...gate, state: 'passed' }))
+assert.equal(hasLiveActionPermission(liveCandidate), true, 'all live gates must be explicit before action permission')
+
+console.log('validation dashboard gates passed')

--- a/Arianus-Sky/projects/crypto-ops-dashboard/tests/validation.test.mjs
+++ b/Arianus-Sky/projects/crypto-ops-dashboard/tests/validation.test.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict'
-import { composeDashboardFromApiPayloads, hasLiveActionPermission, sampleDashboard, validationSummary } from '../src/data/cryptoOps.js'
+import { composeDashboardFromApiPayloads, hasLiveActionPermission, sampleDashboard, submitValidationResult, validationResultEndpoint, validationSummary } from '../src/data/cryptoOps.js'
 
 assert.equal(hasLiveActionPermission(sampleDashboard), false, 'live actions must be disabled in sample safe mode')
 assert.equal(sampleDashboard.risk.liveTrading, false, 'sample dashboard must not imply live trading is active')
@@ -26,6 +26,30 @@ const apiDashboard = composeDashboardFromApiPayloads({
 })
 assert.equal(apiDashboard.mode, 'read-only-fixture')
 assert.equal(hasLiveActionPermission(apiDashboard), false, 'API-composed dashboard must stay read-only by default')
+
+
+assert.equal(validationResultEndpoint('#296'), '/api/crypto/validation/296/result')
+
+const originalFetch = globalThis.fetch
+globalThis.fetch = async (path, options) => {
+  assert.equal(path, '/api/crypto/validation/296/result')
+  assert.equal(options.method, 'POST')
+  const payload = JSON.parse(options.body)
+  assert.deepEqual(Object.keys(payload).sort(), ['evidence', 'result', 'tester'])
+  assert.equal(payload.result, 'blocked')
+  assert.equal(payload.evidence, 'needs runtime screenshot')
+  return { ok: true, json: async () => ({ ok: true, record: { id: '296', liveExecution: 'disabled' } }) }
+}
+const validationPost = await submitValidationResult('#296', {
+  result: 'blocked',
+  evidence: 'needs runtime screenshot',
+  tester: 'Haplo',
+  trade: 'must not pass through',
+})
+assert.equal(validationPost.record.liveExecution, 'disabled')
+globalThis.fetch = originalFetch
+
+await assert.rejects(() => submitValidationResult('#296', { result: 'passed' }), /evidence/)
 
 const liveCandidate = structuredClone(sampleDashboard)
 liveCandidate.risk.liveTrading = true

--- a/Arianus-Sky/projects/crypto-ops-dashboard/vite.config.js
+++ b/Arianus-Sky/projects/crypto-ops-dashboard/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite'
+import vue from '@vitejs/plugin-vue'
+
+export default defineConfig({
+  plugins: [vue()],
+})

--- a/Arianus-Sky/projects/crypto-ops-dashboard/vite.config.js
+++ b/Arianus-Sky/projects/crypto-ops-dashboard/vite.config.js
@@ -3,4 +3,10 @@ import vue from '@vitejs/plugin-vue'
 
 export default defineConfig({
   plugins: [vue()],
+  server: {
+    proxy: {
+      '/api/crypto': 'http://127.0.0.1:8787',
+      '/api/crypto-ops': 'http://127.0.0.1:8787',
+    },
+  },
 })

--- a/Pryan-Fire/haplos-workshop/crypto-ops-api/README.md
+++ b/Pryan-Fire/haplos-workshop/crypto-ops-api/README.md
@@ -1,0 +1,43 @@
+# Crypto Ops API Facade
+
+Read-only Pryan-Fire API facade for The-Nexus #296.
+
+V1 is fixture-backed and safe by construction:
+
+- no wallet imports
+- no executor imports
+- no live-money endpoints
+- no transaction submission fields accepted by validation writes
+
+## Run
+
+```bash
+cd Pryan-Fire/haplos-workshop/crypto-ops-api
+python -m crypto_ops_api.facade --host 127.0.0.1 --port 8787
+```
+
+## Endpoints
+
+- `GET /api/crypto/health`
+- `GET /api/crypto/portfolio`
+- `GET /api/crypto/positions/dlmm`
+- `GET /api/crypto/positions/monitor`
+- `GET /api/crypto/close/state`
+- `GET /api/crypto/sniper/status`
+- `GET /api/crypto/sniper/candidates`
+- `GET /api/crypto/pools/top`
+- `GET /api/crypto/risk/feed`
+- `GET /api/crypto/kill-switch`
+- `GET /api/crypto/validation/prs`
+- `POST /api/crypto/validation/:id/result`
+- `GET /api/crypto-ops/summary.json` legacy aggregated payload for the dashboard shell
+
+Validation POST accepts evidence only: `result`, `evidence`, `riskNotes`, `tester`, `screen`, `blockedReason`.
+It rejects trading/action fields such as `trade`, `tx`, `submitTx`, `amount`, or wallet actions.
+
+## Test
+
+```bash
+cd Pryan-Fire/haplos-workshop/crypto-ops-api
+PYTHONPATH=. python -m unittest discover -s tests
+```

--- a/Pryan-Fire/haplos-workshop/crypto-ops-api/crypto_ops_api/__init__.py
+++ b/Pryan-Fire/haplos-workshop/crypto-ops-api/crypto_ops_api/__init__.py
@@ -1,0 +1,5 @@
+"""Read-only Pryan-Fire crypto ops API facade."""
+
+from .facade import build_app_payloads, create_handler, run
+
+__all__ = ["build_app_payloads", "create_handler", "run"]

--- a/Pryan-Fire/haplos-workshop/crypto-ops-api/crypto_ops_api/facade.py
+++ b/Pryan-Fire/haplos-workshop/crypto-ops-api/crypto_ops_api/facade.py
@@ -1,0 +1,174 @@
+"""Stdlib HTTP facade for read-only Pryan-Fire crypto ops state."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Callable
+from urllib.parse import urlparse
+
+from .fixture_data import fixture_summary, utc_now
+
+MAX_POST_BYTES = 32 * 1024
+DEFAULT_RESULTS_PATH = "/data/openclaw/crypto-ops/validation-results.jsonl"
+VALIDATION_FIELDS = {"result", "evidence", "riskNotes", "tester", "screen", "blockedReason"}
+FORBIDDEN_VALIDATION_FIELDS = {
+    "amount",
+    "execute",
+    "liveTrading",
+    "order",
+    "privateKey",
+    "secret",
+    "submitTx",
+    "trade",
+    "tx",
+    "walletAction",
+}
+
+
+def build_app_payloads() -> dict[str, dict | list]:
+    """Return API-contract payloads from safe fixture data.
+
+    This is the adapter seam for later real read-only integrations. It intentionally
+    imports no executor, wallet, or transaction code.
+    """
+
+    summary = fixture_summary()
+    risk = summary["risk"]
+    return {
+        "/api/crypto/health": {
+            "ok": True,
+            "mode": summary["mode"],
+            "source": "fixture",
+            "generatedAt": summary["generatedAt"],
+            "liveExecution": "disabled",
+        },
+        "/api/crypto/portfolio": summary["portfolio"] | {"generatedAt": summary["generatedAt"], "source": "fixture"},
+        "/api/crypto/positions/dlmm": {"positions": summary["dlmmPositions"], "source": "fixture"},
+        "/api/crypto/positions/monitor": summary["stopLossTakeProfit"] | {"source": "fixture"},
+        "/api/crypto/close/state": {
+            "mode": "read-only",
+            "txStatus": "none submitted",
+            "chain": summary["stopLossTakeProfit"]["chain"],
+            "source": "fixture",
+        },
+        "/api/crypto/sniper/status": {
+            "status": summary["sniper"]["status"],
+            "rejected": summary["sniper"]["rejected"],
+            "source": "fixture",
+        },
+        "/api/crypto/sniper/candidates": {"candidates": summary["sniper"]["candidates"], "source": "fixture"},
+        "/api/crypto/pools/top": {"pools": summary["topPools"], "source": "fixture"},
+        "/api/crypto/risk/feed": {"events": summary["killFeed"], "source": "fixture"},
+        "/api/crypto/kill-switch": {
+            "state": risk["killSwitch"],
+            "liveTrading": risk["liveTrading"],
+            "walletAuth": risk["walletAuth"],
+            "gates": risk["gates"],
+            "source": "fixture",
+        },
+        "/api/crypto/validation/prs": {"records": summary["prValidation"], "source": "fixture"},
+        "/api/crypto-ops/summary.json": summary | {"source": "fixture"},
+    }
+
+
+def persist_validation_result(validation_id: str, payload: dict, path: str = DEFAULT_RESULTS_PATH) -> dict:
+    keys = set(payload)
+    forbidden = sorted(keys & FORBIDDEN_VALIDATION_FIELDS)
+    unknown = sorted(keys - VALIDATION_FIELDS)
+    if forbidden:
+        raise ValueError(f"validation result cannot include trading fields: {', '.join(forbidden)}")
+    if unknown:
+        raise ValueError(f"unsupported validation fields: {', '.join(unknown)}")
+
+    record = {
+        "id": validation_id,
+        "recordedAt": utc_now(),
+        "kind": "validation-result",
+        "liveExecution": "disabled",
+        **payload,
+    }
+    output = Path(path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with output.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(record, sort_keys=True) + "\n")
+    return record
+
+
+def create_handler(results_path: str = DEFAULT_RESULTS_PATH) -> type[BaseHTTPRequestHandler]:
+    payloads_factory: Callable[[], dict[str, dict | list]] = build_app_payloads
+
+    class CryptoOpsHandler(BaseHTTPRequestHandler):
+        server_version = "CryptoOpsFacade/0.1"
+
+        def log_message(self, format: str, *args) -> None:  # noqa: A002 - stdlib signature
+            if os.environ.get("CRYPTO_OPS_API_LOG") == "1":
+                super().log_message(format, *args)
+
+        def _json(self, status: HTTPStatus, payload: dict | list) -> None:
+            body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+            self.send_response(status.value)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Cache-Control", "no-store")
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def do_GET(self) -> None:  # noqa: N802 - stdlib method name
+            path = urlparse(self.path).path.rstrip("/") or "/"
+            payloads = payloads_factory()
+            if path in payloads:
+                self._json(HTTPStatus.OK, payloads[path])
+                return
+            self._json(HTTPStatus.NOT_FOUND, {"ok": False, "error": "unknown endpoint"})
+
+        def do_POST(self) -> None:  # noqa: N802 - stdlib method name
+            path = urlparse(self.path).path.rstrip("/")
+            prefix = "/api/crypto/validation/"
+            suffix = "/result"
+            if not (path.startswith(prefix) and path.endswith(suffix)):
+                self._json(HTTPStatus.NOT_FOUND, {"ok": False, "error": "unknown endpoint"})
+                return
+
+            length = int(self.headers.get("Content-Length", "0") or "0")
+            if length <= 0 or length > MAX_POST_BYTES:
+                self._json(HTTPStatus.BAD_REQUEST, {"ok": False, "error": "invalid payload size"})
+                return
+
+            try:
+                payload = json.loads(self.rfile.read(length).decode("utf-8"))
+                if not isinstance(payload, dict):
+                    raise ValueError("payload must be an object")
+                validation_id = path[len(prefix) : -len(suffix)]
+                record = persist_validation_result(validation_id, payload, results_path)
+            except (json.JSONDecodeError, ValueError) as exc:
+                self._json(HTTPStatus.BAD_REQUEST, {"ok": False, "error": str(exc)})
+                return
+
+            self._json(HTTPStatus.CREATED, {"ok": True, "record": record})
+
+    return CryptoOpsHandler
+
+
+def run(host: str = "127.0.0.1", port: int = 8787, results_path: str = DEFAULT_RESULTS_PATH) -> None:
+    server = ThreadingHTTPServer((host, port), create_handler(results_path))
+    print(f"crypto ops read-only facade listening on http://{host}:{port}")
+    server.serve_forever()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run the read-only Pryan-Fire crypto ops API facade")
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8787)
+    parser.add_argument("--results-path", default=DEFAULT_RESULTS_PATH)
+    args = parser.parse_args()
+    run(args.host, args.port, args.results_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/Pryan-Fire/haplos-workshop/crypto-ops-api/crypto_ops_api/facade.py
+++ b/Pryan-Fire/haplos-workshop/crypto-ops-api/crypto_ops_api/facade.py
@@ -119,6 +119,13 @@ def create_handler(results_path: str = DEFAULT_RESULTS_PATH) -> type[BaseHTTPReq
             self.end_headers()
             self.wfile.write(body)
 
+        def do_OPTIONS(self) -> None:  # noqa: N802 - stdlib method name
+            self.send_response(HTTPStatus.NO_CONTENT.value)
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+            self.send_header("Access-Control-Allow-Headers", "content-type")
+            self.end_headers()
+
         def do_GET(self) -> None:  # noqa: N802 - stdlib method name
             path = urlparse(self.path).path.rstrip("/") or "/"
             payloads = payloads_factory()

--- a/Pryan-Fire/haplos-workshop/crypto-ops-api/crypto_ops_api/fixture_data.py
+++ b/Pryan-Fire/haplos-workshop/crypto-ops-api/crypto_ops_api/fixture_data.py
@@ -1,0 +1,102 @@
+"""Safe fixture-backed data for the crypto ops API facade.
+
+No live-money connectors are imported here. V1 is explicitly read-only and dry-run.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+VALIDATION_CHAIN = [
+    "monitor",
+    "trigger",
+    "close executor",
+    "alert",
+    "state persistence",
+]
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def fixture_summary() -> dict:
+    generated_at = utc_now()
+    return {
+        "generatedAt": generated_at,
+        "mode": "read-only-fixture",
+        "portfolio": {
+            "wallet": "Hugh runtime wallet",
+            "equityUsd": 12840.55,
+            "pnl24hUsd": 316.42,
+            "pnl24hPct": 2.53,
+            "openExposureUsd": 4210.18,
+            "riskPosture": "SAFE_TEST_ONLY",
+        },
+        "risk": {
+            "killSwitch": "ARMED",
+            "liveTrading": False,
+            "walletAuth": "not-connected",
+            "gates": [
+                {"name": "Hugh validation", "state": "passed-safe-mode"},
+                {"name": "Live executor", "state": "disabled"},
+                {"name": "Wallet authorization", "state": "blocked"},
+                {"name": "Kill switch visibility", "state": "visible"},
+            ],
+        },
+        "dlmmPositions": [
+            {
+                "id": "dlmm-001",
+                "pair": "SOL/USDC",
+                "poolId": "pool-sol-usdc-demo",
+                "liquidityUsd": 2480.12,
+                "feesUsd": 41.82,
+                "pnlUsd": 128.34,
+                "state": "open",
+                "closeState": "dry-run-ready",
+                "lastTx": "none submitted",
+            },
+            {
+                "id": "dlmm-002",
+                "pair": "BONK/SOL",
+                "poolId": "pool-bonk-sol-demo",
+                "liquidityUsd": 1730.06,
+                "feesUsd": 18.94,
+                "pnlUsd": -22.7,
+                "state": "watching",
+                "closeState": "risk-gated",
+                "lastTx": "none submitted",
+            },
+        ],
+        "stopLossTakeProfit": {
+            "issue": "#277",
+            "status": "safe-mode-passed",
+            "chain": [{"step": step, "state": "verified-safe-mode"} for step in VALIDATION_CHAIN],
+            "latestEvidence": "Hugh validated PR #295 in clean runtime checkout; 17 regression tests passed.",
+        },
+        "sniper": {
+            "status": "dry-run",
+            "candidates": [
+                {"symbol": "DEMO1/SOL", "score": 82, "reason": "liquidity rising; dry-run only"},
+                {"symbol": "DEMO2/USDC", "score": 74, "reason": "fee velocity; blocked until risk gates pass"},
+            ],
+            "rejected": [
+                {"symbol": "RUG/SOL", "reason": "authority risk"},
+                {"symbol": "THIN/USDC", "reason": "liquidity below threshold"},
+            ],
+        },
+        "topPools": [
+            {"rank": 1, "pair": "SOL/USDC", "liquidityUsd": 12200000, "volume24hUsd": 8400000, "fees24hUsd": 18200, "risk": "low"},
+            {"rank": 2, "pair": "JUP/SOL", "liquidityUsd": 4100000, "volume24hUsd": 2600000, "fees24hUsd": 7400, "risk": "medium"},
+            {"rank": 3, "pair": "BONK/SOL", "liquidityUsd": 2200000, "volume24hUsd": 1900000, "fees24hUsd": 6100, "risk": "medium"},
+        ],
+        "killFeed": [
+            {"time": "00:17 CDT", "severity": "info", "message": "#295 safe-mode validation passed; no live tx submitted."},
+            {"time": "00:13 CDT", "severity": "warn", "message": "Remote pytest unavailable on Hugh until pytest is installed."},
+            {"time": "00:11 CDT", "severity": "safe", "message": "Live-money automation remains disabled."},
+        ],
+        "prValidation": [
+            {"pr": "#295", "issue": "#277", "result": "passed-safe-mode", "evidence": "17 tests passed; fake executor success/failure persisted."},
+            {"pr": "#296", "issue": "#296", "result": "pending", "evidence": "Read-only dashboard and API facade under construction."},
+        ],
+    }

--- a/Pryan-Fire/haplos-workshop/crypto-ops-api/tests/test_facade.py
+++ b/Pryan-Fire/haplos-workshop/crypto-ops-api/tests/test_facade.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from crypto_ops_api.facade import build_app_payloads, persist_validation_result
+
+
+class CryptoOpsFacadeTest(unittest.TestCase):
+    def test_required_read_only_endpoints_exist(self) -> None:
+        payloads = build_app_payloads()
+        required = {
+            "/api/crypto/health",
+            "/api/crypto/portfolio",
+            "/api/crypto/positions/dlmm",
+            "/api/crypto/positions/monitor",
+            "/api/crypto/close/state",
+            "/api/crypto/sniper/status",
+            "/api/crypto/sniper/candidates",
+            "/api/crypto/pools/top",
+            "/api/crypto/risk/feed",
+            "/api/crypto/kill-switch",
+            "/api/crypto/validation/prs",
+            "/api/crypto-ops/summary.json",
+        }
+        self.assertTrue(required.issubset(payloads))
+        self.assertEqual(payloads["/api/crypto/health"]["liveExecution"], "disabled")
+        self.assertFalse(payloads["/api/crypto/kill-switch"]["liveTrading"])
+
+    def test_fixture_never_claims_submitted_transactions(self) -> None:
+        payloads = build_app_payloads()
+        positions = payloads["/api/crypto/positions/dlmm"]["positions"]
+        self.assertTrue(all(position["lastTx"] == "none submitted" for position in positions))
+        close_state = payloads["/api/crypto/close/state"]
+        self.assertEqual(close_state["txStatus"], "none submitted")
+
+    def test_validation_result_persistence_allows_evidence_only(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = str(Path(tmp) / "validation.jsonl")
+            record = persist_validation_result(
+                "296",
+                {"result": "passed", "evidence": "screen reviewed", "tester": "Hugh"},
+                path,
+            )
+            self.assertEqual(record["liveExecution"], "disabled")
+            saved = json.loads(Path(path).read_text(encoding="utf-8"))
+            self.assertEqual(saved["id"], "296")
+
+    def test_validation_result_rejects_trading_fields(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = str(Path(tmp) / "validation.jsonl")
+            with self.assertRaises(ValueError):
+                persist_validation_result("296", {"result": "passed", "trade": "SOL/USDC"}, path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds a mobile-first Vue/PWA dashboard shell under `Arianus-Sky/projects/crypto-ops-dashboard` for issue #296.
- Surfaces portfolio, DLMM positions, #277 SLTP chain evidence, sniper candidates/rejections, top pools, kill feed, risk gates, and Hugh PR validation.
- Keeps all trading controls read-only/dry-run by default; live actions require explicit risk gates, wallet auth, and kill-switch clear state.

## Dependency note
- Adds Vue + Vite only for the requested Vue.js PWA app scaffold.

## Validation
```bash
cd Arianus-Sky/projects/crypto-ops-dashboard
npm run test:validation
npm run build
```

Both passed locally.

Refs #296.