### PR TITLE
fix: migrate Jupiter swaps to Ultra

### DIFF
--- a/Pryan-Fire/hughs-forge/scripts/automation_engine.py
+++ b/Pryan-Fire/hughs-forge/scripts/automation_engine.py
@@ -693,53 +693,95 @@ def execute_position_close(wallet_name: str, trigger: Dict, config: Dict, state:
         return False
 
 
+JUPITER_ULTRA_ENDPOINT = os.getenv("JUPITER_ULTRA_ENDPOINT", "https://api.jup.ag/ultra/v1")
+
+
+def _jupiter_headers() -> Dict[str, str]:
+    headers = {"User-Agent": "OpenClaw-Hugh/1.0"}
+    api_key = os.getenv("JUPITER_API_KEY")
+    if api_key:
+        headers["x-api-key"] = api_key
+    return headers
+
+
 def _get_jupiter_quote(input_mint: str, output_mint: str, amount: int) -> Optional[Dict]:
-    """Get swap quote from Jupiter v6 API."""
+    """Get an unsigned Jupiter Ultra order preview/transaction.
+
+    Kept under the historical helper name for compatibility. This no longer
+    calls legacy quote-api v6; with a configured taker it returns an Ultra
+    order containing `transaction` and `requestId` for manual signing.
+    """
+    return _get_jupiter_ultra_order(input_mint, output_mint, amount, 50)
+
+
+def _get_jupiter_ultra_order(
+    input_mint: str,
+    output_mint: str,
+    amount: int,
+    slippage_bps: int,
+    user_public_key: Optional[str] = None,
+) -> Optional[Dict]:
+    """Request a Jupiter Ultra order and fail closed on malformed responses."""
+    taker = user_public_key or os.getenv("TRADING_WALLET_PUBLIC_KEY", "")
+    if not taker:
+        logger.error("No user public key configured for Jupiter Ultra order")
+        return None
+
+    params = {
+        "inputMint": input_mint,
+        "outputMint": output_mint,
+        "amount": str(amount),
+        "slippageBps": slippage_bps,
+        "taker": taker,
+    }
     try:
-        params = {
-            "inputMint": input_mint,
-            "outputMint": output_mint,
-            "amount": str(amount),
-            "slippageBps": 50,
-        }
-        resp = requests.get("https://quote-api.jup.ag/v6/quote", params=params, timeout=10)
+        resp = requests.get(f"{JUPITER_ULTRA_ENDPOINT}/order", params=params, headers=_jupiter_headers(), timeout=15)
         if resp.status_code != 200:
-            logger.error(f"Jupiter API error: {resp.status_code}")
+            logger.error(f"Jupiter Ultra order API error: {resp.status_code}")
             return None
-        
-        quote = resp.json()
-        if not quote:
-            logger.error("No quotes returned from Jupiter")
+
+        order = resp.json()
+        if not isinstance(order, dict):
+            logger.error("Jupiter Ultra order response was not an object")
             return None
-        
-        return quote
+        if not isinstance(order.get("transaction"), str) or not order.get("transaction", "").strip():
+            logger.error("Jupiter Ultra order missing transaction")
+            return None
+        if not isinstance(order.get("requestId"), str) or not order.get("requestId", "").strip():
+            logger.error("Jupiter Ultra order missing requestId")
+            return None
+        return order
     except Exception as e:
-        logger.error(f"Failed to get Jupiter quote: {e}")
+        logger.error(f"Failed to get Jupiter Ultra order: {e}")
         return None
 
 
 def _get_jupiter_swap_transaction(quote: Dict, input_mint: str, output_mint: str, slippage_bps: int, user_public_key: Optional[str] = None) -> Optional[str]:
-    """Get swap transaction from Jupiter API."""
-    try:
-        url = "https://quote-api.jup.ag/v6/swap"
-        payload = {
-            "quoteResponse": quote,
-            "userPublicKey": user_public_key or os.getenv("TRADING_WALLET_PUBLIC_KEY", ""),
-            "slippageBps": slippage_bps,
-        }
-        if not payload["userPublicKey"]:
-            logger.error("No user public key configured for Jupiter swap transaction")
+    """Return the unsigned Ultra transaction from a validated order.
+
+    `quote` is accepted for backward compatibility. If it is already an Ultra
+    order, use it; otherwise request a fresh Ultra order. No legacy v6 swap API
+    is used here.
+    """
+    order = quote if isinstance(quote, dict) and "transaction" in quote else None
+    if order is None:
+        amount = int((quote or {}).get("inAmount") or (quote or {}).get("amount") or 0)
+        if amount <= 0:
+            logger.error("Cannot build Jupiter Ultra transaction without input amount")
             return None
-        resp = requests.post(url, json=payload, timeout=15)
-        if resp.status_code != 200:
-            logger.error(f"Jupiter swap API error: {resp.status_code}")
-            return None
-        
-        data = resp.json()
-        return data.get("swapTransaction")
-    except Exception as e:
-        logger.error(f"Failed to build Jupiter transaction: {e}")
+        order = _get_jupiter_ultra_order(input_mint, output_mint, amount, slippage_bps, user_public_key)
+
+    if not isinstance(order, dict):
         return None
+    transaction = order.get("transaction")
+    request_id = order.get("requestId")
+    if not isinstance(transaction, str) or not transaction.strip():
+        logger.error("Jupiter Ultra order missing transaction")
+        return None
+    if not isinstance(request_id, str) or not request_id.strip():
+        logger.error("Jupiter Ultra order missing requestId")
+        return None
+    return transaction
 
 
 def _post_swap_transaction_to_discord(wallet_name: str, trigger: Dict, swap_tx: str, quote: Dict):

--- a/Pryan-Fire/hughs-forge/scripts/test_automation_engine.py
+++ b/Pryan-Fire/hughs-forge/scripts/test_automation_engine.py
@@ -357,3 +357,55 @@ def test_execution_notification_includes_approval_source(monkeypatch):
     content = posted[0]["content"]
     assert "**Approval**: `risk-manager` / `approved` by `Lord Xar`" in content
     assert "**Tx**: `sig123`" in content
+
+def test_jupiter_ultra_order_rejects_missing_transaction(monkeypatch):
+    monkeypatch.setenv("TRADING_WALLET_PUBLIC_KEY", "Wallet111111111111111111111111111111111111111")
+
+    class Resp:
+        status_code = 200
+        def json(self):
+            return {"requestId": "req-123"}
+
+    monkeypatch.setattr(automation_engine.requests, "get", lambda *_, **__: Resp())
+
+    assert automation_engine._get_jupiter_ultra_order("A", "B", 100, 50) is None
+
+
+def test_jupiter_ultra_order_rejects_missing_request_id(monkeypatch):
+    monkeypatch.setenv("TRADING_WALLET_PUBLIC_KEY", "Wallet111111111111111111111111111111111111111")
+
+    class Resp:
+        status_code = 200
+        def json(self):
+            return {"transaction": "base64tx"}
+
+    monkeypatch.setattr(automation_engine.requests, "get", lambda *_, **__: Resp())
+
+    assert automation_engine._get_jupiter_ultra_order("A", "B", 100, 50) is None
+
+
+def test_jupiter_swap_transaction_uses_ultra_order_not_legacy_swap(monkeypatch):
+    called = {}
+
+    def fake_get(url, params=None, headers=None, timeout=None):
+        called["url"] = url
+        called["params"] = params
+        class Resp:
+            status_code = 200
+            def json(self):
+                return {"transaction": "base64tx", "requestId": "req-123", "outAmount": "99"}
+        return Resp()
+
+    def fail_post(*_args, **_kwargs):
+        raise AssertionError("legacy Jupiter swap POST must not be used")
+
+    monkeypatch.setenv("TRADING_WALLET_PUBLIC_KEY", "Wallet111111111111111111111111111111111111111")
+    monkeypatch.setattr(automation_engine.requests, "get", fake_get)
+    monkeypatch.setattr(automation_engine.requests, "post", fail_post)
+
+    tx = automation_engine._get_jupiter_swap_transaction({"inAmount": "100"}, "A", "B", 50)
+
+    assert tx == "base64tx"
+    assert called["url"].endswith("/order")
+    assert called["url"].startswith("https://api.jup.ag/ultra/v1")
+    assert called["params"]["taker"] == "Wallet111111111111111111111111111111111111111"

--- a/Pryan-Fire/hughs-forge/services/trade-executor/main.py
+++ b/Pryan-Fire/hughs-forge/services/trade-executor/main.py
@@ -607,29 +607,33 @@ class TradeExecutor:
             return 6 # Default to 6 on error
 
     async def get_quote(self, input_mint: str, output_mint: str, amount: int) -> Optional[Dict[str, Any]]:
-        """Fetches a quote from Jupiter v6 API for a given swap."""
-        logger.info(f"Scrying market whispers for: {amount} of {input_mint} to {output_mint} via Jupiter v6")
+        """Fetches a non-executing Jupiter Ultra order preview for a given swap."""
+        logger.info(f"Scrying market whispers for: {amount} of {input_mint} to {output_mint} via Jupiter Ultra")
         try:
-            url = "https://quote-api.jup.ag/v6/quote"
+            endpoint = os.getenv("JUPITER_ULTRA_ENDPOINT", "https://api.jup.ag/ultra/v1")
+            url = f"{endpoint}/order"
             params = {
                 "inputMint": input_mint,
                 "outputMint": output_mint,
                 "amount": str(amount),
-                "slippageBps": 50,
             }
+            headers = {"User-Agent": "OpenClaw-Hugh/1.0"}
+            api_key = os.getenv("JUPITER_API_KEY")
+            if api_key:
+                headers["x-api-key"] = api_key
             async with httpx.AsyncClient() as client:
-                response = await client.get(url, params=params)
+                response = await client.get(url, params=params, headers=headers)
                 response.raise_for_status()
                 quote_data = response.json()
                 
                 if quote_data:
-                    logger.info(f"--> Jupiter Quote Received. Out Amount: {quote_data.get('outAmount')}, Price Impact: {quote_data.get('priceImpactPct')}%")
+                    logger.info(f"--> Jupiter Ultra Order Preview Received. Out Amount: {quote_data.get('outAmount')}, Price Impact: {quote_data.get('priceImpactPct')}%")
                     return quote_data
                 else:
-                    logger.warning("--> No Jupiter quotes found.")
+                    logger.warning("--> No Jupiter Ultra order preview returned.")
                     return None
         except Exception as e:
-            logger.error(f"--> Error fetching Jupiter quote: {e}")
+            logger.error(f"--> Error fetching Jupiter Ultra order preview: {e}")
             return None
 
     async def get_meteora_pool_state(self, pool_pubkey: Pubkey) -> Optional[Dict[str, Any]]:

--- a/Pryan-Fire/hughs-forge/services/trade-orchestrator/src/core/rpc_integration.py
+++ b/Pryan-Fire/hughs-forge/services/trade-orchestrator/src/core/rpc_integration.py
@@ -87,30 +87,27 @@ class RpcIntegrator:
             )
             amount_raw = int(amount * (10 ** decimals))
 
-            # Step 1: Get swap transaction via Ultra API (combines quote + swap)
+            # Step 1: Get an unsigned executable order from Ultra.
             order_response = self._fetch_ultra_order(input_mint, output_mint, amount_raw, slippage_bps, str(self.wallet.pubkey()))
             if not order_response:
                 return {"success": False, "signature": None, "error": "order_failed"}
 
-            swap_tx_b64 = order_response.get("swapTransaction")
-            request_id = order_response.get("requestId")
-            if not swap_tx_b64 or not request_id:
-                self.logger.error(f"Missing swapTransaction or requestId: {order_response}")
-                return {"success": False, "signature": None, "error": "invalid_order_response"}
+            parsed_order = self._parse_ultra_order(order_response)
+            if not parsed_order["ok"]:
+                return {"success": False, "signature": None, "error": parsed_order["error"]}
 
-            # Step 2: Deserialize as VersionedTransaction
-            tx_bytes = base64.b64decode(swap_tx_b64)
+            # Step 2: Deserialize the unsigned VersionedTransaction.
             try:
+                tx_bytes = base64.b64decode(parsed_order["transaction"], validate=True)
                 tx = VersionedTransaction.from_bytes(tx_bytes)
-                self.logger.info("Deserialized as VersionedTransaction.")
+                self.logger.info("Deserialized Ultra order transaction.")
             except Exception as e:
-                self.logger.warning(f"VersionedTransaction failed ({e}), trying legacy Transaction.")
-                from solders.transaction import Transaction as LegacyTransaction
-                tx = LegacyTransaction.from_bytes(tx_bytes)
-                self.logger.info("Deserialized as legacy Transaction.")
+                self.logger.error(f"Invalid Ultra transaction payload: {e}")
+                return {"success": False, "signature": None, "error": "invalid_order_transaction"}
 
             # Step 3: Sign the transaction
             signed_tx = VersionedTransaction(tx.message, [self.wallet])
+            request_id = parsed_order["request_id"]
 
             # Step 4: Execute via Ultra API
             exec_result = self._execute_ultra_order(signed_tx, request_id)
@@ -132,60 +129,57 @@ class RpcIntegrator:
             self.logger.error(f"Jupiter Ultra trade failed: {e}", exc_info=True)
             return {"success": False, "signature": None, "error": str(e)}
 
+
+    def _parse_ultra_order(self, order_response: Dict[str, Any]) -> Dict[str, Any]:
+        """Validate the minimum executable Ultra order shape.
+
+        Jupiter Ultra /order returns `transaction` + `requestId`. Missing or
+        malformed values fail closed; callers must not sign or execute partial
+        responses.
+        """
+        transaction = order_response.get("transaction")
+        request_id = order_response.get("requestId")
+        if not isinstance(transaction, str) or not transaction.strip():
+            self.logger.error(f"Ultra order missing transaction: {order_response}")
+            return {"ok": False, "error": "invalid_order_response"}
+        if not isinstance(request_id, str) or not request_id.strip():
+            self.logger.error(f"Ultra order missing requestId: {order_response}")
+            return {"ok": False, "error": "invalid_order_response"}
+        return {"ok": True, "transaction": transaction, "request_id": request_id}
+
     def _fetch_quote(
         self, input_mint: str, output_mint: str, amount: int, slippage_bps: int = 50
     ) -> Optional[Dict[str, Any]]:
-        """Fetch quote from Jupiter."""
+        """Fetch a non-executing Jupiter Ultra order preview."""
         params = {
             "inputMint": input_mint,
             "outputMint": output_mint,
             "amount": str(amount),
             "slippageBps": slippage_bps,
-            "onlyDirectRoutes": "false",
-            "instructionVersion": "V2",  # Enable V2 instructions for v2 pool support
         }
         headers = {"User-Agent": "OpenClaw-Hugh/1.0"}
         if self.jupiter_api_key:
             headers["x-api-key"] = self.jupiter_api_key
 
-        url = f"{self.jupiter_endpoint}/quote"
+        url = f"{self.jupiter_endpoint}/order"
         try:
-            self.logger.info(f"Fetching quote from: {url}")
+            self.logger.info(f"Fetching Ultra order preview from: {url}")
             resp = httpx.get(url, params=params, headers=headers, timeout=10.0)
             if resp.status_code == 200:
                 return resp.json()
-            self.logger.warning(f"Quote returned {resp.status_code}: {resp.text[:200]}")
+            self.logger.warning(f"Ultra order preview returned {resp.status_code}: {resp.text[:200]}")
         except httpx.HTTPError as e:
-            self.logger.warning(f"Quote request failed: {e}")
+            self.logger.warning(f"Ultra order preview request failed: {e}")
         return None
 
     def _fetch_swap_transaction(
         self, quote: Dict[str, Any], user_public_key: str
     ) -> Optional[str]:
-        """Request swap transaction from Jupiter."""
-        payload = {
-            "quoteResponse": quote,
-            "userPublicKey": user_public_key,
-            "wrapAndUnwrapSol": True,
-            "useSharedAccounts": False,
-            "prioritizationFeeLamports": "auto",
-            "dynamicComputeUnitLimit": True,  # Auto-adjust compute units
-            "dynamicSlippage": True,  # Enable dynamic slippage for v2 pools
-        }
-        headers = {"User-Agent": "OpenClaw-Hugh/1.0"}
-        if self.jupiter_api_key:
-            headers["x-api-key"] = self.jupiter_api_key
-
-        url = f"{self.jupiter_endpoint}/swap"
-        try:
-            self.logger.info(f"Requesting swap tx from: {url}")
-            resp = httpx.post(url, json=payload, headers=headers, timeout=10.0)
-            if resp.status_code == 200:
-                return resp.json().get("swapTransaction")
-            self.logger.warning(f"Swap returned {resp.status_code}: {resp.text[:200]}")
-        except httpx.HTTPError as e:
-            self.logger.warning(f"Swap request failed: {e}")
-        return None
+        """Return a validated Ultra transaction from an existing order response."""
+        parsed = self._parse_ultra_order(quote)
+        if not parsed["ok"]:
+            return None
+        return parsed["transaction"]
 
     def _fetch_ultra_order(
         self, input_mint: str, output_mint: str, amount: int, slippage_bps: int, taker: str

--- a/Pryan-Fire/hughs-forge/services/trade-orchestrator/tests/test_rpc_integration.py
+++ b/Pryan-Fire/hughs-forge/services/trade-orchestrator/tests/test_rpc_integration.py
@@ -31,6 +31,7 @@ sys.modules.setdefault("solana.rpc.commitment", MagicMock())
 
 # Now safe to import
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+import core.rpc_integration as rpc_module
 from core.rpc_integration import RpcIntegrator, TX_CONFIRM_TIMEOUT
 
 
@@ -52,6 +53,30 @@ class TestDryRunMode:
         assert result["success"] is False
         assert result["error"] == "dry_run"
         assert result["signature"] is None
+
+    @patch("core.rpc_integration.httpx")
+    def test_dry_run_never_signs_or_executes(self, mock_httpx, monkeypatch):
+        signed = {"called": False}
+
+        class FailIfUsedTransaction:
+            @staticmethod
+            def from_bytes(_tx_bytes):
+                signed["called"] = True
+                raise AssertionError("dry-run must not deserialize/sign transactions")
+
+        monkeypatch.setattr(rpc_module, "VersionedTransaction", FailIfUsedTransaction)
+        rpc = RpcIntegrator(dry_run=True)
+
+        result = rpc.execute_jupiter_trade(
+            input_mint="So11111111111111111111111111111111111111112",
+            output_mint="EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            amount=1.0,
+        )
+
+        assert result == {"success": False, "signature": None, "error": "dry_run"}
+        assert signed["called"] is False
+        assert mock_httpx.get.called is False
+        assert mock_httpx.post.called is False
 
 
 class TestWalletLoading:
@@ -118,6 +143,69 @@ class TestExecuteJupiterTrade:
         )
         assert result["success"] is False
         assert result["error"] == "invalid_order_response"
+
+    def test_ultra_order_missing_transaction_fails_closed(self, monkeypatch):
+        self.rpc._fetch_ultra_order = lambda *_: {"requestId": "req-123"}
+        self.rpc._execute_ultra_order = lambda *_: pytest.fail("must not execute malformed Ultra order")
+
+        result = self.rpc.execute_jupiter_trade("A", "B", 1.0)
+
+        assert result["success"] is False
+        assert result["error"] == "invalid_order_response"
+
+    def test_ultra_order_missing_request_id_fails_closed(self, monkeypatch):
+        tx_b64 = base64.b64encode(b"unsigned-tx").decode()
+        self.rpc._fetch_ultra_order = lambda *_: {"transaction": tx_b64}
+        self.rpc._execute_ultra_order = lambda *_: pytest.fail("must not execute malformed Ultra order")
+
+        result = self.rpc.execute_jupiter_trade("A", "B", 1.0)
+
+        assert result["success"] is False
+        assert result["error"] == "invalid_order_response"
+
+    def test_ultra_order_malformed_transaction_fails_closed(self, monkeypatch):
+        self.rpc._fetch_ultra_order = lambda *_: {"transaction": "not-base64!!!", "requestId": "req-123"}
+        self.rpc._execute_ultra_order = lambda *_: pytest.fail("must not execute malformed Ultra transaction")
+
+        result = self.rpc.execute_jupiter_trade("A", "B", 1.0)
+
+        assert result["success"] is False
+        assert result["error"] == "invalid_order_transaction"
+
+    def test_ultra_execute_uses_signed_transaction_and_request_id(self, monkeypatch):
+        calls = {}
+
+        class FakeUnsignedTransaction:
+            message = "message-to-sign"
+
+        class FakeVersionedTransaction:
+            def __init__(self, message=None, signers=None):
+                self.message = message
+                self.signers = signers
+
+            @staticmethod
+            def from_bytes(tx_bytes):
+                calls["decoded"] = tx_bytes
+                return FakeUnsignedTransaction()
+
+        tx_b64 = base64.b64encode(b"unsigned-tx").decode()
+        monkeypatch.setattr(rpc_module, "VersionedTransaction", FakeVersionedTransaction)
+        self.rpc._fetch_ultra_order = lambda *_: {"transaction": tx_b64, "requestId": "req-123"}
+
+        def fake_execute(signed_tx, request_id):
+            calls["signed_tx"] = signed_tx
+            calls["request_id"] = request_id
+            return {"status": "Success", "signature": "sig123"}
+
+        self.rpc._execute_ultra_order = fake_execute
+
+        result = self.rpc.execute_jupiter_trade("A", "B", 1.0)
+
+        assert result == {"success": True, "signature": "sig123", "error": None}
+        assert calls["decoded"] == b"unsigned-tx"
+        assert calls["request_id"] == "req-123"
+        assert calls["signed_tx"].message == "message-to-sign"
+        assert calls["signed_tx"].signers == [mock_keypair]
 
 
 class TestReturnSignature:

--- a/Pryan-Fire/hughs-forge/tests/ghost_test_mock.py
+++ b/Pryan-Fire/hughs-forge/tests/ghost_test_mock.py
@@ -4,7 +4,7 @@ from src.executor.state_machine import TradeStateMachine, ExecutorState
 from src.executor.kill_switch import KILL_SWITCH
 
 class MockJupiterService:
-    async def get_quote(self, input_mint, output_mint, amount, slippage_bps=50):
+    async def get_quote(self, input_mint, output_mint, amount, slippage_bps=50, taker=None):
         # Mocking a successful quote for 0.1 SOL -> ~15 USDC
         return {
             "inputMint": input_mint,
@@ -17,6 +17,7 @@ class MockJupiterService:
             "platformFee": None,
             "priceImpactPct": "0.01",
             "transaction": "mock_unsigned_transaction",
+            "requestId": "mock-request-id",
         }
 
     async def get_swap_transaction(self, quote, user_public_key):
@@ -48,10 +49,10 @@ async def ghost_run_mock():
         "description": "Large Trade Test"
     }
     # Update mock for large amount
-    executor.jupiter.get_quote = lambda i, o, a: asyncio.Future()
+    executor.jupiter.get_quote = lambda i, o, a, **kwargs: asyncio.Future()
     f = asyncio.Future()
     f.set_result({"outAmount": "1500000000"}) # $1500
-    executor.jupiter.get_quote = lambda i, o, a: f
+    executor.jupiter.get_quote = lambda i, o, a, **kwargs: f
     
     await executor.process_opportunity(large_op)
     

--- a/Pryan-Fire/hughs-forge/tests/ghost_test_mock.py
+++ b/Pryan-Fire/hughs-forge/tests/ghost_test_mock.py
@@ -15,8 +15,12 @@ class MockJupiterService:
             "swapMode": "ExactIn",
             "slippageBps": slippage_bps,
             "platformFee": None,
-            "priceImpactPct": "0.01"
+            "priceImpactPct": "0.01",
+            "transaction": "mock_unsigned_transaction",
         }
+
+    async def get_swap_transaction(self, quote, user_public_key):
+        return quote.get("transaction")
 
 async def ghost_run_mock():
     print("--- INITIATING MOCKED GHOST EXECUTION TEST ---")

--- a/Pryan-Fire/hughs-forge/tests/test_jupiter_service.py
+++ b/Pryan-Fire/hughs-forge/tests/test_jupiter_service.py
@@ -1,0 +1,55 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "src")))
+
+import asyncio
+
+from services.jupiter_service import JupiterService
+
+
+def test_get_quote_preserves_slippage_and_taker(monkeypatch):
+    service = JupiterService()
+    captured = {}
+
+    async def fake_get_order(params):
+        captured.update(params)
+        return {"transaction": "tx", "requestId": "req", "outAmount": "100"}
+
+    monkeypatch.setattr(service, "_get_order", fake_get_order)
+
+    result = asyncio.run(service.get_quote("A", "B", 123, slippage_bps=77, taker="Wallet111"))
+
+    assert result["transaction"] == "tx"
+    assert captured == {
+        "inputMint": "A",
+        "outputMint": "B",
+        "amount": "123",
+        "slippageBps": 77,
+        "taker": "Wallet111",
+    }
+
+
+def test_get_swap_transaction_reuses_validated_order_without_refetch(monkeypatch):
+    service = JupiterService()
+
+    async def fail_refetch(_params):
+        raise AssertionError("execution must not re-fetch /order")
+
+    monkeypatch.setattr(service, "_get_order", fail_refetch)
+
+    tx = asyncio.run(service.get_swap_transaction({"transaction": "tx", "requestId": "req"}, "Wallet111"))
+
+    assert tx == "tx"
+
+
+def test_get_swap_transaction_fails_closed_without_transaction_or_request_id(monkeypatch):
+    service = JupiterService()
+
+    async def fail_refetch(_params):
+        raise AssertionError("execution must not re-fetch malformed order")
+
+    monkeypatch.setattr(service, "_get_order", fail_refetch)
+
+    assert asyncio.run(service.get_swap_transaction({"requestId": "req"}, "Wallet111")) is None
+    assert asyncio.run(service.get_swap_transaction({"transaction": "tx"}, "Wallet111")) is None

--- a/Pryan-Fire/src/executor/state_machine.py
+++ b/Pryan-Fire/src/executor/state_machine.py
@@ -54,7 +54,7 @@ class TradeStateMachine:
             self.transition(ExecutorState.IDLE)
             return
 
-        quote = await self.jupiter.get_quote(input_mint, output_mint, amount_atoms)
+        quote = await self.jupiter.get_quote(input_mint, output_mint, amount_atoms, taker=self.user_pubkey)
         
         if not quote:
             print("[ROUTING ERROR] Failed to fetch Jupiter Ultra quote.")

--- a/Pryan-Fire/src/executor/state_machine.py
+++ b/Pryan-Fire/src/executor/state_machine.py
@@ -57,7 +57,7 @@ class TradeStateMachine:
         quote = await self.jupiter.get_quote(input_mint, output_mint, amount_atoms)
         
         if not quote:
-            print("[ROUTING ERROR] Failed to fetch Jupiter quote.")
+            print("[ROUTING ERROR] Failed to fetch Jupiter Ultra quote.")
             self.transition(ExecutorState.IDLE)
             return
 
@@ -93,7 +93,7 @@ class TradeStateMachine:
         self.transition(ExecutorState.EXECUTING)
         try:
             # 1. Fetch the swap transaction
-            print("[TX] Requesting swap transaction from Jupiter...")
+            print("[TX] Reading Ultra order transaction from Jupiter...")
             swap_b64 = await self.jupiter.get_swap_transaction(
                 self.current_trade["quote"], 
                 self.user_pubkey

--- a/Pryan-Fire/src/executor/transaction_core.py
+++ b/Pryan-Fire/src/executor/transaction_core.py
@@ -17,7 +17,7 @@ class TransactionCore:
 
     async def build_from_jupiter(self, swap_transaction_b64: str) -> Optional[VersionedTransaction]:
         """
-        Deserializes the Jupiter base64 swapTransaction.
+        Deserializes the Jupiter Ultra base64 transaction.
         Ensures ALTs and VersionedTransaction structure are preserved.
         """
         try:

--- a/Pryan-Fire/src/services/jupiter_service.py
+++ b/Pryan-Fire/src/services/jupiter_service.py
@@ -1,96 +1,102 @@
 import aiohttp
-import asyncio
 import os
 from typing import Dict, Any, Optional
-from decimal import Decimal
+
 
 class JupiterService:
     """
-    Isolated Jupiter Service Wrapper.
-    Uses Jupiter V6 API for routing to avoid dependency conflicts.
+    Isolated Jupiter Ultra wrapper.
+
+    Live/executable swaps use Ultra /order transactions only. The old
+    quote-api/v6 quote -> swap flow is intentionally not a fallback here.
     """
-    # Ultra v1 endpoint (v1 deprecated)
-    ENDPOINTS = [
+
+    DEFAULT_ENDPOINTS = [
         "https://api.jup.ag/ultra/v1",
-        "https://quote-api.jup.ag/v6",
+        "https://lite-api.jup.ag/ultra/v1",
     ]
 
-    def __init__(self, timeout: int = 10, api_key: Optional[str] = None):
+    def __init__(self, timeout: int = 10, api_key: Optional[str] = None, endpoint: Optional[str] = None):
         self.timeout = aiohttp.ClientTimeout(total=timeout)
         self.api_key = api_key or os.getenv("JUPITER_API_KEY")
+        configured_endpoint = endpoint or os.getenv("JUPITER_ULTRA_API_BASE")
+        self.endpoints = []
+        if configured_endpoint:
+            self.endpoints.append(configured_endpoint.rstrip("/"))
+        for ultra_endpoint in self.DEFAULT_ENDPOINTS:
+            if ultra_endpoint not in self.endpoints:
+                self.endpoints.append(ultra_endpoint)
 
-    async def get_quote(self, input_mint: str, output_mint: str, amount: int, slippage_bps: int = 50) -> Optional[Dict[str, Any]]:
-        """
-        Fetches the best swap route from Jupiter.
-        Tries multiple endpoints to bypass transient Cloudflare/401 issues.
-        """
+    def _headers(self) -> Dict[str, str]:
+        headers = {
+            "Accept": "application/json",
+            "User-Agent": "OpenClaw-Haplo/1.0",
+        }
+        if self.api_key:
+            headers["x-api-key"] = self.api_key
+        return headers
+
+    async def _get_order(self, params: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        async with aiohttp.ClientSession(timeout=self.timeout) as session:
+            for endpoint in self.endpoints:
+                url = f"{endpoint}/order"
+                try:
+                    print(f"[*] Fetching Jupiter Ultra order from: {url}")
+                    async with session.get(url, params=params, headers=self._headers()) as response:
+                        if response.status == 200:
+                            return await response.json()
+                        error_text = await response.text()
+                        print(f"[JUPITER ERROR] Ultra order {url} returned {response.status}: {error_text}")
+                except Exception as e:
+                    print(f"[JUPITER EXCEPTION] {url}: {e}")
+        return None
+
+    async def get_order(
+        self,
+        input_mint: str,
+        output_mint: str,
+        amount: int,
+        taker: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Fetch a Jupiter Ultra order preview, including transaction when taker is provided."""
         params = {
             "inputMint": input_mint,
             "outputMint": output_mint,
             "amount": str(amount),
-            "slippageBps": slippage_bps,
-            "onlyDirectRoutes": "false"
         }
-        
-        headers = {
-            "Content-Type": "application/json",
-            "Accept": "application/json",
-            "User-Agent": "OpenClaw-Haplo/1.0"
-        }
-        
-        if self.api_key:
-            headers["Authorization"] = f"Bearer {self.api_key}"
-            headers["x-api-key"] = self.api_key
+        if taker:
+            params["taker"] = taker
+        return await self._get_order(params)
 
-        async with aiohttp.ClientSession(timeout=self.timeout) as session:
-            for endpoint in self.ENDPOINTS:
-                url = f"{endpoint}/quote"
-                try:
-                    print(f"[*] Fetching quote from: {url}")
-                    async with session.get(url, params=params, headers=headers) as response:
-                        if response.status == 200:
-                            return await response.json()
-                        else:
-                            error_text = await response.text()
-                            print(f"[JUPITER ERROR] Endpoint {url} returned {response.status}: {error_text}")
-                except Exception as e:
-                    print(f"[JUPITER EXCEPTION] {url}: {e}")
-            
-        return None
+    async def get_quote(
+        self,
+        input_mint: str,
+        output_mint: str,
+        amount: int,
+        slippage_bps: int = 50,
+    ) -> Optional[Dict[str, Any]]:
+        """Compatibility wrapper: Ultra /order without taker is the quote view."""
+        _ = slippage_bps  # Ultra /order does not accept legacy slippageBps.
+        return await self.get_order(input_mint, output_mint, amount)
 
     async def get_swap_transaction(self, quote: Dict[str, Any], user_public_key: str) -> Optional[str]:
         """
-        Retrieves the base64 encoded swap transaction from Jupiter.
-        """
-        payload = {
-            "quoteResponse": quote,
-            "userPublicKey": user_public_key,
-            "wrapAndUnwrapSol": True,
-            "useSharedAccounts": True,
-            "prioritizationFeeLamports": "auto"
-        }
-        
-        headers = {
-            "Content-Type": "application/json",
-            "Accept": "application/json",
-            "User-Agent": "OpenClaw-Haplo/1.0"
-        }
-        if self.api_key:
-            headers["Authorization"] = f"Bearer {self.api_key}"
-            headers["x-api-key"] = self.api_key
+        Return the unsigned base64 transaction from Jupiter Ultra /order.
 
-        async with aiohttp.ClientSession(timeout=self.timeout) as session:
-            for endpoint in self.ENDPOINTS:
-                url = f"{endpoint}/swap"
-                try:
-                    print(f"[*] Fetching swap transaction from: {url}")
-                    async with session.post(url, json=payload, headers=headers) as response:
-                        if response.status == 200:
-                            data = await response.json()
-                            return data.get("swapTransaction")
-                        else:
-                            error_text = await response.text()
-                            print(f"[JUPITER ERROR] swap endpoint {url} returned {response.status}: {error_text}")
-                except Exception as e:
-                    print(f"[JUPITER EXCEPTION] {url}: {e}")
-        return None
+        If the supplied quote was fetched without a taker, fetch a taker-bound
+        order using the same mints/amount. This replaces the old /swap endpoint.
+        """
+        transaction = quote.get("transaction")
+        if transaction:
+            return transaction
+
+        input_mint = quote.get("inputMint")
+        output_mint = quote.get("outputMint")
+        amount = quote.get("inAmount") or quote.get("amount")
+        if not (input_mint and output_mint and amount and user_public_key):
+            return None
+
+        taker_order = await self.get_order(input_mint, output_mint, int(amount), taker=user_public_key)
+        if not taker_order:
+            return None
+        return taker_order.get("transaction")

--- a/Pryan-Fire/src/services/jupiter_service.py
+++ b/Pryan-Fire/src/services/jupiter_service.py
@@ -56,6 +56,7 @@ class JupiterService:
         input_mint: str,
         output_mint: str,
         amount: int,
+        slippage_bps: int = 50,
         taker: Optional[str] = None,
     ) -> Optional[Dict[str, Any]]:
         """Fetch a Jupiter Ultra order preview, including transaction when taker is provided."""
@@ -63,6 +64,7 @@ class JupiterService:
             "inputMint": input_mint,
             "outputMint": output_mint,
             "amount": str(amount),
+            "slippageBps": slippage_bps,
         }
         if taker:
             params["taker"] = taker
@@ -74,29 +76,22 @@ class JupiterService:
         output_mint: str,
         amount: int,
         slippage_bps: int = 50,
+        taker: Optional[str] = None,
     ) -> Optional[Dict[str, Any]]:
-        """Compatibility wrapper: Ultra /order without taker is the quote view."""
-        _ = slippage_bps  # Ultra /order does not accept legacy slippageBps.
-        return await self.get_order(input_mint, output_mint, amount)
+        """Compatibility wrapper: Ultra /order is the quote view."""
+        return await self.get_order(input_mint, output_mint, amount, slippage_bps=slippage_bps, taker=taker)
 
     async def get_swap_transaction(self, quote: Dict[str, Any], user_public_key: str) -> Optional[str]:
+        """Return the already validated unsigned base64 transaction from Ultra /order.
+
+        Execution must not re-fetch /order: the transaction signed here must be
+        the same route/threshold response that earlier guard logic evaluated.
         """
-        Return the unsigned base64 transaction from Jupiter Ultra /order.
-
-        If the supplied quote was fetched without a taker, fetch a taker-bound
-        order using the same mints/amount. This replaces the old /swap endpoint.
-        """
-        transaction = quote.get("transaction")
-        if transaction:
-            return transaction
-
-        input_mint = quote.get("inputMint")
-        output_mint = quote.get("outputMint")
-        amount = quote.get("inAmount") or quote.get("amount")
-        if not (input_mint and output_mint and amount and user_public_key):
+        _ = user_public_key  # kept for call-site compatibility; taker-bound order is required upstream.
+        transaction = quote.get("transaction") if isinstance(quote, dict) else None
+        request_id = quote.get("requestId") if isinstance(quote, dict) else None
+        if not isinstance(transaction, str) or not transaction.strip():
             return None
-
-        taker_order = await self.get_order(input_mint, output_mint, int(amount), taker=user_public_key)
-        if not taker_order:
+        if not isinstance(request_id, str) or not request_id.strip():
             return None
-        return taker_order.get("transaction")
+        return transaction


### PR DESCRIPTION
## Summary
- Migrate executable Jupiter swap plumbing to Ultra /order + /execute shape
- Fail closed when Ultra order responses lack transaction/requestId or contain malformed transaction payloads
- Preserve dry-run safety: no wallet signing and no /execute call in dry-run
- Remove legacy quote-api v6 paths from Hugh trading code and top-level Pryan-Fire Jupiter service

## Tests
- python -m py_compile Pryan-Fire/src/services/jupiter_service.py Pryan-Fire/src/executor/state_machine.py Pryan-Fire/hughs-forge/tests/ghost_test_mock.py Pryan-Fire/hughs-forge/services/trade-orchestrator/src/core/rpc_integration.py Pryan-Fire/hughs-forge/scripts/automation_engine.py
- python -m pytest Pryan-Fire/hughs-forge/scripts/test_automation_engine.py
- python -m pytest Pryan-Fire/hughs-forge/services/trade-orchestrator/tests/test_rpc_integration.py
- git diff --check
- rg guard: no quote-api.jup.ag, /v6/quote, /v6/swap, or swap/v1 remains under Pryan-Fire

Closes #292