### PR TITLE
fix: require risk approval for live DLMM closes

### DIFF
--- a/Pryan-Fire/hughs-forge/scripts/automation_engine.py
+++ b/Pryan-Fire/hughs-forge/scripts/automation_engine.py
@@ -34,6 +34,158 @@ MAX_EXECUTE_RETRIES = 3
 BACKOFF_MULTIPLIER = 2.0
 MAX_ALERT_INTERVAL = 3600
 COOLDOWN_DURATION_SECONDS = 7200
+DEFAULT_KILL_SWITCH_FILE = "/data/openclaw/trade_stop.lock"
+
+
+def _utcnow() -> datetime:
+    return datetime.utcnow()
+
+
+def _parse_utc(value: Any) -> Optional[datetime]:
+    if not value or not isinstance(value, str):
+        return None
+    try:
+        return datetime.fromisoformat(value.rstrip("Z"))
+    except (TypeError, ValueError):
+        return None
+
+
+def _approval_scope(wallet_name: str, trigger: Dict[str, Any]) -> Dict[str, str]:
+    pos = trigger.get("position", {})
+    return {
+        "action": "dlmm_close",
+        "wallet_name": wallet_name,
+        "position": pos.get("position", ""),
+        "pool": pos.get("pool") or pos.get("lb_pair", ""),
+        "trigger_type": trigger.get("trigger_type", ""),
+    }
+
+
+def _risk_approval_id(wallet_name: str, trigger: Dict[str, Any]) -> str:
+    scope = _approval_scope(wallet_name, trigger)
+    return ":".join([
+        scope["action"],
+        scope["wallet_name"],
+        scope["position"],
+        scope["pool"],
+        scope["trigger_type"],
+    ])
+
+
+def _get_risk_approval_record(wallet_name: str, approval_id: str, state: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    if not state:
+        return None
+    approvals = state.get("risk_approvals", {})
+    if approval_id in approvals:
+        return approvals[approval_id]
+    wallet_approvals = state.get("automation", {}).get(wallet_name, {}).get("risk_approvals", {})
+    return wallet_approvals.get(approval_id)
+
+
+def _check_live_risk_approval(
+    wallet_name: str,
+    trigger: Dict[str, Any],
+    config: Dict[str, Any],
+    state: Optional[Dict[str, Any]],
+) -> Dict[str, Any]:
+    """Fail-closed live-money approval gate for DLMM closes.
+
+    Dry runs are always allowed. Live closes require an explicit, scoped,
+    unexpired approval record written by the risk/approval layer. This keeps
+    legacy mock RiskManager behavior from silently authorizing real money.
+    """
+    execution = config.get("execution", {})
+    dry_run = execution.get("dry_run", AUTOMATION_DRY_RUN)
+    approval_id = _risk_approval_id(wallet_name, trigger)
+
+    if dry_run:
+        return {
+            "approved": True,
+            "approval_id": approval_id,
+            "state": "dry_run",
+            "source": "dry_run",
+            "approved_by": "not_required",
+        }
+
+    kill_switch_file = execution.get("kill_switch_file", DEFAULT_KILL_SWITCH_FILE)
+    if kill_switch_file and Path(kill_switch_file).exists():
+        return {
+            "approved": False,
+            "approval_id": approval_id,
+            "state": "denied",
+            "source": "kill_switch",
+            "reason": "kill_switch_active",
+        }
+
+    record = _get_risk_approval_record(wallet_name, approval_id, state)
+    if not record:
+        return {
+            "approved": False,
+            "approval_id": approval_id,
+            "state": "missing",
+            "source": "none",
+            "reason": "risk_approval_required",
+        }
+
+    source = str(record.get("source") or record.get("approval_source") or "unknown")
+    status = str(record.get("status") or record.get("state") or "").lower()
+    if status != "approved":
+        return {
+            "approved": False,
+            "approval_id": approval_id,
+            "state": status or "not_approved",
+            "source": source,
+            "reason": "risk_approval_not_approved",
+        }
+
+    approved_by = record.get("approved_by") or record.get("operator")
+    approved_by_id = record.get("approved_by_id") or record.get("operator_id")
+    auth_method = record.get("auth_method") or record.get("authentication")
+    if not approved_by or not approved_by_id or not auth_method:
+        return {
+            "approved": False,
+            "approval_id": approval_id,
+            "state": "unauthenticated",
+            "source": source,
+            "reason": "risk_approval_unauthenticated",
+        }
+
+    expires_at = _parse_utc(record.get("expires_at"))
+    if not expires_at or expires_at <= _utcnow():
+        return {
+            "approved": False,
+            "approval_id": approval_id,
+            "state": "expired",
+            "source": source,
+            "approved_by": approved_by,
+            "reason": "risk_approval_expired",
+        }
+
+    expected_scope = _approval_scope(wallet_name, trigger)
+    record_scope = record.get("scope", {})
+    for key, expected_value in expected_scope.items():
+        if str(record_scope.get(key, "")) != str(expected_value):
+            return {
+                "approved": False,
+                "approval_id": approval_id,
+                "state": "scope_mismatch",
+                "source": source,
+                "approved_by": approved_by,
+                "reason": "risk_approval_scope_mismatch",
+                "scope_key": key,
+            }
+
+    return {
+        "approved": True,
+        "approval_id": approval_id,
+        "state": "approved",
+        "source": source,
+        "approved_by": approved_by,
+        "approved_by_id": str(approved_by_id),
+        "auth_method": str(auth_method),
+        "expires_at": record.get("expires_at"),
+    }
+
 
 
 def _position_fee_value(pos: Dict[str, Any]) -> float:
@@ -262,7 +414,7 @@ def handle_alert_owner(wallet_name: str, trigger: Dict, config: Dict, state: Dic
         alert["execute_attempts"] = execute_attempts + 1
         alert["last_alert_at"] = datetime.utcnow().isoformat() + "Z"
         
-        success = execute_position_close(wallet_name, trigger, config)
+        success = execute_position_close(wallet_name, trigger, config, state)
         execution_result = trigger.get("_execution_result", {})
         
         if success:
@@ -345,7 +497,7 @@ def handle_auto_execute(wallet_name: str, trigger: Dict, config: Dict, state: Di
     
     tracker["attempts"] = attempt_num
     tracker["last_attempt_at"] = datetime.utcnow().isoformat() + "Z"
-    success = execute_position_close(wallet_name, trigger, config)
+    success = execute_position_close(wallet_name, trigger, config, state)
     execution_result = trigger.get("_execution_result", {})
     if success:
         automation_state.setdefault("executions", {})[pubkey] = {
@@ -444,7 +596,7 @@ def _run_dlmm_close_command(wallet_name: str, trigger: Dict, config: Dict, pool_
     return result
 
 
-def execute_position_close(wallet_name: str, trigger: Dict, config: Dict) -> bool:
+def execute_position_close(wallet_name: str, trigger: Dict, config: Dict, state: Optional[Dict[str, Any]] = None) -> bool:
     """
     Full execution flow:
     1. Claim unclaimed fees
@@ -472,13 +624,22 @@ def execute_position_close(wallet_name: str, trigger: Dict, config: Dict) -> boo
     
     if dry_run:
         logger.info(f"DRY RUN: Would close position {pubkey}, claim fees, swap tokens to USDC")
-        _set_execution_result(trigger, success=True, dry_run=True, signatures=[])
+        approval = _check_live_risk_approval(wallet_name, trigger, config, state)
+        _set_execution_result(trigger, success=True, dry_run=True, signatures=[], approval=approval)
         _post_execution_notification(wallet_name, trigger, dry_run=True)
         return True
 
+    approval = _check_live_risk_approval(wallet_name, trigger, config, state)
+    if not approval.get("approved"):
+        reason = approval.get("reason", "risk_approval_required")
+        logger.error(f"Live DLMM close denied for {pubkey}: {reason} ({approval.get('state')} via {approval.get('source')})")
+        _set_execution_result(trigger, success=False, dry_run=False, error=reason, signatures=[], approval=approval)
+        _post_execution_notification(wallet_name, trigger, dry_run=False, success=False, error=reason)
+        return False
+
     if not pool_pubkey:
         logger.error(f"Cannot close DLMM position {pubkey}: missing pool/lb_pair")
-        _set_execution_result(trigger, success=False, dry_run=False, error="missing_pool", signatures=[])
+        _set_execution_result(trigger, success=False, dry_run=False, error="missing_pool", signatures=[], approval=approval)
         _post_execution_notification(wallet_name, trigger, dry_run=False, success=False, error="missing_pool")
         return False
     
@@ -497,6 +658,7 @@ def execute_position_close(wallet_name: str, trigger: Dict, config: Dict) -> boo
                 error=error,
                 signatures=close_result.get("signatures", []),
                 raw_result=close_result,
+                approval=approval,
             )
             _post_execution_notification(wallet_name, trigger, dry_run=False, success=False, error=error)
             return False
@@ -507,13 +669,13 @@ def execute_position_close(wallet_name: str, trigger: Dict, config: Dict) -> boo
         if execution.get("swap_after_close", False):
             logger.warning("swap_after_close is configured but not implemented in automation_engine; DLMM close succeeded, swap skipped")
 
-        _set_execution_result(trigger, success=True, dry_run=False, signatures=signatures, raw_result=close_result)
+        _set_execution_result(trigger, success=True, dry_run=False, signatures=signatures, raw_result=close_result, approval=approval)
         _post_execution_notification(wallet_name, trigger, dry_run=False, success=True, signatures=signatures)
         return True
         
     except Exception as e:
         logger.error(f"Execution error: {e}")
-        _set_execution_result(trigger, success=False, dry_run=False, error=str(e), signatures=[])
+        _set_execution_result(trigger, success=False, dry_run=False, error=str(e), signatures=[], approval=approval)
         _post_execution_notification(wallet_name, trigger, dry_run=False, success=False, error=str(e))
         return False
 
@@ -633,6 +795,15 @@ def _post_execution_notification(
     )
     if error:
         content += f"\n**Error**: `{error}`"
+    execution_result = trigger.get("_execution_result", {})
+    approval = execution_result.get("approval") or {}
+    if approval:
+        approval_source = approval.get("source", "unknown")
+        approval_state = approval.get("state", "unknown")
+        approved_by = approval.get("approved_by")
+        content += f"\n**Approval**: `{approval_source}` / `{approval_state}`"
+        if approved_by and approved_by != "not_required":
+            content += f" by `{approved_by}`"
     if not dry_run and not success:
         content += "\n**Tx**: none submitted"
     if signatures:

--- a/Pryan-Fire/hughs-forge/scripts/automation_engine.py
+++ b/Pryan-Fire/hughs-forge/scripts/automation_engine.py
@@ -9,7 +9,7 @@ import os
 import logging
 import subprocess
 import shlex
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict, Any, List, Optional
 
@@ -45,9 +45,12 @@ def _parse_utc(value: Any) -> Optional[datetime]:
     if not value or not isinstance(value, str):
         return None
     try:
-        return datetime.fromisoformat(value.rstrip("Z"))
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
     except (TypeError, ValueError):
         return None
+    if parsed.tzinfo is not None:
+        return parsed.astimezone(timezone.utc).replace(tzinfo=None)
+    return parsed
 
 
 def _approval_scope(wallet_name: str, trigger: Dict[str, Any]) -> Dict[str, str]:

--- a/Pryan-Fire/hughs-forge/scripts/automation_engine.py
+++ b/Pryan-Fire/hughs-forge/scripts/automation_engine.py
@@ -166,6 +166,16 @@ def _check_live_risk_approval(
 
     expected_scope = _approval_scope(wallet_name, trigger)
     record_scope = record.get("scope", {})
+    if not isinstance(record_scope, dict):
+        return {
+            "approved": False,
+            "approval_id": approval_id,
+            "state": "scope_mismatch",
+            "source": source,
+            "approved_by": approved_by,
+            "reason": "risk_approval_scope_mismatch",
+            "scope_key": "scope",
+        }
     for key, expected_value in expected_scope.items():
         if str(record_scope.get(key, "")) != str(expected_value):
             return {

--- a/Pryan-Fire/hughs-forge/scripts/test_automation_engine.py
+++ b/Pryan-Fire/hughs-forge/scripts/test_automation_engine.py
@@ -2,7 +2,7 @@
 """Tests for automation_engine.py - SL/TP automation and close boundaries."""
 import os
 import sys
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 sys.path.insert(0, os.path.dirname(__file__))
 
@@ -14,7 +14,7 @@ def _live_config(tmp_path):
     return {"execution": {"dry_run": False, "kill_switch_file": str(tmp_path / "trade_stop.lock")}}
 
 
-def _approval_state(wallet_name, trigger, *, expires_delta=300, status="approved", authenticated=True, scope_override=None):
+def _approval_state(wallet_name, trigger, *, expires_delta=300, expires_at=None, status="approved", authenticated=True, scope_override=None):
     approval_id = automation_engine._risk_approval_id(wallet_name, trigger)
     scope = automation_engine._approval_scope(wallet_name, trigger)
     if scope_override:
@@ -26,7 +26,7 @@ def _approval_state(wallet_name, trigger, *, expires_delta=300, status="approved
         "approved_by_id": "316308517520801793",
         "auth_method": "discord_operator",
         "approved_at": datetime.utcnow().isoformat() + "Z",
-        "expires_at": (datetime.utcnow() + timedelta(seconds=expires_delta)).isoformat() + "Z",
+        "expires_at": expires_at or (datetime.utcnow() + timedelta(seconds=expires_delta)).isoformat() + "Z",
         "scope": scope,
     }
     if not authenticated:
@@ -115,6 +115,53 @@ def test_execute_position_close_live_rejects_expired_approval(monkeypatch, tmp_p
     state = _approval_state("bot", trigger, expires_delta=-1)
     assert execute_position_close("bot", trigger, _live_config(tmp_path), state) is False
     assert trigger["_execution_result"]["error"] == "risk_approval_expired"
+
+
+def test_execute_position_close_live_accepts_timezone_aware_approval(monkeypatch, tmp_path):
+    monkeypatch.setattr(automation_engine, "DISCORD_WEBHOOK_ALERTS", None)
+    monkeypatch.setattr(automation_engine, "_run_dlmm_close_command", lambda *_: {"success": True})
+    trigger = {
+        "trigger_type": "stop_loss",
+        "pnl_pct": -12.0,
+        "position": {"position": "pos123", "lb_pair": "pool123", "pool_name": "SOL-USDC"},
+    }
+    expires_at = (datetime.now(timezone.utc) + timedelta(minutes=5)).isoformat()
+    state = _approval_state("bot", trigger, expires_at=expires_at)
+
+    assert execute_position_close("bot", trigger, _live_config(tmp_path), state) is True
+    assert trigger["_execution_result"]["approval"]["state"] == "approved"
+
+
+def test_execute_position_close_live_accepts_zulu_approval(monkeypatch, tmp_path):
+    monkeypatch.setattr(automation_engine, "DISCORD_WEBHOOK_ALERTS", None)
+    monkeypatch.setattr(automation_engine, "_run_dlmm_close_command", lambda *_: {"success": True})
+    trigger = {
+        "trigger_type": "stop_loss",
+        "pnl_pct": -12.0,
+        "position": {"position": "pos123", "lb_pair": "pool123", "pool_name": "SOL-USDC"},
+    }
+    expires_at = (datetime.utcnow() + timedelta(minutes=5)).isoformat() + "Z"
+    state = _approval_state("bot", trigger, expires_at=expires_at)
+
+    assert execute_position_close("bot", trigger, _live_config(tmp_path), state) is True
+    assert trigger["_execution_result"]["approval"]["state"] == "approved"
+
+
+def test_execute_position_close_live_rejects_malformed_approval_expiry(monkeypatch, tmp_path):
+    monkeypatch.setattr(automation_engine, "DISCORD_WEBHOOK_ALERTS", None)
+    called = {"close": False}
+    monkeypatch.setattr(automation_engine, "_run_dlmm_close_command", lambda *_: called.update(close=True) or {"success": True})
+    trigger = {
+        "trigger_type": "stop_loss",
+        "pnl_pct": -12.0,
+        "position": {"position": "pos123", "lb_pair": "pool123", "pool_name": "SOL-USDC"},
+    }
+    state = _approval_state("bot", trigger, expires_at="not-a-timestamp")
+
+    assert execute_position_close("bot", trigger, _live_config(tmp_path), state) is False
+    assert trigger["_execution_result"]["error"] == "risk_approval_expired"
+    assert trigger["_execution_result"]["approval"]["state"] == "expired"
+    assert called["close"] is False
 
 
 def test_execute_position_close_live_rejects_unauthenticated_approval(monkeypatch, tmp_path):

--- a/Pryan-Fire/hughs-forge/scripts/test_automation_engine.py
+++ b/Pryan-Fire/hughs-forge/scripts/test_automation_engine.py
@@ -176,6 +176,25 @@ def test_execute_position_close_live_rejects_unauthenticated_approval(monkeypatc
     assert trigger["_execution_result"]["error"] == "risk_approval_unauthenticated"
 
 
+def test_execute_position_close_live_rejects_non_mapping_approval_scope(monkeypatch, tmp_path):
+    monkeypatch.setattr(automation_engine, "DISCORD_WEBHOOK_ALERTS", None)
+    called = {"close": False}
+    monkeypatch.setattr(automation_engine, "_run_dlmm_close_command", lambda *_: called.update(close=True) or {"success": True})
+    trigger = {
+        "trigger_type": "stop_loss",
+        "pnl_pct": -12.0,
+        "position": {"position": "pos123", "lb_pair": "pool123", "pool_name": "SOL-USDC"},
+    }
+    state = _approval_state("bot", trigger)
+    next(iter(state["risk_approvals"].values()))["scope"] = None
+
+    assert execute_position_close("bot", trigger, _live_config(tmp_path), state) is False
+    assert trigger["_execution_result"]["error"] == "risk_approval_scope_mismatch"
+    assert trigger["_execution_result"]["approval"]["state"] == "scope_mismatch"
+    assert trigger["_execution_result"]["approval"]["scope_key"] == "scope"
+    assert called["close"] is False
+
+
 def test_execute_position_close_live_uses_dlmm_command(monkeypatch, tmp_path):
     monkeypatch.setattr(automation_engine, "DISCORD_WEBHOOK_ALERTS", None)
     called = {}

--- a/Pryan-Fire/hughs-forge/scripts/test_automation_engine.py
+++ b/Pryan-Fire/hughs-forge/scripts/test_automation_engine.py
@@ -2,11 +2,37 @@
 """Tests for automation_engine.py - SL/TP automation and close boundaries."""
 import os
 import sys
+from datetime import datetime, timedelta
 
 sys.path.insert(0, os.path.dirname(__file__))
 
 import automation_engine
 from automation_engine import evaluate_triggers, execute_position_close, handle_auto_execute
+
+
+def _live_config(tmp_path):
+    return {"execution": {"dry_run": False, "kill_switch_file": str(tmp_path / "trade_stop.lock")}}
+
+
+def _approval_state(wallet_name, trigger, *, expires_delta=300, status="approved", authenticated=True, scope_override=None):
+    approval_id = automation_engine._risk_approval_id(wallet_name, trigger)
+    scope = automation_engine._approval_scope(wallet_name, trigger)
+    if scope_override:
+        scope.update(scope_override)
+    record = {
+        "status": status,
+        "source": "risk-manager",
+        "approved_by": "Lord Xar",
+        "approved_by_id": "316308517520801793",
+        "auth_method": "discord_operator",
+        "approved_at": datetime.utcnow().isoformat() + "Z",
+        "expires_at": (datetime.utcnow() + timedelta(seconds=expires_delta)).isoformat() + "Z",
+        "scope": scope,
+    }
+    if not authenticated:
+        record.pop("approved_by_id")
+        record.pop("auth_method")
+    return {"risk_approvals": {approval_id: record}}
 
 
 def test_evaluate_triggers_no_automation():
@@ -52,17 +78,58 @@ def test_evaluate_triggers_zero_value_live_position_stop_loss():
     assert triggers[0]["pnl_pct"] == -100.0
 
 
-def test_execute_position_close_live_fails_without_pool(monkeypatch):
+def test_execute_position_close_live_fails_closed_without_approval(monkeypatch, tmp_path):
+    monkeypatch.setattr(automation_engine, "DISCORD_WEBHOOK_ALERTS", None)
+    called = {"close": False}
+    monkeypatch.setattr(automation_engine, "_run_dlmm_close_command", lambda *_: called.update(close=True) or {"success": True})
+    trigger = {
+        "trigger_type": "stop_loss",
+        "pnl_pct": -12.0,
+        "position": {"position": "pos123", "lb_pair": "pool123", "pool_name": "SOL-USDC"},
+    }
+    assert execute_position_close("bot", trigger, _live_config(tmp_path), {}) is False
+    assert trigger["_execution_result"]["error"] == "risk_approval_required"
+    assert trigger["_execution_result"]["approval"]["state"] == "missing"
+    assert called["close"] is False
+
+
+def test_execute_position_close_live_fails_without_pool_after_approval(monkeypatch, tmp_path):
     monkeypatch.setattr(automation_engine, "DISCORD_WEBHOOK_ALERTS", None)
     trigger = {
         "trigger_type": "stop_loss",
         "pnl_pct": -12.0,
         "position": {"position": "pos123", "pool_name": "SOL-USDC"},
     }
-    assert execute_position_close("bot", trigger, {"execution": {"dry_run": False}}) is False
+    state = _approval_state("bot", trigger)
+    assert execute_position_close("bot", trigger, _live_config(tmp_path), state) is False
+    assert trigger["_execution_result"]["error"] == "missing_pool"
 
 
-def test_execute_position_close_live_uses_dlmm_command(monkeypatch):
+def test_execute_position_close_live_rejects_expired_approval(monkeypatch, tmp_path):
+    monkeypatch.setattr(automation_engine, "DISCORD_WEBHOOK_ALERTS", None)
+    trigger = {
+        "trigger_type": "stop_loss",
+        "pnl_pct": -12.0,
+        "position": {"position": "pos123", "lb_pair": "pool123", "pool_name": "SOL-USDC"},
+    }
+    state = _approval_state("bot", trigger, expires_delta=-1)
+    assert execute_position_close("bot", trigger, _live_config(tmp_path), state) is False
+    assert trigger["_execution_result"]["error"] == "risk_approval_expired"
+
+
+def test_execute_position_close_live_rejects_unauthenticated_approval(monkeypatch, tmp_path):
+    monkeypatch.setattr(automation_engine, "DISCORD_WEBHOOK_ALERTS", None)
+    trigger = {
+        "trigger_type": "stop_loss",
+        "pnl_pct": -12.0,
+        "position": {"position": "pos123", "lb_pair": "pool123", "pool_name": "SOL-USDC"},
+    }
+    state = _approval_state("bot", trigger, authenticated=False)
+    assert execute_position_close("bot", trigger, _live_config(tmp_path), state) is False
+    assert trigger["_execution_result"]["error"] == "risk_approval_unauthenticated"
+
+
+def test_execute_position_close_live_uses_dlmm_command(monkeypatch, tmp_path):
     monkeypatch.setattr(automation_engine, "DISCORD_WEBHOOK_ALERTS", None)
     called = {}
 
@@ -76,8 +143,10 @@ def test_execute_position_close_live_uses_dlmm_command(monkeypatch):
         "pnl_pct": 55.0,
         "position": {"position": "pos123", "lb_pair": "pool123", "pool_name": "SOL-USDC"},
     }
-    assert execute_position_close("bot", trigger, {"execution": {"dry_run": False}}) is True
+    state = _approval_state("bot", trigger)
+    assert execute_position_close("bot", trigger, _live_config(tmp_path), state) is True
     assert called["pool"] == "pool123"
+    assert trigger["_execution_result"]["approval"]["state"] == "approved"
 
 
 def test_handle_auto_execute_tracks_failure_attempt(monkeypatch):
@@ -116,7 +185,7 @@ def test_handle_auto_execute_blacklist_is_idempotent(monkeypatch):
 def test_handle_auto_execute_records_success_signatures(monkeypatch):
     monkeypatch.setattr(automation_engine, "DISCORD_WEBHOOK_ALERTS", None)
 
-    def fake_execute(_wallet_name, trigger, _config):
+    def fake_execute(_wallet_name, trigger, _config, *_args):
         trigger["_execution_result"] = {"success": True, "dry_run": False, "signatures": ["sig123"]}
         return True
 
@@ -139,7 +208,7 @@ def test_handle_auto_execute_records_success_signatures(monkeypatch):
 def test_handle_auto_execute_records_failure_error(monkeypatch):
     monkeypatch.setattr(automation_engine, "DISCORD_WEBHOOK_ALERTS", None)
 
-    def fake_execute(_wallet_name, trigger, _config):
+    def fake_execute(_wallet_name, trigger, _config, *_args):
         trigger["_execution_result"] = {"success": False, "dry_run": False, "error": "missing_pool"}
         return False
 
@@ -202,3 +271,23 @@ def test_evaluate_triggers_skips_value_unavailable_position():
     }]
     state = {"wallets": {"test_wallet": {"positions": {"unknown_value": {"entry_value_usd": 1000}}}}}
     assert evaluate_triggers("test_wallet", positions, wallet_config, state) == []
+
+
+def test_execution_notification_includes_approval_source(monkeypatch):
+    monkeypatch.setattr(automation_engine, "DISCORD_WEBHOOK_ALERTS", "https://discord.invalid/webhook")
+    posted = []
+    monkeypatch.setattr(automation_engine, "_post_to_discord_alerts", lambda msg: posted.append(msg) or True)
+    trigger = {
+        "trigger_type": "stop_loss",
+        "pnl_pct": -12.0,
+        "entry_value": 1000,
+        "current_value": 850,
+        "position": {"position": "pos123", "lb_pair": "pool123", "pool_name": "SOL-USDC"},
+        "_execution_result": {
+            "approval": {"source": "risk-manager", "state": "approved", "approved_by": "Lord Xar"}
+        },
+    }
+    automation_engine._post_execution_notification("bot", trigger, dry_run=False, success=True, signatures=["sig123"])
+    content = posted[0]["content"]
+    assert "**Approval**: `risk-manager` / `approved` by `Lord Xar`" in content
+    assert "**Tx**: `sig123`" in content


### PR DESCRIPTION
## Summary
- Adds a fail-closed live-money RiskManager approval gate before DLMM close execution.
- Requires scoped, authenticated, unexpired approval records for live closes.
- Preserves dry-run/safe-test execution without live signing.
- Adds approval source/state to automation notifications without exposing secrets.

## Links
- Supports #277 live-readiness chain.
- Addresses #294 approval/auth gate.

## Tests
- `python3 -m pytest Pryan-Fire/hughs-forge/scripts/test_automation_engine.py Pryan-Fire/hughs-forge/scripts/test_position_monitor.py -q`
- `git diff --check`
- `python3 -m py_compile Pryan-Fire/hughs-forge/scripts/automation_engine.py Pryan-Fire/hughs-forge/scripts/test_automation_engine.py Pryan-Fire/hughs-forge/scripts/position_monitor.py`

## Notes
- No live systemd commands.
- No funded/dust test.
- Live execution stays blocked unless an exact-scope approval record exists and the kill switch is clear.