### PR TITLE
fix: add post-close USDC swap flow

### DIFF
--- a/Pryan-Fire/hughs-forge/scripts/automation_engine.py
+++ b/Pryan-Fire/hughs-forge/scripts/automation_engine.py
@@ -520,6 +520,9 @@ def handle_auto_execute(wallet_name: str, trigger: Dict, config: Dict, state: Di
             "pnl_pct": pnl_pct,
             "pool_name": pool_name,
             "signatures": execution_result.get("signatures", []),
+            "close_signatures": execution_result.get("close_signatures", []),
+            "swap_signatures": execution_result.get("swap_signatures", []),
+            "post_close_swap": execution_result.get("post_close_swap"),
             "dry_run": execution_result.get("dry_run", False),
         }
         tracker["executed_at"] = datetime.utcnow().isoformat() + "Z"
@@ -528,6 +531,20 @@ def handle_auto_execute(wallet_name: str, trigger: Dict, config: Dict, state: Di
         tracker["last_status"] = "failed"
         tracker["last_error"] = execution_result.get("error", "close_failed")
         tracker["pool_name"] = pool_name
+        if execution_result.get("close_signatures") or execution_result.get("post_close_swap"):
+            automation_state.setdefault("executions", {})[pubkey] = {
+                "status": "failed",
+                "failed_at": datetime.utcnow().isoformat() + "Z",
+                "trigger_type": trigger_type,
+                "pnl_pct": pnl_pct,
+                "pool_name": pool_name,
+                "error": execution_result.get("error", "close_failed"),
+                "signatures": execution_result.get("signatures", []),
+                "close_signatures": execution_result.get("close_signatures", []),
+                "swap_signatures": execution_result.get("swap_signatures", []),
+                "post_close_swap": execution_result.get("post_close_swap"),
+                "dry_run": execution_result.get("dry_run", False),
+            }
     return success
 
 
@@ -609,6 +626,237 @@ def _run_dlmm_close_command(wallet_name: str, trigger: Dict, config: Dict, pool_
     return result
 
 
+
+def _int_amount(value: Any) -> int:
+    try:
+        if value is None or value == "":
+            return 0
+        return max(0, int(str(value)))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _normalize_post_close_assets(close_result: Dict[str, Any], trigger: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Return candidate post-close assets in raw atoms.
+
+    The DLMM close executor reports wallet balance deltas as `post_close_assets`.
+    Tests and dry-run probes may also provide the same structure on the trigger.
+    """
+    raw_assets = close_result.get("post_close_assets") or close_result.get("unswapped_assets") or trigger.get("post_close_assets") or []
+    normalized: List[Dict[str, Any]] = []
+    if not isinstance(raw_assets, list):
+        return normalized
+
+    for asset in raw_assets:
+        if not isinstance(asset, dict):
+            continue
+        mint = str(asset.get("mint") or asset.get("input_mint") or "").strip()
+        amount_atoms = _int_amount(asset.get("delta_atoms") or asset.get("amount_atoms") or asset.get("raw_amount") or asset.get("amount"))
+        if not mint or amount_atoms <= 0:
+            continue
+        normalized.append({
+            "mint": mint,
+            "symbol": asset.get("symbol") or asset.get("token_symbol") or mint[:8],
+            "decimals": int(asset.get("decimals", 9) or 9),
+            "amount_atoms": amount_atoms,
+            "before_atoms": str(asset.get("before_atoms", "")),
+            "after_atoms": str(asset.get("after_atoms", "")),
+        })
+    return normalized
+
+
+def _post_close_swap_plan(close_result: Dict[str, Any], trigger: Dict[str, Any], execution: Dict[str, Any]) -> Dict[str, Any]:
+    output_mint = execution.get("swap_to_mint", USDC_MINT)
+    assets_reported = (
+        "post_close_assets" in close_result
+        or "unswapped_assets" in close_result
+        or "post_close_assets" in trigger
+    )
+    assets = _normalize_post_close_assets(close_result, trigger)
+    swappable = [asset for asset in assets if asset["mint"] != output_mint and asset["amount_atoms"] > 0]
+    skipped = [asset for asset in assets if asset["mint"] == output_mint]
+    return {
+        "enabled": bool(execution.get("swap_after_close", False)),
+        "output_mint": output_mint,
+        "slippage_bps": int(execution.get("swap_slippage_bps", 100) or 100),
+        "assets": swappable,
+        "skipped_assets": skipped,
+        "assets_reported": assets_reported,
+    }
+
+
+def _default_post_close_swap_command() -> Optional[List[str]]:
+    script_path = Path(__file__).resolve().parents[1] / "services" / "meteora-trader" / "scripts" / "ultra-swap.mjs"
+    if script_path.exists():
+        return ["node", str(script_path)]
+    return None
+
+
+def _resolve_post_close_swap_command(execution: Dict[str, Any]) -> Optional[List[str]]:
+    command = execution.get("post_close_swap_command") or os.getenv("POST_CLOSE_SWAP_COMMAND")
+    if isinstance(command, list):
+        return [str(part) for part in command]
+    if isinstance(command, str) and command.strip():
+        return shlex.split(command)
+    return _default_post_close_swap_command()
+
+
+def _order_summary(order: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "request_id": order.get("requestId"),
+        "out_amount": order.get("outAmount"),
+        "transaction_present": bool(order.get("transaction")),
+    }
+
+
+def _run_post_close_swap_command(
+    wallet_name: str,
+    trigger: Dict[str, Any],
+    config: Dict[str, Any],
+    close_result: Dict[str, Any],
+    asset: Dict[str, Any],
+    order: Dict[str, Any],
+) -> Dict[str, Any]:
+    execution = config.get("execution", {})
+    command = _resolve_post_close_swap_command(execution)
+    if not command:
+        return {"success": False, "error": "post_close_swap_command_not_configured"}
+
+    payload = {
+        "wallet_name": wallet_name,
+        "wallet": config.get("wallets", {}).get(wallet_name, {}),
+        "trigger": trigger,
+        "position": trigger.get("position", {}),
+        "execution": execution,
+        "close_result": close_result,
+        "asset": asset,
+        "ultra_order": order,
+    }
+    payload_json = json.dumps(payload)
+    env = os.environ.copy()
+    env["POST_CLOSE_SWAP_PAYLOAD"] = payload_json
+    timeout = int(execution.get("post_close_swap_timeout_seconds", 180))
+
+    try:
+        completed = subprocess.run(
+            command,
+            input=payload_json,
+            text=True,
+            capture_output=True,
+            timeout=timeout,
+            env=env,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        return {"success": False, "error": "post_close_swap_timeout"}
+    except Exception as exc:
+        return {"success": False, "error": "post_close_swap_command_error", "message": str(exc)}
+
+    stdout = (completed.stdout or "").strip()
+    stderr = (completed.stderr or "").strip()
+    result: Dict[str, Any] = {}
+    if stdout:
+        try:
+            result = json.loads(stdout.splitlines()[-1])
+        except json.JSONDecodeError:
+            result = {"success": False, "error": "post_close_swap_invalid_json", "stdout": stdout[-500:]}
+
+    if completed.returncode != 0:
+        result.setdefault("success", False)
+        result.setdefault("error", "post_close_swap_command_failed")
+        if stderr:
+            result["stderr"] = stderr[-500:]
+        return result
+
+    if not result:
+        result = {"success": False, "error": "post_close_swap_no_result"}
+    return result
+
+
+def _execute_single_post_close_swap(
+    wallet_name: str,
+    trigger: Dict[str, Any],
+    config: Dict[str, Any],
+    close_result: Dict[str, Any],
+    asset: Dict[str, Any],
+    output_mint: str,
+    slippage_bps: int,
+) -> Dict[str, Any]:
+    user_public_key = close_result.get("wallet") or config.get("wallets", {}).get(wallet_name, {}).get("address")
+    order = _get_jupiter_ultra_order(asset["mint"], output_mint, asset["amount_atoms"], slippage_bps, user_public_key)
+    if not order:
+        return {"success": False, "error": "post_close_swap_order_failed", "asset": asset}
+
+    command_result = _run_post_close_swap_command(wallet_name, trigger, config, close_result, asset, order)
+    signatures = command_result.get("signatures") or ([command_result.get("signature")] if command_result.get("signature") else [])
+    return {
+        "success": bool(command_result.get("success")),
+        "error": command_result.get("error"),
+        "asset": asset,
+        "order": _order_summary(order),
+        "signatures": signatures,
+        "raw_result": command_result,
+    }
+
+
+def _execute_post_close_swaps(
+    wallet_name: str,
+    trigger: Dict[str, Any],
+    config: Dict[str, Any],
+    close_result: Dict[str, Any],
+    dry_run: bool,
+) -> Dict[str, Any]:
+    execution = config.get("execution", {})
+    plan = _post_close_swap_plan(close_result, trigger, execution)
+    if not plan["enabled"]:
+        return {"success": True, "status": "disabled", "output_mint": plan["output_mint"], "swaps": [], "unswapped_assets": []}
+
+    if not plan["assets"]:
+        if not plan.get("assets_reported") and not dry_run:
+            return {
+                "success": False,
+                "status": "failed",
+                "error": "missing_post_close_assets",
+                "output_mint": plan["output_mint"],
+                "swaps": [],
+                "unswapped_assets": [],
+                "skipped_assets": plan["skipped_assets"],
+            }
+        return {
+            "success": True,
+            "status": "no_assets",
+            "output_mint": plan["output_mint"],
+            "swaps": [],
+            "unswapped_assets": [],
+            "skipped_assets": plan["skipped_assets"],
+        }
+
+    if dry_run:
+        return {
+            "success": True,
+            "status": "dry_run",
+            "output_mint": plan["output_mint"],
+            "slippage_bps": plan["slippage_bps"],
+            "swaps": [{"success": True, "dry_run": True, "asset": asset, "signatures": []} for asset in plan["assets"]],
+            "unswapped_assets": plan["assets"],
+            "skipped_assets": plan["skipped_assets"],
+        }
+
+    swaps = [
+        _execute_single_post_close_swap(wallet_name, trigger, config, close_result, asset, plan["output_mint"], plan["slippage_bps"])
+        for asset in plan["assets"]
+    ]
+    failed = [swap for swap in swaps if not swap.get("success")]
+    return {
+        "success": not failed,
+        "status": "success" if not failed else ("partial" if len(failed) < len(swaps) else "failed"),
+        "output_mint": plan["output_mint"],
+        "slippage_bps": plan["slippage_bps"],
+        "swaps": swaps,
+        "unswapped_assets": [swap.get("asset") for swap in failed if swap.get("asset")],
+        "skipped_assets": plan["skipped_assets"],
+    }
+
 def execute_position_close(wallet_name: str, trigger: Dict, config: Dict, state: Optional[Dict[str, Any]] = None) -> bool:
     """
     Full execution flow:
@@ -638,7 +886,17 @@ def execute_position_close(wallet_name: str, trigger: Dict, config: Dict, state:
     if dry_run:
         logger.info(f"DRY RUN: Would close position {pubkey}, claim fees, swap tokens to USDC")
         approval = _check_live_risk_approval(wallet_name, trigger, config, state)
-        _set_execution_result(trigger, success=True, dry_run=True, signatures=[], approval=approval)
+        post_close_swap = _execute_post_close_swaps(wallet_name, trigger, config, {}, dry_run=True)
+        _set_execution_result(
+            trigger,
+            success=True,
+            dry_run=True,
+            signatures=[],
+            close_signatures=[],
+            swap_signatures=[],
+            post_close_swap=post_close_swap,
+            approval=approval,
+        )
         _post_execution_notification(wallet_name, trigger, dry_run=True)
         return True
 
@@ -676,13 +934,47 @@ def execute_position_close(wallet_name: str, trigger: Dict, config: Dict, state:
             _post_execution_notification(wallet_name, trigger, dry_run=False, success=False, error=error)
             return False
 
-        signatures = close_result.get("signatures", [])
-        logger.info(f"DLMM close completed for {pubkey}: {signatures}")
+        close_signatures = close_result.get("signatures", [])
+        logger.info(f"DLMM close completed for {pubkey}: {close_signatures}")
 
-        if execution.get("swap_after_close", False):
-            logger.warning("swap_after_close is configured but not implemented in automation_engine; DLMM close succeeded, swap skipped")
+        post_close_swap = _execute_post_close_swaps(wallet_name, trigger, config, close_result, dry_run=False)
+        swap_signatures = [
+            signature
+            for swap in post_close_swap.get("swaps", [])
+            for signature in (swap.get("signatures") or [])
+            if signature
+        ]
+        signatures = close_signatures + swap_signatures
 
-        _set_execution_result(trigger, success=True, dry_run=False, signatures=signatures, raw_result=close_result, approval=approval)
+        if not post_close_swap.get("success", True):
+            error = "post_close_swap_failed"
+            logger.error(f"Post-close swap failed for {pubkey}; unswapped assets preserved: {post_close_swap.get('unswapped_assets', [])}")
+            _set_execution_result(
+                trigger,
+                success=False,
+                dry_run=False,
+                error=error,
+                signatures=signatures,
+                close_signatures=close_signatures,
+                swap_signatures=swap_signatures,
+                raw_result=close_result,
+                post_close_swap=post_close_swap,
+                approval=approval,
+            )
+            _post_execution_notification(wallet_name, trigger, dry_run=False, success=False, error=error, signatures=signatures)
+            return False
+
+        _set_execution_result(
+            trigger,
+            success=True,
+            dry_run=False,
+            signatures=signatures,
+            close_signatures=close_signatures,
+            swap_signatures=swap_signatures,
+            raw_result=close_result,
+            post_close_swap=post_close_swap,
+            approval=approval,
+        )
         _post_execution_notification(wallet_name, trigger, dry_run=False, success=True, signatures=signatures)
         return True
         
@@ -859,10 +1151,24 @@ def _post_execution_notification(
         content += f"\n**Approval**: `{approval_source}` / `{approval_state}`"
         if approved_by and approved_by != "not_required":
             content += f" by `{approved_by}`"
-    if not dry_run and not success:
-        content += "\n**Tx**: none submitted"
-    if signatures:
+
+    post_close_swap = execution_result.get("post_close_swap") or {}
+    close_signatures = execution_result.get("close_signatures") or []
+    swap_signatures = execution_result.get("swap_signatures") or []
+    if post_close_swap:
+        content += f"\n**Post-close swap**: `{post_close_swap.get('status', 'unknown')}`"
+        unswapped = post_close_swap.get("unswapped_assets") or []
+        if unswapped:
+            asset_labels = [f"{asset.get('amount_atoms')} atoms {asset.get('symbol') or asset.get('mint', '')[:8]}" for asset in unswapped[:3]]
+            content += "\n**Unswapped assets**: " + ", ".join(f"`{label}`" for label in asset_labels)
+    if close_signatures:
+        content += "\n**Close Tx**: " + ", ".join(f"`{sig}`" for sig in close_signatures[:3])
+    if swap_signatures:
+        content += "\n**Swap Tx**: " + ", ".join(f"`{sig}`" for sig in swap_signatures[:3])
+    elif signatures and not close_signatures:
         content += "\n**Tx**: " + ", ".join(f"`{sig}`" for sig in signatures[:3])
+    if not dry_run and not success and not (signatures or close_signatures or swap_signatures):
+        content += "\n**Tx**: none submitted"
 
     _post_to_discord_alerts({"content": content})
 

--- a/Pryan-Fire/hughs-forge/scripts/test_automation_engine.py
+++ b/Pryan-Fire/hughs-forge/scripts/test_automation_engine.py
@@ -409,3 +409,215 @@ def test_jupiter_swap_transaction_uses_ultra_order_not_legacy_swap(monkeypatch):
     assert called["url"].endswith("/order")
     assert called["url"].startswith("https://api.jup.ag/ultra/v1")
     assert called["params"]["taker"] == "Wallet111111111111111111111111111111111111111"
+
+
+def test_execute_position_close_dry_run_records_post_close_swap_plan(monkeypatch):
+    monkeypatch.setattr(automation_engine, "DISCORD_WEBHOOK_ALERTS", None)
+    trigger = {
+        "trigger_type": "take_profit",
+        "pnl_pct": 55.0,
+        "post_close_assets": [{"mint": "TokenMint111", "symbol": "TOK", "delta_atoms": "12345", "decimals": 6}],
+        "position": {"position": "pos123", "lb_pair": "pool123", "pool_name": "TOK-USDC"},
+    }
+
+    config = {"execution": {"dry_run": True, "swap_after_close": True}}
+    assert execute_position_close("bot", trigger, config, {}) is True
+    result = trigger["_execution_result"]
+    assert result["dry_run"] is True
+    assert result["post_close_swap"]["status"] == "dry_run"
+    assert result["post_close_swap"]["swaps"][0]["asset"]["mint"] == "TokenMint111"
+    assert result["swap_signatures"] == []
+
+
+def test_post_close_swap_failure_preserves_unswapped_assets(monkeypatch, tmp_path):
+    monkeypatch.setattr(automation_engine, "DISCORD_WEBHOOK_ALERTS", None)
+    monkeypatch.setattr(
+        automation_engine,
+        "_run_dlmm_close_command",
+        lambda *_: {
+            "success": True,
+            "signatures": ["close_sig"],
+            "wallet": "Wallet111111111111111111111111111111111111111",
+            "post_close_assets": [{"mint": "TokenMint111", "symbol": "TOK", "delta_atoms": "12345", "decimals": 6}],
+        },
+    )
+    monkeypatch.setattr(
+        automation_engine,
+        "_get_jupiter_ultra_order",
+        lambda *_: {"transaction": "base64tx", "requestId": "req-123", "outAmount": "1000"},
+    )
+
+    trigger = {
+        "trigger_type": "take_profit",
+        "pnl_pct": 55.0,
+        "position": {"position": "pos123", "lb_pair": "pool123", "pool_name": "TOK-USDC"},
+    }
+    config = _live_config(tmp_path)
+    config["execution"]["swap_after_close"] = True
+    state = _approval_state("bot", trigger)
+
+    assert execute_position_close("bot", trigger, config, state) is False
+    result = trigger["_execution_result"]
+    assert result["error"] == "post_close_swap_failed"
+    assert result["close_signatures"] == ["close_sig"]
+    assert result["post_close_swap"]["status"] == "failed"
+    assert result["post_close_swap"]["unswapped_assets"][0]["mint"] == "TokenMint111"
+
+
+def test_post_close_swap_success_persists_close_and_swap_signatures(monkeypatch, tmp_path):
+    monkeypatch.setattr(automation_engine, "DISCORD_WEBHOOK_ALERTS", None)
+    monkeypatch.setattr(
+        automation_engine,
+        "_run_dlmm_close_command",
+        lambda *_: {
+            "success": True,
+            "signatures": ["close_sig"],
+            "wallet": "Wallet111111111111111111111111111111111111111",
+            "post_close_assets": [{"mint": "TokenMint111", "symbol": "TOK", "delta_atoms": "12345", "decimals": 6}],
+        },
+    )
+    monkeypatch.setattr(
+        automation_engine,
+        "_execute_single_post_close_swap",
+        lambda *_: {"success": True, "asset": {"mint": "TokenMint111", "amount_atoms": 12345}, "signatures": ["swap_sig"]},
+    )
+
+    trigger = {
+        "trigger_type": "take_profit",
+        "pnl_pct": 55.0,
+        "position": {"position": "pos123", "lb_pair": "pool123", "pool_name": "TOK-USDC"},
+    }
+    config = _live_config(tmp_path)
+    config["execution"]["swap_after_close"] = True
+    state = _approval_state("bot", trigger)
+
+    assert execute_position_close("bot", trigger, config, state) is True
+    result = trigger["_execution_result"]
+    assert result["signatures"] == ["close_sig", "swap_sig"]
+    assert result["close_signatures"] == ["close_sig"]
+    assert result["swap_signatures"] == ["swap_sig"]
+    assert result["post_close_swap"]["status"] == "success"
+
+
+def test_handle_auto_execute_persists_post_close_swap_outcome(monkeypatch):
+    monkeypatch.setattr(automation_engine, "DISCORD_WEBHOOK_ALERTS", None)
+
+    def fake_execute(_wallet_name, trigger, _config, *_args):
+        trigger["_execution_result"] = {
+            "success": True,
+            "dry_run": False,
+            "signatures": ["close_sig", "swap_sig"],
+            "close_signatures": ["close_sig"],
+            "swap_signatures": ["swap_sig"],
+            "post_close_swap": {"status": "success", "swaps": [{"signatures": ["swap_sig"]}]},
+        }
+        return True
+
+    monkeypatch.setattr(automation_engine, "execute_position_close", fake_execute)
+    state = {}
+    trigger = {
+        "trigger_type": "take_profit",
+        "pnl_pct": 55.0,
+        "entry_value": 1000,
+        "current_value": 1600,
+        "position": {"position": "pos123", "lb_pair": "pool123", "pool_name": "TOK-USDC"},
+    }
+
+    assert handle_auto_execute("bot", trigger, {"execution": {"dry_run": False}}, state) is True
+    execution = state["automation"]["bot"]["executions"]["pos123"]
+    assert execution["close_signatures"] == ["close_sig"]
+    assert execution["swap_signatures"] == ["swap_sig"]
+    assert execution["post_close_swap"]["status"] == "success"
+
+
+def test_execution_notification_includes_close_swap_and_unswapped(monkeypatch):
+    monkeypatch.setattr(automation_engine, "DISCORD_WEBHOOK_ALERTS", "https://discord.invalid/webhook")
+    posted = []
+    monkeypatch.setattr(automation_engine, "_post_to_discord_alerts", lambda msg: posted.append(msg) or True)
+    trigger = {
+        "trigger_type": "take_profit",
+        "pnl_pct": 55.0,
+        "entry_value": 1000,
+        "current_value": 1600,
+        "position": {"position": "pos123", "lb_pair": "pool123", "pool_name": "TOK-USDC"},
+        "_execution_result": {
+            "close_signatures": ["close_sig"],
+            "swap_signatures": ["swap_sig"],
+            "post_close_swap": {
+                "status": "partial",
+                "unswapped_assets": [{"symbol": "TOK", "amount_atoms": 12345}],
+            },
+        },
+    }
+
+    automation_engine._post_execution_notification("bot", trigger, dry_run=False, success=False, error="post_close_swap_failed", signatures=["close_sig", "swap_sig"])
+    content = posted[0]["content"]
+    assert "**Post-close swap**: `partial`" in content
+    assert "**Unswapped assets**: `12345 atoms TOK`" in content
+    assert "**Close Tx**: `close_sig`" in content
+    assert "**Swap Tx**: `swap_sig`" in content
+
+
+def test_post_close_swap_enabled_fails_closed_without_asset_report(monkeypatch, tmp_path):
+    monkeypatch.setattr(automation_engine, "DISCORD_WEBHOOK_ALERTS", None)
+    monkeypatch.setattr(
+        automation_engine,
+        "_run_dlmm_close_command",
+        lambda *_: {"success": True, "signatures": ["close_sig"], "wallet": "Wallet111111111111111111111111111111111111111"},
+    )
+    trigger = {
+        "trigger_type": "take_profit",
+        "pnl_pct": 55.0,
+        "position": {"position": "pos123", "lb_pair": "pool123", "pool_name": "TOK-USDC"},
+    }
+    config = _live_config(tmp_path)
+    config["execution"]["swap_after_close"] = True
+    state = _approval_state("bot", trigger)
+
+    assert execute_position_close("bot", trigger, config, state) is False
+    assert trigger["_execution_result"]["error"] == "post_close_swap_failed"
+    assert trigger["_execution_result"]["post_close_swap"]["error"] == "missing_post_close_assets"
+
+
+def test_default_post_close_swap_command_points_to_ultra_swap_script():
+    command = automation_engine._default_post_close_swap_command()
+    assert command is not None
+    assert command[0] == "node"
+    assert command[1].endswith("services/meteora-trader/scripts/ultra-swap.mjs")
+
+
+def test_handle_auto_execute_persists_failed_post_close_swap_artifacts(monkeypatch):
+    monkeypatch.setattr(automation_engine, "DISCORD_WEBHOOK_ALERTS", None)
+
+    def fake_execute(_wallet_name, trigger, _config, *_args):
+        trigger["_execution_result"] = {
+            "success": False,
+            "dry_run": False,
+            "error": "post_close_swap_failed",
+            "signatures": ["close_sig"],
+            "close_signatures": ["close_sig"],
+            "swap_signatures": [],
+            "post_close_swap": {
+                "status": "failed",
+                "unswapped_assets": [{"mint": "TokenMint111", "amount_atoms": 12345}],
+            },
+        }
+        return False
+
+    monkeypatch.setattr(automation_engine, "execute_position_close", fake_execute)
+    state = {}
+    trigger = {
+        "trigger_type": "take_profit",
+        "pnl_pct": 55.0,
+        "entry_value": 1000,
+        "current_value": 1600,
+        "position": {"position": "pos123", "lb_pair": "pool123", "pool_name": "TOK-USDC"},
+    }
+
+    assert handle_auto_execute("bot", trigger, {"execution": {"dry_run": False}}, state) is False
+    execution = state["automation"]["bot"]["executions"]["pos123"]
+    assert execution["status"] == "failed"
+    assert execution["error"] == "post_close_swap_failed"
+    assert execution["close_signatures"] == ["close_sig"]
+    assert execution["post_close_swap"]["unswapped_assets"][0]["mint"] == "TokenMint111"
+    assert state["automation"]["bot"]["exec_attempts"]["pos123"]["last_error"] == "post_close_swap_failed"

--- a/Pryan-Fire/hughs-forge/services/meteora-trader/scripts/close-position.mjs
+++ b/Pryan-Fire/hughs-forge/services/meteora-trader/scripts/close-position.mjs
@@ -10,6 +10,9 @@ import { createRequire } from 'node:module';
 
 const require = createRequire(import.meta.url);
 
+const USDC_MINT = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+const SOL_MINT = 'So11111111111111111111111111111111111111112';
+
 function loadSolanaDeps() {
   const { Connection, Keypair, PublicKey, sendAndConfirmTransaction } = require('@solana/web3.js');
   const { BN } = require('@coral-xyz/anchor');
@@ -39,6 +42,63 @@ function asTxArray(txs) {
   return Array.isArray(txs) ? txs : [txs];
 }
 
+function tokenMetadata(positionData) {
+  const candidates = [
+    {
+      mint: positionData.mint_x,
+      symbol: positionData.token_x_symbol || positionData.symbol_x || 'X',
+      decimals: Number(positionData.decimals_x ?? positionData.token_x_decimals ?? (positionData.mint_x === USDC_MINT ? 6 : 9)),
+    },
+    {
+      mint: positionData.mint_y,
+      symbol: positionData.token_y_symbol || positionData.symbol_y || 'Y',
+      decimals: Number(positionData.decimals_y ?? positionData.token_y_decimals ?? (positionData.mint_y === USDC_MINT ? 6 : 9)),
+    },
+  ];
+  const seen = new Set();
+  return candidates.filter((asset) => {
+    if (!asset.mint || seen.has(asset.mint)) return false;
+    seen.add(asset.mint);
+    return true;
+  });
+}
+
+async function tokenBalanceAtoms(connection, owner, mintAddress, PublicKey) {
+  const accounts = await connection.getParsedTokenAccountsByOwner(owner, { mint: new PublicKey(mintAddress) }, 'confirmed');
+  return accounts.value.reduce((total, account) => {
+    const amount = account.account.data?.parsed?.info?.tokenAmount?.amount || '0';
+    return total + BigInt(amount);
+  }, 0n);
+}
+
+async function snapshotBalances(connection, owner, assets, PublicKey) {
+  const balances = {};
+  for (const asset of assets) {
+    if (asset.mint === SOL_MINT) {
+      balances[asset.mint] = BigInt(await connection.getBalance(owner, 'confirmed'));
+    } else {
+      balances[asset.mint] = await tokenBalanceAtoms(connection, owner, asset.mint, PublicKey);
+    }
+  }
+  return balances;
+}
+
+function postCloseAssets(assets, beforeBalances, afterBalances) {
+  return assets.map((asset) => {
+    const before = beforeBalances[asset.mint] ?? 0n;
+    const after = afterBalances[asset.mint] ?? 0n;
+    const delta = after - before;
+    return {
+      mint: asset.mint,
+      symbol: asset.symbol,
+      decimals: Number.isFinite(asset.decimals) ? asset.decimals : (asset.mint === USDC_MINT ? 6 : 9),
+      before_atoms: before.toString(),
+      after_atoms: after.toString(),
+      delta_atoms: delta > 0n ? delta.toString() : '0',
+    };
+  }).filter((asset) => asset.delta_atoms !== '0');
+}
+
 try {
   const payload = readPayload();
   const positionData = payload.position || payload.trigger?.position || {};
@@ -61,6 +121,9 @@ try {
   if (expectedOwner && expectedOwner !== String(wallet.publicKey)) {
     throw new Error(`wallet_owner_mismatch:${wallet.publicKey}`);
   }
+
+  const trackedAssets = tokenMetadata(positionData);
+  const beforeBalances = await snapshotBalances(connection, wallet.publicKey, trackedAssets, PublicKey);
 
   const dlmmPool = await DLMM.create(connection, new PublicKey(poolAddress));
   const positions = await dlmmPool.getPositionsByUserAndLbPair(wallet.publicKey);
@@ -99,12 +162,15 @@ try {
     signatures.push(signature);
   }
 
+  const afterBalances = await snapshotBalances(connection, wallet.publicKey, trackedAssets, PublicKey);
+
   writeResult({
     success: true,
     position: positionAddress,
     pool: poolAddress,
     wallet: String(wallet.publicKey),
     signatures,
+    post_close_assets: postCloseAssets(trackedAssets, beforeBalances, afterBalances),
   });
 } catch (error) {
   const message = error instanceof Error ? error.message : String(error);

--- a/Pryan-Fire/hughs-forge/services/meteora-trader/scripts/ultra-swap.mjs
+++ b/Pryan-Fire/hughs-forge/services/meteora-trader/scripts/ultra-swap.mjs
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+/**
+ * Execute a prepared Jupiter Ultra post-close swap.
+ *
+ * Input: JSON payload on stdin or POST_CLOSE_SWAP_PAYLOAD env var.
+ * Output: single JSON object on stdout.
+ */
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+
+function loadSolanaDeps() {
+  const { Keypair, PublicKey, VersionedTransaction } = require('@solana/web3.js');
+  return { Keypair, PublicKey, VersionedTransaction };
+}
+
+function readPayload() {
+  const raw = process.env.POST_CLOSE_SWAP_PAYLOAD || fs.readFileSync(0, 'utf8');
+  if (!raw || !raw.trim()) throw new Error('missing_payload');
+  return JSON.parse(raw);
+}
+
+function loadKeypair(walletPath, Keypair) {
+  const parsed = JSON.parse(fs.readFileSync(walletPath, 'utf8'));
+  const secret = Array.isArray(parsed) ? parsed : parsed.secretKey;
+  if (!Array.isArray(secret)) throw new Error('wallet_file_must_be_secret_key_array');
+  return Keypair.fromSecretKey(Uint8Array.from(secret));
+}
+
+function writeResult(result) {
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+}
+
+function headers(execution) {
+  const result = {
+    'Content-Type': 'application/json',
+    'User-Agent': 'OpenClaw-Hugh/1.0',
+  };
+  const apiKey = execution.jupiter_api_key || process.env.JUPITER_API_KEY;
+  if (apiKey) result['x-api-key'] = apiKey;
+  return result;
+}
+
+try {
+  const payload = readPayload();
+  const execution = payload.execution || {};
+  const asset = payload.asset || {};
+  const order = payload.ultra_order || {};
+
+  const walletPath = execution.wallet_path || process.env.TRADING_WALLET_PATH || process.env.WALLET_KEYPAIR_PATH;
+  if (!walletPath) throw new Error('missing_wallet_path');
+  if (!order.transaction) throw new Error('missing_ultra_transaction');
+  if (!order.requestId) throw new Error('missing_ultra_request_id');
+
+  const { Keypair, PublicKey, VersionedTransaction } = loadSolanaDeps();
+  const wallet = loadKeypair(walletPath, Keypair);
+
+  const expectedOwner = payload.close_result?.wallet || payload.wallet?.address || execution.owner_public_key || process.env.TRADING_WALLET_PUBLIC_KEY;
+  if (expectedOwner && !new PublicKey(expectedOwner).equals(wallet.publicKey)) {
+    throw new Error(`wallet_owner_mismatch:${wallet.publicKey}`);
+  }
+
+  const tx = VersionedTransaction.deserialize(Buffer.from(order.transaction, 'base64'));
+  tx.sign([wallet]);
+  const signedTransaction = Buffer.from(tx.serialize()).toString('base64');
+
+  const endpoint = (execution.jupiter_ultra_endpoint || process.env.JUPITER_ULTRA_ENDPOINT || 'https://api.jup.ag/ultra/v1').replace(/\/$/, '');
+  const response = await fetch(`${endpoint}/execute`, {
+    method: 'POST',
+    headers: headers(execution),
+    body: JSON.stringify({ signedTransaction, requestId: order.requestId }),
+  });
+
+  const text = await response.text();
+  let body = {};
+  try {
+    body = text ? JSON.parse(text) : {};
+  } catch {
+    body = { raw: text.slice(0, 500) };
+  }
+
+  if (!response.ok) {
+    writeResult({
+      success: false,
+      error: 'jupiter_ultra_execute_http_error',
+      status_code: response.status,
+      asset,
+      request_id: order.requestId,
+      response: body,
+    });
+    process.exit(1);
+  }
+
+  const status = body.status || body.result?.status;
+  const signature = body.signature || body.result?.signature;
+  if (status !== 'Success' || !signature) {
+    writeResult({
+      success: false,
+      error: body.error || 'jupiter_ultra_execute_failed',
+      status,
+      asset,
+      request_id: order.requestId,
+      response: body,
+    });
+    process.exit(1);
+  }
+
+  writeResult({
+    success: true,
+    asset,
+    request_id: order.requestId,
+    signature,
+    signatures: [signature],
+    response: { status, signature },
+  });
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(message);
+  writeResult({ success: false, error: message });
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- Wires the DLMM close result into a protected post-close swap-to-USDC flow.
- Adds balance-delta reporting from `close-position.mjs` so unswapped assets are explicit after close.
- Adds `ultra-swap.mjs` to sign/execute prepared Jupiter Ultra `/order` payloads only after the existing live approval gate.
- Persists close signatures, swap signatures, post-close swap status, and unswapped assets in automation state/alerts.

## Safety
- `dry_run` still never signs or executes swaps.
- Live close/swap remains blocked without scoped risk approval.
- If swap planning/execution fails after DLMM close, result is failed with unswapped asset state preserved instead of fake completion.
- Config default remains `swap_after_close: false`.

## Tests
- `node --check Pryan-Fire/hughs-forge/services/meteora-trader/scripts/close-position.mjs`
- `node --check Pryan-Fire/hughs-forge/services/meteora-trader/scripts/ultra-swap.mjs`
- `python3 -m pytest Pryan-Fire/hughs-forge/scripts/test_automation_engine.py -q` — 31 passed
- `python3 -m pytest Pryan-Fire/hughs-forge/services/trade-orchestrator/tests/test_rpc_integration.py -q` — 15 passed
- `git diff --check`

Closes #293
