### PR TITLE
Fix MiniMax CLI fail-closed fallback

### DIFF
--- a/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/model.py
+++ b/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/model.py
@@ -147,13 +147,18 @@ class MiniMaxCLIAdapter:
         if not image_path:
             return _manual_failure("missing_image_reference", self.model, "No local image path was available for MiniMax CLI review.")
 
-        proc = subprocess.run(
-            ["openclaw", "infer", "image", "describe", "--model", self.model, "--file", str(image_path), "--json"],
-            check=False,
-            text=True,
-            capture_output=True,
-            timeout=self.timeout_seconds,
-        )
+        try:
+            proc = subprocess.run(
+                ["openclaw", "infer", "image", "describe", "--model", self.model, "--file", str(image_path), "--json"],
+                check=False,
+                text=True,
+                capture_output=True,
+                timeout=self.timeout_seconds,
+            )
+        except FileNotFoundError:
+            return _manual_failure("api_failure_fallback", self.model, "MiniMax CLI dependency was not available; manual review required.", fallback="manual_review")
+        except subprocess.TimeoutExpired:
+            return _manual_failure("api_failure_fallback", self.model, "MiniMax CLI timed out; manual review required.", fallback="manual_review")
         if proc.returncode != 0:
             return _manual_failure("api_failure_fallback", self.model, f"MiniMax CLI exited with status {proc.returncode}; manual review required.", fallback="manual_review")
 

--- a/Pryan-Fire/projects/backend/anewluv-photo-moderation/tests/test_smoke.py
+++ b/Pryan-Fire/projects/backend/anewluv-photo-moderation/tests/test_smoke.py
@@ -769,6 +769,27 @@ class PhotoSweeperSmokeTests(unittest.TestCase):
         self.assertEqual(result["reason_code"], "inappropriate_photos")
         self.assertEqual(result["vision_model_used"], "minimax/MiniMax-VL-01 + parser")
 
+    def test_minimax_cli_adapter_missing_binary_fails_closed_to_manual_review(self):
+        with mock.patch("subprocess.run", side_effect=FileNotFoundError("openclaw")):
+            result = MiniMaxCLIAdapter().review({"local_fixture_path": "/tmp/fake.jpg"}, {})
+
+        self.assertEqual(result["verdict"], "review")
+        self.assertEqual(result["raw_reason_code"], "api_failure_fallback")
+        self.assertEqual(result["reason_code"], "manual_admin_decision")
+        self.assertEqual(result["fallback_model"], "manual_review")
+        self.assertIn("dependency was not available", result["note"])
+
+    def test_minimax_cli_adapter_timeout_fails_closed_to_manual_review(self):
+        timeout = subprocess.TimeoutExpired(cmd=["openclaw"], timeout=1)
+        with mock.patch("subprocess.run", side_effect=timeout):
+            result = MiniMaxCLIAdapter().review({"local_fixture_path": "/tmp/fake.jpg"}, {})
+
+        self.assertEqual(result["verdict"], "review")
+        self.assertEqual(result["raw_reason_code"], "api_failure_fallback")
+        self.assertEqual(result["reason_code"], "manual_admin_decision")
+        self.assertEqual(result["fallback_model"], "manual_review")
+        self.assertIn("timed out", result["note"])
+
 
 class XanoPhaseOneTests(unittest.TestCase):
     def test_xano_client_logs_in_caches_jwt_and_uses_page_per_page_queue_contract(self):


### PR DESCRIPTION
## Summary
- Rebased PR #328 onto the current active worker stack.
- Narrowed the diff to the Codex P1 fix: MiniMax CLI invocation failures now fail closed to manual review instead of crashing.
- Covers missing `openclaw` (`FileNotFoundError`) and CLI timeout (`subprocess.TimeoutExpired`).

## Proof
- `PYTHONPATH=src python3 -m unittest tests.test_smoke -v` → 58 tests OK
- Targeted MiniMax tests cover success parse, missing binary fallback, and timeout fallback.

## Review note
- Addresses Codex inline P1: https://github.com/The-Nexus-Decoded/The-Nexus/pull/328#discussion_r3167572939
