### PR TITLE
fix: parallelize wallet fees payloads

### DIFF
--- a/Pryan-Fire/hughs-forge/services/trade-orchestrator/src/health_server.py
+++ b/Pryan-Fire/hughs-forge/services/trade-orchestrator/src/health_server.py
@@ -7,6 +7,7 @@ import asyncio
 import requests
 import json
 import struct
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Optional, List, Dict, Any
 
 logger = logging.getLogger(__name__)
@@ -363,6 +364,28 @@ def get_positions(wallet_address: str):
     }
 
 
+def _wallet_fees_payload(address: str) -> Dict[str, Any]:
+    """Build /wallet-fees payload for one tracked wallet."""
+    raw_positions = _find_dlmm_positions(address)
+    if not raw_positions:
+        return {
+            "wallet": address,
+            "positions": [],
+            "count": 0,
+            "sol_balance": _get_sol_balance(address),
+        }
+
+    parsed = [_parse_position(r) for r in raw_positions]
+    enriched = _enrich_positions(parsed)
+
+    return {
+        "wallet": address,
+        "positions": enriched,
+        "count": len(enriched),
+        "sol_balance": _get_sol_balance(address),
+    }
+
+
 @app.get("/wallet-fees")
 def get_wallet_fees():
     """
@@ -372,28 +395,27 @@ def get_wallet_fees():
     No management — display only.
     """
     timestamp = datetime.datetime.utcnow().isoformat() + "Z"
-    wallets = {}
+    wallets: Dict[str, Dict[str, Any]] = {}
 
-    for name, address in TRACKED_WALLETS.items():
-        raw_positions = _find_dlmm_positions(address)
-        if not raw_positions:
-            wallets[name] = {
-                "wallet": address,
-                "positions": [],
-                "count": 0,
-                "sol_balance": _get_sol_balance(address),
-            }
-            continue
-
-        parsed = [_parse_position(r) for r in raw_positions]
-        enriched = _enrich_positions(parsed)
-
-        wallets[name] = {
-            "wallet": address,
-            "positions": enriched,
-            "count": len(enriched),
-            "sol_balance": _get_sol_balance(address),
+    max_workers = max(1, min(len(TRACKED_WALLETS), int(os.getenv("WALLET_FEES_WORKERS", "4"))))
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        futures = {
+            executor.submit(_wallet_fees_payload, address): name
+            for name, address in TRACKED_WALLETS.items()
         }
+        for future in as_completed(futures):
+            name = futures[future]
+            try:
+                wallets[name] = future.result()
+            except Exception as e:
+                logger.error(f"Wallet fee payload failed for {name}: {e}")
+                wallets[name] = {
+                    "wallet": TRACKED_WALLETS[name],
+                    "positions": [],
+                    "count": 0,
+                    "sol_balance": 0.0,
+                    "error": str(e),
+                }
 
     return {
         "timestamp": timestamp,

--- a/Pryan-Fire/hughs-forge/services/trade-orchestrator/src/test_health_server.py
+++ b/Pryan-Fire/hughs-forge/services/trade-orchestrator/src/test_health_server.py
@@ -71,3 +71,48 @@ def test_enrich_positions_does_not_fallback_to_pool_tvl_for_position_value(monke
     assert result["liquidity_value_source"] == "unavailable"
     assert result["pnl_value_unavailable"] is True
     assert result["pool_liquidity_usd"] > 50_000
+
+
+def test_wallet_fees_processes_wallets_concurrently(monkeypatch):
+    calls = []
+    monkeypatch.setattr(health_server, "TRACKED_WALLETS", {"owner": "owner_addr", "bot": "bot_addr"})
+
+    def fake_payload(address):
+        calls.append(address)
+        return {"wallet": address, "positions": [], "count": 0, "sol_balance": 1.0}
+
+    class ImmediateFuture:
+        def __init__(self, result):
+            self._result = result
+
+        def result(self):
+            return self._result
+
+    class FakeExecutor:
+        def __init__(self, max_workers):
+            self.max_workers = max_workers
+            self.futures = []
+
+        def __enter__(self):
+            created["executor"] = self
+            return self
+
+        def __exit__(self, *_exc):
+            return False
+
+        def submit(self, fn, address):
+            future = ImmediateFuture(fn(address))
+            self.futures.append(future)
+            return future
+
+    created = {}
+    monkeypatch.setattr(health_server, "_wallet_fees_payload", fake_payload)
+    monkeypatch.setattr(health_server, "ThreadPoolExecutor", FakeExecutor)
+    monkeypatch.setattr(health_server, "as_completed", lambda futures: list(futures))
+
+    response = health_server.get_wallet_fees()
+
+    assert created["executor"].max_workers == 2
+    assert set(calls) == {"owner_addr", "bot_addr"}
+    assert response["wallets"]["owner"]["wallet"] == "owner_addr"
+    assert response["wallets"]["bot"]["wallet"] == "bot_addr"


### PR DESCRIPTION
## Summary
- addresses #145 live blocker where /wallet-fees takes ~11s by processing tracked wallets concurrently
- keeps per-wallet failures isolated so one wallet error does not blank the whole endpoint
- adds regression coverage for concurrent wallet payload dispatch

## Live diagnosis
- Hugh /health is healthy
- Hugh /wallet-fees returns in ~11.1s with a 25s client timeout, but fails 8-10s checks
- deployed Hugh repo is stale/wrong branch and running Apr 15 code; no systemd changes made

## Verification
- python -m py_compile Pryan-Fire/hughs-forge/services/trade-orchestrator/src/health_server.py
- python -m pytest -q Pryan-Fire/hughs-forge/services/trade-orchestrator/src/test_health_server.py -> 3 passed
- git diff --check

## Gate notes
Codex wait cap: 10 minutes. If current-head Codex reports blockers, Haplo patches before handoff.