### PR TITLE
fix: use position value for DLMM PnL

### DIFF
--- a/Pryan-Fire/hughs-forge/scripts/automation_engine.py
+++ b/Pryan-Fire/hughs-forge/scripts/automation_engine.py
@@ -72,8 +72,13 @@ def evaluate_triggers(wallet_name: str, positions: List[Dict], wallet_config: Di
         # zero value alone: a live position can collapse to zero and still needs
         # stop-loss handling. Upstream must mark closed/stale explicitly.
         is_stale = bool(pos.get("stale") or pos.get("closed") or pos.get("pnl", {}).get("stale"))
-        if is_stale:
-            logger.debug(f"[{wallet_name}] Skipping stale position {pubkey}")
+        value_unavailable = bool(
+            pos.get("pnl_value_unavailable")
+            or pos.get("liquidity_value_source") == "unavailable"
+            or pos.get("pnl", {}).get("value_unavailable")
+        )
+        if is_stale or value_unavailable:
+            logger.debug(f"[{wallet_name}] Skipping stale/value-unavailable position {pubkey}")
             continue
         
         # Get entry value from state

--- a/Pryan-Fire/hughs-forge/scripts/position_monitor.py
+++ b/Pryan-Fire/hughs-forge/scripts/position_monitor.py
@@ -143,6 +143,24 @@ def calculate_pnl(state_wallet: Dict[str, Any], position_addr: str, current_data
     """Calculate PnL for a position."""
     current_liquidity = float(current_data.get("liquidity_usd", 0) or 0)
     fees = _position_fee_value(current_data)
+    value_unavailable = bool(
+        current_data.get("pnl_value_unavailable")
+        or current_data.get("liquidity_value_source") == "unavailable"
+    )
+
+    if value_unavailable:
+        pos_state = state_wallet.get("positions", {}).get(position_addr, {})
+        entry_value = pos_state.get("entry_value_usd", 0.0)
+        return {
+            "pnl_usd": 0.0,
+            "pnl_pct": 0.0,
+            "pnl_24h": 0.0,
+            "entry_value_usd": entry_value,
+            "current_value_usd": 0.0,
+            "stale": True,
+            "value_unavailable": True,
+            "last_known_value_usd": pos_state.get("last_known_value_usd", entry_value),
+        }
     
     # Initialize if first time seeing this position
     if position_addr not in state_wallet.get("positions", {}):
@@ -226,8 +244,10 @@ def build_wallet_embed(wallet_name: str, wallet_config: Dict[str, Any], wallet_d
     positions = wallet_data.get("positions", [])
     sol_balance = wallet_data.get("sol_balance", 0)
     
-    # Calculate totals
+    # Calculate totals. liquidity_usd is per-position value; pool_liquidity_usd
+    # is displayed separately for context and must not feed PnL math.
     total_value = sum(p.get("liquidity_usd", 0) for p in positions)
+    total_pool_tvl = sum(p.get("pool_liquidity_usd", 0) for p in positions)
     total_fees_claimed = sum(p.get("fees_claimed_usd", 0) for p in positions)
     
     # Calculate total PnL
@@ -251,7 +271,8 @@ def build_wallet_embed(wallet_name: str, wallet_config: Dict[str, Any], wallet_d
         "fields": [
             {"name": "SOL Balance", "value": f"{sol_balance:.4f} SOL", "inline": True},
             {"name": "Positions", "value": str(len(positions)), "inline": True},
-            {"name": "Pool TVL (all)", "value": f"${total_value:,.2f}", "inline": True},
+            {"name": "Position Value", "value": f"${total_value:,.2f}", "inline": True},
+            {"name": "Pool TVL", "value": f"${total_pool_tvl:,.2f}", "inline": True},
             {"name": "Fees Claimed", "value": f"${total_fees_claimed:,.2f}", "inline": True},
             {"name": "Total PnL", "value": f"${total_pnl:,.2f} ({total_pnl_pct:.1f}%)", "inline": True},
         ],
@@ -301,7 +322,7 @@ def build_position_embed(wallet_name: str, position: Dict[str, Any], pnl: Dict[s
             {"name": "Entry Value", "value": f"${pnl.get('entry_value_usd', 0):,.2f}", "inline": True},
             {"name": "Current Value", "value": f"${pnl.get('current_value_usd', 0):,.2f}", "inline": True},
             {"name": "24h PnL", "value": f"${pnl.get('pnl_24h', 0):,.2f}", "inline": True},
-            {"name": "Pool TVL", "value": f"${position.get('liquidity_usd', 0):,.2f}", "inline": True},
+            {"name": "Pool TVL", "value": f"${position.get('pool_liquidity_usd', 0):,.2f}", "inline": True},
             {"name": "Volume (24h)", "value": f"${position.get('volume_24h', 0):,.2f}", "inline": True},
             {"name": "Bin Range", "value": f"{lower_bin}-{upper_bin} (Active: {active_bin})", "inline": False},
             {"name": "Links", "value": f"[Meteora]({meteora_url}) | [DexScreener]({get_dexscreener_url(mint_x)})", "inline": False},

--- a/Pryan-Fire/hughs-forge/scripts/test_automation_engine.py
+++ b/Pryan-Fire/hughs-forge/scripts/test_automation_engine.py
@@ -190,3 +190,15 @@ def test_execution_failure_notification_includes_full_context(monkeypatch):
     assert "**PnL**: -100.0% ($1,000.00 → $0.00)" in content
     assert "**Error**: `jupiter_401`" in content
     assert "**Tx**: none submitted" in content
+
+
+def test_evaluate_triggers_skips_value_unavailable_position():
+    wallet_config = {"automation": {"enabled": True, "stop_loss_pct": 10.0, "take_profit_pct": 50.0}}
+    positions = [{
+        "position": "unknown_value",
+        "liquidity_usd": 0,
+        "liquidity_value_source": "unavailable",
+        "pool_liquidity_usd": 250000,
+    }]
+    state = {"wallets": {"test_wallet": {"positions": {"unknown_value": {"entry_value_usd": 1000}}}}}
+    assert evaluate_triggers("test_wallet", positions, wallet_config, state) == []

--- a/Pryan-Fire/hughs-forge/scripts/test_position_monitor.py
+++ b/Pryan-Fire/hughs-forge/scripts/test_position_monitor.py
@@ -52,3 +52,17 @@ def test_build_position_embed_keeps_full_position(monkeypatch):
     )
     position_field = next(field for field in embed["fields"] if field["name"] == "Position")
     assert position_field["value"] == f"`{position_addr}`"
+
+
+def test_calculate_pnl_value_unavailable_does_not_initialize_or_trigger_loss():
+    state_wallet = {"positions": {}}
+    result = calculate_pnl(
+        state_wallet,
+        "pos_missing_value",
+        {"liquidity_usd": 0, "liquidity_value_source": "unavailable", "pool_liquidity_usd": 250000},
+    )
+    assert result["stale"] is True
+    assert result["value_unavailable"] is True
+    assert result["pnl_usd"] == 0.0
+    assert result["pnl_pct"] == 0.0
+    assert "pos_missing_value" not in state_wallet["positions"]

--- a/Pryan-Fire/hughs-forge/services/trade-orchestrator/src/health_server.py
+++ b/Pryan-Fire/hughs-forge/services/trade-orchestrator/src/health_server.py
@@ -137,6 +137,48 @@ def _calculate_usd_liquidity(pool: Dict[str, Any]) -> float:
         return float(pool.get("cumulative_fee_volume", 0))
 
 
+POSITION_VALUE_FIELDS = (
+    "position_value_usd",
+    "current_value_usd",
+    "liquidity_usd",
+    "total_value_usd",
+    "total_position_value_usd",
+    "value_usd",
+    "usd_value",
+)
+
+
+def _coerce_positive_float(value: Any) -> Optional[float]:
+    try:
+        coerced = float(value)
+    except (TypeError, ValueError):
+        return None
+    return coerced if coerced >= 0 else None
+
+
+def _position_liquidity_usd(pos_data: Dict[str, Any]) -> tuple[float, str]:
+    """Return per-position current USD value and source.
+
+    Pool TVL is deliberately excluded here. Using pool liquidity as a wallet
+    position value creates impossible PnL spikes (for example SOL-USDC +81%)
+    and can falsely trigger SL/TP automation.
+    """
+    for field in POSITION_VALUE_FIELDS:
+        value = _coerce_positive_float(pos_data.get(field))
+        if value is not None:
+            return value, field
+
+    for container_key in ("position", "liquidity", "value"):
+        nested = pos_data.get(container_key)
+        if isinstance(nested, dict):
+            for field in ("usd", "usd_value", "value_usd", "liquidity_usd"):
+                value = _coerce_positive_float(nested.get(field))
+                if value is not None:
+                    return value, f"{container_key}.{field}"
+
+    return 0.0, "unavailable"
+
+
 def _rpc_call(method: str, params: List[Any]) -> Optional[Dict]:
     """Make a Solana RPC call."""
     try:
@@ -261,9 +303,12 @@ def _enrich_positions(parsed: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         lower_bin = p.get("lower_bin_id", 0)
         upper_bin = p.get("upper_bin_id", 0)
 
-        # Per-position APY from Meteora position endpoint
+        # Per-position APY/value from Meteora position endpoint. Pool TVL is
+        # exposed separately and must not be used as the wallet position value.
         fee_apy_24h = float(pos_data.get("fee_apy_24h", 0))
         fees_claimed_usd = float(pos_data.get("total_fee_usd_claimed", 0))
+        position_liquidity_usd, liquidity_value_source = _position_liquidity_usd(pos_data)
+        pool_liquidity_usd = round(_calculate_usd_liquidity(pool), 2) if pool else 0
 
         enriched.append({
             "position": p["position"],
@@ -274,7 +319,10 @@ def _enrich_positions(parsed: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
             "fees_24h": round(float(pool.get("today_fees", 0)), 2),  # pool-level total
             "base_fee": pool.get("base_fee_percentage", "?"),
             "volume_24h": round(float(pool.get("trade_volume_24h", 0)), 2),
-            "liquidity_usd": round(_calculate_usd_liquidity(pool), 2) if pool else 0,
+            "liquidity_usd": round(position_liquidity_usd, 2),
+            "liquidity_value_source": liquidity_value_source,
+            "pnl_value_unavailable": liquidity_value_source == "unavailable",
+            "pool_liquidity_usd": pool_liquidity_usd,
             "mint_x": pool.get("mint_x", ""),
             "mint_y": pool.get("mint_y", ""),
             "meteora_url": f"https://app.meteora.ag/dlmm/{p['lb_pair']}",

--- a/Pryan-Fire/hughs-forge/services/trade-orchestrator/src/test_health_server.py
+++ b/Pryan-Fire/hughs-forge/services/trade-orchestrator/src/test_health_server.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Tests for trade-orchestrator health server position enrichment."""
+
+import health_server
+
+
+def test_enrich_positions_uses_position_value_not_pool_tvl(monkeypatch):
+    pool = {
+        "name": "SOL-USDC",
+        "reserve_x_amount": 100_000_000_000,
+        "reserve_y_amount": 50_000_000_000,
+        "mint_y": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+        "current_price": 100,
+        "today_fees": 99,
+        "trade_volume_24h": 1000,
+    }
+    position = {"fee_apy_24h": 12.3, "total_fee_usd_claimed": 4.5, "liquidity_usd": 123.45}
+
+    def fake_get(url, timeout=10):
+        class Response:
+            status_code = 200
+
+            def json(self):
+                return position if "/position/" in url else pool
+
+        return Response()
+
+    monkeypatch.setattr(health_server.requests, "get", fake_get)
+    monkeypatch.setattr(health_server, "_rpc_call", lambda *_: None)
+
+    enriched = health_server._enrich_positions([
+        {"position": "pos123", "lb_pair": "pool123", "lower_bin_id": 1, "upper_bin_id": 2}
+    ])
+
+    result = enriched[0]
+    assert result["liquidity_usd"] == 123.45
+    assert result["liquidity_value_source"] == "liquidity_usd"
+    assert result["pnl_value_unavailable"] is False
+    assert result["pool_liquidity_usd"] > 50_000
+
+
+def test_enrich_positions_does_not_fallback_to_pool_tvl_for_position_value(monkeypatch):
+    pool = {
+        "name": "SOL-USDC",
+        "reserve_x_amount": 100_000_000_000,
+        "reserve_y_amount": 50_000_000_000,
+        "mint_y": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+        "current_price": 100,
+        "today_fees": 99,
+        "trade_volume_24h": 1000,
+    }
+
+    def fake_get(url, timeout=10):
+        class Response:
+            status_code = 200
+
+            def json(self):
+                return {} if "/position/" in url else pool
+
+        return Response()
+
+    monkeypatch.setattr(health_server.requests, "get", fake_get)
+    monkeypatch.setattr(health_server, "_rpc_call", lambda *_: None)
+
+    enriched = health_server._enrich_positions([
+        {"position": "pos123", "lb_pair": "pool123", "lower_bin_id": 1, "upper_bin_id": 2}
+    ])
+
+    result = enriched[0]
+    assert result["liquidity_usd"] == 0
+    assert result["liquidity_value_source"] == "unavailable"
+    assert result["pnl_value_unavailable"] is True
+    assert result["pool_liquidity_usd"] > 50_000


### PR DESCRIPTION
## Summary
- fix #163 by separating per-position USD value from pool TVL in /wallet-fees enrichment
- expose pool_liquidity_usd separately for display/context
- skip PnL/automation when Meteora position value is unavailable instead of fabricating PnL from pool TVL
- keep automation from firing on value-unavailable positions

## Verification
- python -m py_compile Pryan-Fire/hughs-forge/scripts/automation_engine.py Pryan-Fire/hughs-forge/scripts/position_monitor.py Pryan-Fire/hughs-forge/services/trade-orchestrator/src/health_server.py
- python -m pytest -q Pryan-Fire/hughs-forge/scripts/test_position_monitor.py Pryan-Fire/hughs-forge/scripts/test_automation_engine.py Pryan-Fire/hughs-forge/services/trade-orchestrator/src/test_health_server.py -> 21 passed
- git diff --check

## Gate notes
Codex wait cap: 10 minutes after PR creation/update. If current-head Codex produces blockers, Haplo resolves them before handoff.