### PR TITLE
feat(anewluv): add codex openai image analysis adapter

### DIFF
--- a/Pryan-Fire/projects/backend/anewluv-photo-moderation/docs/dry-run-design-2026-04-30.md
+++ b/Pryan-Fire/projects/backend/anewluv-photo-moderation/docs/dry-run-design-2026-04-30.md
@@ -99,6 +99,15 @@ Local dependency state at design time:
 - available: Python, Pillow, Numpy, `file` binary;
 - unavailable: OpenCV, pyzbar/zbar, zxing, tesseract binary.
 
+### Provider order
+
+```txt
+1. OpenClaw/Codex OpenAI image-input route
+2. OpenAI Moderations API supplement
+3. MiniMax VL / image-analysis fallback
+4. OpenRouter multimodal fallback
+```
+
 ### Phase 4 — broad safety moderation
 
 Optional OpenAI Moderations adapter:
@@ -121,7 +130,25 @@ Dry-run behavior if unavailable:
 
 ### Phase 5 — primary image/vision review
 
-The vision adapter is the main app-specific reviewer.
+The vision adapter is the main app-specific reviewer. The primary path is `codex-openai-image`; `omni-moderation-latest` is only a broad safety supplement, MiniMax VL is the tertiary fallback after its endpoint/request/response contract is verified, and OpenRouter multimodal fallback is last-resort only.
+
+Pinned provider path:
+
+```txt
+codex-openai-image
+model_route: gpt-5.5 + gpt-image-2 configured image route
+input_text + input_image
+image_generation_events=0
+output_type=text_json
+```
+
+Implementation lesson:
+
+```txt
+gpt-image-2 route can analyze existing image input
+```
+
+Adapter output must be strictly JSON-validated before normalization or report inclusion.
 
 Must produce strict normalized result:
 

--- a/Pryan-Fire/projects/backend/anewluv-photo-moderation/docs/read-only-worker-contract-2026-04-30.md
+++ b/Pryan-Fire/projects/backend/anewluv-photo-moderation/docs/read-only-worker-contract-2026-04-30.md
@@ -1,0 +1,286 @@
+# Read-only Worker Contract — 2026-04-30
+
+## Scope
+
+This document records the staged proof contract for the ANewLuv photo moderation worker.
+
+Implementation remains gated. Documentation-only updates are allowed; worker execution, provider calls, queue reads, queue writes, and API mutations are not allowed until the gates below are cleared.
+
+## Current Worker Expectation
+
+The staged worker uses a pre-issued worker JWT/token.
+
+It must not wire or depend on the app login flow unless Lord Xar explicitly chooses that path later.
+
+## Required Worker Environment
+
+Use project-specific environment names only.
+
+Canonical env contract:
+
+```txt
+ANEWLUV_API_BASE_URL
+ANEWLUV_AUTH_API_BASE_URL
+ANEWLUV_ACTOR_KEY
+ANEWLUV_WORKER_JWT or ANEWLUV_WORKER_TOKEN
+```
+
+Alias only:
+
+```txt
+ANEWLUV_MODERATION_ACTOR_KEY -> ANEWLUV_ACTOR_KEY
+```
+
+Do not use generic aliases unless Lord Xar explicitly approves them.
+
+```txt
+XANO_JWT
+XANO_ACTOR_KEY
+```
+
+## Environment Meanings
+
+```txt
+ANEWLUV_API_BASE_URL = moderation API group base
+ANEWLUV_ACTOR_KEY = moderation service gate key
+ANEWLUV_WORKER_JWT = users JWT for service/admin AI account
+```
+
+Secrets must be read from approved secret/env paths only. Do not print token, password, key, cookie, credential header, query-string secret, or OAuth material.
+
+## Auth Split
+
+### Codex image analysis route
+
+```txt
+Codex OAuth from ~/.codex/auth.json
+never print token material
+```
+
+Provider order:
+
+```txt
+1. OpenClaw/Codex OpenAI image-input route
+2. OpenAI Moderations API supplement
+3. MiniMax VL / image-analysis fallback
+4. OpenRouter multimodal fallback
+```
+
+Provider path:
+
+```txt
+codex-openai-image
+model_route: gpt-5.5 + gpt-image-2 configured image route
+input_text + input_image
+image_generation_events=0
+output_type=text_json
+```
+
+Implementation lesson:
+
+```txt
+gpt-image-2 route can analyze existing image input
+```
+
+Codex route stays provider execution only.
+
+Auth proof boundary:
+
+```txt
+route + request shape + redacted sample output only
+no OAuth/session/token material printed
+```
+
+Adapter guardrail:
+
+```txt
+strict JSON parse
+verdict enum validator
+safe-only normalization: reject -> rejected
+uncertainty flags force review/escalate, never approved
+dry_run=true
+write_enabled=false
+/photos/decide not called
+```
+
+Adapter output must be strictly JSON-validated before normalization or report inclusion.
+
+### Xano moderation/admin API
+
+```txt
+JWT + actor_key required
+```
+
+JWT alone is not sufficient.
+
+## Recorded App Auth Path
+
+This is app behavior context, not the staged worker path.
+
+```txt
+login route: POST /auth/login
+auth base: /api:X_P2XjJo
+fields: email, password
+JWT field: authToken
+app variable: AuthKey2
+```
+
+Evidence:
+
+```txt
+anewluvExpo/apis/AuthApi.js:43-49
+anewluvExpo/apis/AuthApi.js:530-546
+anewluvExpo/app/LoginNewScreen.js:396-405
+```
+
+## Doc-only Auth/Queue Seal
+
+```txt
+auth base: ANEWLUV_AUTH_API_BASE_URL
+login: POST /auth/login
+fields: email, password
+token: authToken
+
+queue: GET /photos/queue
+auth: users JWT + ANEWLUV_ACTOR_KEY
+actor_type: ai_agent
+```
+
+Auth base stays distinct from queue/API base.
+
+The staged worker must not read or mutate app/global/AuthKey2/AsyncStorage state.
+
+## Two-seal Gate
+
+Identity seal, enforced by the server/API:
+
+```txt
+users JWT/token for AI moderation service user
+server/API verifies users.is_admin = true
+server/API verifies users.is_ai_agent = true
+```
+
+Moderation seal, presented by the worker:
+
+```txt
+ANEWLUV_ACTOR_KEY
+alias only: ANEWLUV_MODERATION_ACTOR_KEY
+```
+
+This prevents a normal user JWT plus a leaked actor key from being enough. The worker must not locally re-verify users rows or treat possession of either seal as sufficient by itself.
+
+## Verified Worker Code Contract
+
+```txt
+GET /photos/queue only
+Authorization: Bearer ***
+actor_key param
+actor_type=ai_agent
+no local account creation
+no local users row verification
+```
+
+The staged worker relies on Xano/API enforcement for the service-user identity seal. User/admin verification stays server-side. The worker only presents the two seals; it must not invent trust locally. Local row verification is not part of the worker code contract.
+
+## Execution Gate
+
+No live queue access until all of the following are true:
+
+```txt
+approved env/secret path exists for ANEWLUV_API_BASE_URL
+approved env/secret path exists for ANEWLUV_WORKER_JWT or ANEWLUV_WORKER_TOKEN
+approved env/secret path exists for ANEWLUV_ACTOR_KEY or approved alias ANEWLUV_MODERATION_ACTOR_KEY
+JWT identifies the AI moderation service user
+users.is_admin = true
+users.is_ai_agent = true
+actor_key present
+```
+
+Allowed first live proof after approval:
+
+```txt
+GET /photos/queue only
+users JWT
+actor_key
+actor_type=ai_agent
+users.is_admin=true
+users.is_ai_agent=true metadata/audit marker
+small limit
+redacted report
+zero writes
+strict JSON validator
+normalize reject -> rejected only after validation
+/photos/decide not called
+```
+
+The `users.is_admin=true` and `users.is_ai_agent=true` metadata/audit marker is descriptive only unless the endpoint actually accepts or returns that field. The worker must not invent local trust.
+
+Still forbidden until explicitly approved:
+
+```txt
+queue run
+API mutation
+/photos/decide call
+Photos.ai_* write
+provider request beyond approved staged proof
+```
+
+Non-scope for first proof:
+
+```txt
+no /photos/decide
+no Profiles.is_ai
+no worker writes
+tables 162/163 inert
+```
+
+## Leak-Risk Seal
+
+```txt
+actor_key is query-param transport
+secret-only
+no logs
+no Discord
+no raw command echo with values
+```
+
+Any proof command must show placeholders only, never the real query string.
+
+## Output Redaction Gate
+
+Reports and channel-shared output must not include raw image or user identifying fields. Use this replacement field instead:
+
+```txt
+source_field = redacted_image_reference
+```
+
+This gate applies to every output path, including:
+
+```txt
+successful final reports
+error reports
+exceptions
+validation failures
+dry-run summaries
+debug/status output shared back to channel
+```
+
+## Validation Recorded
+
+```txt
+PYTHONPATH=src python3 -m unittest discover -s tests -q
+Ran 12 tests — OK
+```
+
+Final handoff must include that exact green validation line.
+
+## Current Frozen State
+
+Before any live read-only proof, still required:
+
+```txt
+branch/status summary
+approved secret/env path
+explicit read-only small-limit command
+confirmation that error paths apply the same redaction rules
+```

--- a/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/cli.py
+++ b/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/cli.py
@@ -8,6 +8,19 @@ from pathlib import Path
 from .queue import load_queue
 from .runner import run_once
 
+MODEL_PROVIDER_CHOICES = (
+    "mock",
+    "codex-openai-image",
+    "codex-openai",
+    "openclaw-codex-openai",
+    "primary",
+    "openai-moderations",
+    "minimax-cli",
+    "minimax-fallback",
+    "minimax-vl",
+    "openrouter-multimodal",
+)
+
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
@@ -35,6 +48,18 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         help="Path to a mock model response manifest JSON file.",
     )
+    parser.add_argument(
+        "--provider",
+        choices=MODEL_PROVIDER_CHOICES,
+        default=None,
+        help="Live/model provider to use. codex-openai-image is primary; minimax-cli/minimax-vl is fallback only.",
+    )
+    parser.add_argument(
+        "--model-adapter",
+        choices=MODEL_PROVIDER_CHOICES,
+        default="mock",
+        help="Deprecated alias for --provider. Kept for existing smoke scripts.",
+    )
     return parser
 
 
@@ -46,13 +71,19 @@ def main(argv: list[str] | None = None) -> int:
         return 2
 
     queue = load_queue(args.queue_fixture)
-    result = run_once(
-        queue,
-        limit=args.limit,
-        photo_id=args.photo_id,
-        dry_run=True,
-        force=bool(args.force),
-        model_fixture=args.model_fixture,
-    )
+    provider = args.provider or args.model_adapter
+    try:
+        result = run_once(
+            queue,
+            limit=args.limit,
+            photo_id=args.photo_id,
+            dry_run=True,
+            force=bool(args.force),
+            model_fixture=args.model_fixture,
+            model_adapter=provider,
+        )
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
     print(json.dumps(result, indent=2, sort_keys=True))
     return 0

--- a/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/fixtures/mock_model_responses.json
+++ b/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/fixtures/mock_model_responses.json
@@ -1,6 +1,6 @@
 {
   "clean_profile_style": {
-    "verdict": "approved",
+    "verdict": "approve_recommendation",
     "confidence": 0.93,
     "reason_code": "clean_profile_style",
     "note": "Mock clean profile-style image; recommendation only.",

--- a/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/model.py
+++ b/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/model.py
@@ -1,9 +1,28 @@
 from __future__ import annotations
 
+import base64
 import json
+import mimetypes
+import os
+import re
+import subprocess
+import tempfile
+import urllib.error
+import urllib.request
 from pathlib import Path
+from typing import Any
 
 DEFAULT_MODEL_FIXTURE = Path(__file__).resolve().parent / "fixtures" / "mock_model_responses.json"
+DEFAULT_CODEX_MODEL_ROUTE = "gpt-5.5 + gpt-image-2 configured image route"
+DEFAULT_CODEX_MODEL = "gpt-5.5"
+DEFAULT_CODEX_ENDPOINT = "https://api.openai.com/v1/responses"
+DEFAULT_MINIMAX_MODEL = "minimax/MiniMax-VL-01"
+
+FINAL_TO_RECOMMENDATION_VERDICTS = {
+    "rejected": "reject_recommendation",
+    "reject": "reject_recommendation",
+}
+VALID_VERDICTS = {"approve_recommendation", "reject_recommendation", "review", "escalate"}
 
 
 class MockModelAdapter:
@@ -27,4 +46,307 @@ class MockModelAdapter:
             "darkness_score",
             "sharpness_edge_score",
         ]
-        return response
+        return normalize_model_result(response, default_model=response["vision_model_used"])
+
+
+class CodexOpenAIAdapter:
+    """Primary text-json image moderation adapter.
+
+    This sends image input for analysis only. It does not call Xano, does not call
+    /photos/decide, and does not generate images. Auth material is read from the
+    process environment and is never returned in reports.
+    """
+
+    provider = "codex-openai-image"
+    model_route = DEFAULT_CODEX_MODEL_ROUTE
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        endpoint: str = DEFAULT_CODEX_ENDPOINT,
+        model: str = DEFAULT_CODEX_MODEL,
+        timeout_seconds: int = 120,
+    ) -> None:
+        self.api_key = api_key or os.environ.get("CODEX_OPENAI_API_KEY") or os.environ.get("OPENAI_API_KEY")
+        self.endpoint = endpoint
+        self.model = model
+        self.timeout_seconds = timeout_seconds
+
+    def review(self, item: dict, deterministic_checks: dict) -> dict:
+        image_path = item.get("resolved_image_path") or item.get("local_fixture_path")
+        if not image_path:
+            return _manual_failure("missing_image_reference", DEFAULT_CODEX_MODEL_ROUTE, "No local image path was available for Codex/OpenAI review.")
+        if not self.api_key:
+            return _manual_failure("api_auth_unavailable", DEFAULT_CODEX_MODEL_ROUTE, "Codex/OpenAI auth was not available; manual review required.")
+
+        try:
+            image_url = _image_path_to_data_url(Path(image_path))
+            body = json.dumps(_codex_request_payload(self.model, image_url)).encode("utf-8")
+            request = urllib.request.Request(
+                self.endpoint,
+                data=body,
+                method="POST",
+                headers={
+                    "Authorization": f"Bearer {self.api_key}",
+                    "Content-Type": "application/json",
+                },
+            )
+            with urllib.request.urlopen(request, timeout=self.timeout_seconds) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+        except urllib.error.HTTPError as exc:
+            return _manual_failure("api_failure_fallback", DEFAULT_CODEX_MODEL_ROUTE, _safe_http_error_note(exc))
+        except Exception as exc:  # pragma: no cover - network/provider dependent
+            return _manual_failure("api_failure_fallback", DEFAULT_CODEX_MODEL_ROUTE, f"Codex/OpenAI route failed with {exc.__class__.__name__}; manual review required.")
+
+        return normalize_model_result(_extract_provider_json(payload), default_model=DEFAULT_CODEX_MODEL_ROUTE)
+
+
+class MiniMaxCLIAdapter:
+    """OpenClaw CLI vision adapter, fallback only."""
+
+    def __init__(self, model: str = DEFAULT_MINIMAX_MODEL, timeout_seconds: int = 120) -> None:
+        self.model = model
+        self.timeout_seconds = timeout_seconds
+
+    def review(self, item: dict, deterministic_checks: dict) -> dict:
+        image_path = item.get("resolved_image_path") or item.get("local_fixture_path")
+        if not image_path:
+            return _manual_failure("missing_image_reference", self.model, "No local image path was available for MiniMax CLI review.")
+
+        proc = subprocess.run(
+            ["openclaw", "infer", "image", "describe", "--model", self.model, "--file", str(image_path), "--json"],
+            check=False,
+            text=True,
+            capture_output=True,
+            timeout=self.timeout_seconds,
+        )
+        if proc.returncode != 0:
+            return _manual_failure("api_failure_fallback", self.model, f"MiniMax CLI exited with status {proc.returncode}; manual review required.", fallback="manual_review")
+
+        return normalize_minimax_description(_extract_text(proc.stdout), model=self.model)
+
+
+def normalize_minimax_description(description: str, *, model: str = DEFAULT_MINIMAX_MODEL) -> dict:
+    text = description.lower()
+    checks = _default_profile_checks(needs_human_review=True)
+    unsafe_categories: list[str] = []
+    verdict = "review"
+    reason_code = "manual_review_needed"
+    confidence = 0.55
+
+    if any(term in text for term in ["porn", "pornographic", "explicit", "genital", "sexual act", "intercourse", "masturbat", "nude", "nudity"]):
+        verdict = "reject_recommendation"
+        reason_code = "sexual_content"
+        confidence = 0.88
+        unsafe_categories = ["sexual_content"]
+    elif any(term in text for term in ["ai-generated", "ai generated", "generated image", "illustration", "cartoon", "anime", "drawing", "rendered"]):
+        reason_code = "ai_generated_image"
+        confidence = 0.78
+        unsafe_categories = ["ai_generated_image"]
+        checks["is_ai_generated"] = True
+    elif any(term in text for term in ["screenshot", "meme", "advertisement", "phone number", "email", "social media handle", "qr code"]):
+        reason_code = "contact_info_or_ad"
+        confidence = 0.74
+        unsafe_categories = ["contact_info_or_ad"]
+        checks["has_contact_info"] = True
+        checks["is_meme_or_screenshot"] = True
+    elif any(term in text for term in ["blurry", "dark", "unclear", "obscured", "low quality", "not visible"]):
+        reason_code = "low_quality_or_unusable"
+        confidence = 0.68
+        unsafe_categories = ["low_quality_or_unusable"]
+        checks["is_blank_or_unusable"] = True
+    elif any(term in text for term in ["person", "people", "man", "woman", "face", "portrait", "selfie", "individual", "subject"]):
+        verdict = "approve_recommendation"
+        reason_code = "clean_profile_style"
+        confidence = 0.82
+        checks["is_profile_style_photo"] = True
+        checks["needs_human_review"] = False
+    else:
+        reason_code = "not_a_profile_photo"
+        confidence = 0.62
+        unsafe_categories = ["not_a_profile_photo"]
+
+    return normalize_model_result(
+        {
+            "verdict": verdict,
+            "confidence": confidence,
+            "reason_code": reason_code,
+            "note": _safe_note_for_reason(reason_code),
+            "unsafe_categories": unsafe_categories,
+            "vision_model_used": f"{model} + parser",
+            "fallback_model": None,
+            "app_profile_photo_checks": checks,
+        },
+        default_model=f"{model} + parser",
+    )
+
+
+def normalize_model_result(result: dict, *, default_model: str) -> dict:
+    normalized = dict(result)
+    raw_verdict = str(normalized.get("verdict", "review")).lower()
+    normalized["verdict"] = FINAL_TO_RECOMMENDATION_VERDICTS.get(raw_verdict, raw_verdict)
+    normalized["normalization_applied"] = "yes" if normalized["verdict"] != raw_verdict else "no"
+    normalized.setdefault("confidence", 0.0)
+    normalized.setdefault("reason_code", "manual_review_needed")
+    normalized.setdefault("note", _safe_note_for_reason(normalized["reason_code"]))
+    normalized.setdefault("unsafe_categories", [])
+    normalized.setdefault("moderation_api_used", False)
+    normalized.setdefault("moderation_model", None)
+    normalized.setdefault("vision_model_used", default_model)
+    normalized.setdefault("fallback_model", None)
+    normalized.setdefault("image_generation_events", 0)
+    normalized.setdefault("output_type", "text_json")
+    normalized.setdefault("app_profile_photo_checks", _default_profile_checks(needs_human_review=True))
+    normalized["validator"] = "pass" if _is_valid_normalized_result(normalized) else "fail"
+    if normalized["validator"] == "fail":
+        normalized["verdict"] = "review"
+        normalized["reason_code"] = "manual_review_needed"
+        normalized["note"] = "Model output failed strict validation; manual review required."
+        normalized["validator"] = "fail"
+    return normalized
+
+
+def _is_valid_normalized_result(result: dict) -> bool:
+    return result.get("verdict") in VALID_VERDICTS and isinstance(result.get("unsafe_categories"), list)
+
+
+def _codex_request_payload(model: str, image_url: str) -> dict:
+    instructions = (
+        "Return only compact JSON for Anewluv profile photo moderation. "
+        "Use recommendation language only: approve_recommendation, reject_recommendation, review, or escalate. "
+        "Do not make final moderation decisions. Do not generate or edit images."
+    )
+    return {
+        "model": model,
+        "instructions": instructions,
+        "input": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "input_text", "text": "Classify this profile photo candidate and return strict JSON."},
+                    {"type": "input_image", "image_url": image_url},
+                ],
+            }
+        ],
+        "text": {"format": {"type": "json_object"}},
+    }
+
+
+def _image_path_to_data_url(path: Path) -> str:
+    if not path.exists():
+        raise FileNotFoundError(str(path))
+    send_path = path
+    mime = mimetypes.guess_type(path.name)[0]
+    if path.suffix.lower() == ".ppm" or mime not in {"image/jpeg", "image/png", "image/webp", "image/gif"}:
+        send_path = _convert_to_png(path)
+        mime = "image/png"
+    encoded = base64.b64encode(send_path.read_bytes()).decode("ascii")
+    return f"data:{mime};base64,{encoded}"
+
+
+def _convert_to_png(path: Path) -> Path:
+    from PIL import Image
+
+    with Image.open(path) as image:
+        tmp = tempfile.NamedTemporaryFile(prefix="photo-sweeper-", suffix=".png", delete=False)
+        tmp_path = Path(tmp.name)
+        tmp.close()
+        image.save(tmp_path, format="PNG")
+    return tmp_path
+
+
+def _extract_provider_json(payload: dict) -> dict:
+    text = payload.get("output_text") or "\n".join(_strings(payload))
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        return {"verdict": "review", "reason_code": "manual_review_needed", "note": "Provider returned non-JSON text; manual review required.", "vision_model_used": DEFAULT_CODEX_MODEL_ROUTE}
+    if isinstance(parsed, dict):
+        parsed.setdefault("vision_model_used", DEFAULT_CODEX_MODEL_ROUTE)
+        return parsed
+    return {"verdict": "review", "reason_code": "manual_review_needed", "vision_model_used": DEFAULT_CODEX_MODEL_ROUTE}
+
+
+def _manual_failure(reason_code: str, model: str, note: str, *, fallback: str | None = None) -> dict:
+    return normalize_model_result(
+        {
+            "verdict": "review",
+            "confidence": 0.0,
+            "reason_code": reason_code,
+            "note": note,
+            "unsafe_categories": [],
+            "vision_model_used": model,
+            "fallback_model": fallback,
+            "app_profile_photo_checks": _default_profile_checks(needs_human_review=True),
+        },
+        default_model=model,
+    )
+
+
+def _safe_http_error_note(exc: urllib.error.HTTPError) -> str:
+    try:
+        body = exc.read(512).decode("utf-8", errors="replace")
+    except Exception:
+        body = ""
+    redacted = _redact_provider_error_body(body)
+    return f"Codex/OpenAI route returned HTTP {exc.code} {exc.__class__.__name__}; manual review required. Body snippet: {redacted[:240]}"
+
+
+def _redact_provider_error_body(body: str) -> str:
+    redacted = body
+    for value in (os.environ.get("CODEX_OPENAI_API_KEY"), os.environ.get("OPENAI_API_KEY")):
+        if value:
+            redacted = redacted.replace(value, "[redacted]")
+    redacted = re.sub(r"Bearer\s+[A-Za-z0-9._~+/=-]+", "Bearer [redacted]", redacted, flags=re.IGNORECASE)
+    redacted = re.sub(r"https?://[^\s'\"<>]+", "[redacted-url]", redacted)
+    redacted = re.sub(r"(?i)(authorization|api[_-]?key|access[_-]?token|refresh[_-]?token|oauth|session)(['\"\s:=]+)[^,}\]\s]+", r"\1\2[redacted]", redacted)
+    return redacted
+
+
+def _extract_text(stdout: str) -> str:
+    try:
+        parsed = json.loads(stdout)
+    except json.JSONDecodeError:
+        return stdout
+    return "\n".join(_strings(parsed))
+
+
+def _strings(value: Any):
+    if isinstance(value, str):
+        yield value
+    elif isinstance(value, dict):
+        for child in value.values():
+            yield from _strings(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from _strings(child)
+
+
+def _default_profile_checks(*, needs_human_review: bool) -> dict:
+    return {
+        "is_profile_style_photo": False,
+        "has_contact_info": False,
+        "is_meme_or_screenshot": False,
+        "is_blank_or_unusable": False,
+        "is_ai_generated": False,
+        "needs_human_review": needs_human_review,
+    }
+
+
+def _safe_note_for_reason(reason_code: str) -> str:
+    notes = {
+        "clean_profile_style": "AI recommends approval as profile-style image; human/admin workflow remains final.",
+        "sexual_content": "AI recommends rejection/escalation for possible sexual content; human/admin workflow remains final.",
+        "nudity": "AI recommends rejection/escalation for possible nudity; human/admin workflow remains final.",
+        "pornographic_explicit": "AI recommends rejection/escalation for possible explicit content; human/admin workflow remains final.",
+        "inappropriate_photos": "AI recommends rejection/escalation for possible inappropriate photo content; human/admin workflow remains final.",
+        "ai_generated_image": "AI recommends manual review for possible AI-generated image.",
+        "contact_info_or_ad": "AI recommends manual review for possible contact info, screenshot, or advertisement.",
+        "low_quality_or_unusable": "AI recommends manual review for low-quality or unusable image.",
+        "not_a_profile_photo": "AI recommends manual review because the image may not be a profile photo.",
+        "api_failure_fallback": "Vision path failed; manual review required.",
+        "api_auth_unavailable": "Vision auth unavailable; manual review required.",
+        "missing_image_reference": "Image reference missing; manual review required.",
+    }
+    return notes.get(reason_code, "AI recommends manual review; human/admin workflow remains final.")

--- a/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/policy.py
+++ b/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/policy.py
@@ -13,18 +13,20 @@ def combine(item: dict, checks: dict, model_result: dict, *, dry_run: bool, forc
     planned_action = "manual_review"
     recommended_decision = None
 
-    if not checks.get("image_reference_present") or checks.get("exists") is False:
+    if model_result.get("validator") == "fail":
+        planned_action = "manual_review"
+    elif not checks.get("image_reference_present") or checks.get("exists") is False:
         planned_action = "leave_pending"
         recommended_decision = None
-    elif verdict == "approved" and reason in REPORT_ONLY_REASONS and _checks_pass(checks) and _profile_clean(flags):
+    elif verdict == "approve_recommendation" and reason in REPORT_ONLY_REASONS and _checks_pass(checks) and _profile_clean(flags):
         planned_action = "report_only"
-        recommended_decision = "approve"
-    elif verdict == "rejected" and reason in EXPLICIT_REASONS:
+        recommended_decision = "approve_recommendation"
+    elif verdict == "reject_recommendation" and reason in EXPLICIT_REASONS:
         planned_action = "escalate"
-        recommended_decision = "reject"
-    elif verdict == "rejected":
+        recommended_decision = "reject_recommendation"
+    elif verdict == "reject_recommendation":
         planned_action = "manual_review"
-        recommended_decision = "reject"
+        recommended_decision = "reject_recommendation"
     elif verdict == "escalate" or reason in EXPLICIT_REASONS:
         planned_action = "escalate"
     elif verdict == "review" or warnings:
@@ -32,7 +34,6 @@ def combine(item: dict, checks: dict, model_result: dict, *, dry_run: bool, forc
 
     return {
         "photo_id": item["photo_id"],
-        "user_id": item.get("user_id"),
         "queue_source": item.get("queue_source", "local_redacted_fixture"),
         "dry_run": True,
         "force_requested": force,

--- a/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/runner.py
+++ b/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/runner.py
@@ -3,8 +3,13 @@ from __future__ import annotations
 from pathlib import Path
 
 from .deterministic import inspect_image
-from .model import MockModelAdapter
+from .model import CodexOpenAIAdapter, MiniMaxCLIAdapter, MockModelAdapter
 from .policy import combine
+
+CODEX_OPENAI_ADAPTER_NAMES = {"codex-openai-image", "codex-openai", "openclaw-codex-openai", "primary"}
+OPENAI_MODERATIONS_ADAPTER_NAMES = {"openai-moderations"}
+MINIMAX_FALLBACK_ADAPTER_NAMES = {"minimax-cli", "minimax-fallback", "minimax-vl"}
+OPENROUTER_ADAPTER_NAMES = {"openrouter-multimodal"}
 
 
 def run_once(
@@ -15,9 +20,10 @@ def run_once(
     dry_run: bool,
     force: bool,
     model_fixture: Path | None,
+    model_adapter: str = "mock",
 ) -> dict:
     selected = _select(queue, limit=limit, photo_id=photo_id)
-    adapter = MockModelAdapter(model_fixture)
+    adapter = _build_adapter(model_adapter, model_fixture)
     photos = []
 
     for item in selected:
@@ -29,6 +35,7 @@ def run_once(
         "dry_run": True,
         "write_enabled": False,
         "force_requested": force,
+        **_provider_report(model_adapter),
         "photos_scanned": len(photos),
         "photos": photos,
         "summary": _summary(photos),
@@ -55,8 +62,50 @@ def _summary(photos: list[dict]) -> dict:
         "report_only": sum(1 for item in photos if item["planned_action"] == "report_only"),
         "leave_pending": sum(1 for item in photos if item["planned_action"] == "leave_pending"),
         "failures": [],
-        "model_api_path_used": ["mock_fixture"] if photos else [],
-        "fallback_usage": 0,
+        "model_api_path_used": sorted({item["model_path"]["vision_model_used"] for item in photos}) if photos else [],
+        "fallback_usage": sum(1 for item in photos if item["model_path"].get("fallback_model")),
         "next_scheduled_run": None,
         "unresolved_escalations": sum(1 for item in photos if item["planned_action"] == "escalate"),
+    }
+
+
+def _build_adapter(model_adapter: str, model_fixture: Path | None):
+    normalized = model_adapter.strip().lower()
+    if normalized == "mock":
+        return MockModelAdapter(model_fixture)
+    if normalized in CODEX_OPENAI_ADAPTER_NAMES:
+        return CodexOpenAIAdapter()
+    if normalized in OPENAI_MODERATIONS_ADAPTER_NAMES:
+        raise ValueError("openai-moderations adapter is not available in this checkout")
+    if normalized in MINIMAX_FALLBACK_ADAPTER_NAMES:
+        return MiniMaxCLIAdapter()
+    if normalized in OPENROUTER_ADAPTER_NAMES:
+        raise ValueError("openrouter-multimodal adapter is not available in this checkout")
+    raise ValueError(f"unsupported model_adapter: {model_adapter}")
+
+
+def _provider_report(model_adapter: str) -> dict:
+    normalized = model_adapter.strip().lower()
+    if normalized in CODEX_OPENAI_ADAPTER_NAMES:
+        provider = "codex-openai-image"
+        model_route = "gpt-5.5 + gpt-image-2 configured image route"
+    elif normalized in OPENAI_MODERATIONS_ADAPTER_NAMES:
+        provider = "openai-moderations"
+        model_route = "openai-moderations"
+    elif normalized in MINIMAX_FALLBACK_ADAPTER_NAMES:
+        provider = "minimax-cli"
+        model_route = "minimax-vl"
+    elif normalized in OPENROUTER_ADAPTER_NAMES:
+        provider = "openrouter-multimodal"
+        model_route = "openrouter-multimodal"
+    else:
+        provider = "mock"
+        model_route = "mock_fixture"
+    return {
+        "provider": provider,
+        "model_route": model_route,
+        "image_generation_events": 0,
+        "output_type": "text_json",
+        "writes": False,
+        "/photos/decide": "not called",
     }

--- a/Pryan-Fire/projects/backend/anewluv-photo-moderation/tests/test_smoke.py
+++ b/Pryan-Fire/projects/backend/anewluv-photo-moderation/tests/test_smoke.py
@@ -2,33 +2,44 @@ import json
 import subprocess
 import sys
 import unittest
+from unittest import mock
 
+from photo_sweeper.model import (
+    CodexOpenAIAdapter,
+    MiniMaxCLIAdapter,
+    _codex_request_payload,
+    _image_path_to_data_url,
+    _redact_provider_error_body,
+    normalize_minimax_description,
+    normalize_model_result,
+)
 from photo_sweeper.queue import load_queue
 from photo_sweeper.runner import run_once
 
 
-def run_cli(*args):
+def run_cli(*args, check=True):
     proc = subprocess.run(
         [sys.executable, "-m", "photo_sweeper", *args],
-        check=True,
+        check=check,
         text=True,
         capture_output=True,
     )
-    return proc.stdout
+    return proc
 
 
 class PhotoSweeperSmokeTests(unittest.TestCase):
     def test_cli_limit_works_and_redacts_email(self):
-        output = run_cli("--once", "--dry-run", "--limit", "2")
+        output = run_cli("--once", "--dry-run", "--limit", "2").stdout
         payload = json.loads(output)
 
         self.assertIs(payload["dry_run"], True)
         self.assertIs(payload["write_enabled"], False)
         self.assertEqual(payload["photos_scanned"], 2)
         self.assertNotIn("user_email", output)
+        self.assertNotIn("user_id", output)
 
     def test_photo_id_force_does_not_enable_writes(self):
-        output = run_cli("--once", "--photo-id", "101", "--force")
+        output = run_cli("--once", "--photo-id", "101", "--force").stdout
         payload = json.loads(output)
 
         self.assertIs(payload["force_requested"], True)
@@ -48,7 +59,7 @@ class PhotoSweeperSmokeTests(unittest.TestCase):
         ]
 
         self.assertEqual({item["planned_action"] for item in explicit}, {"escalate"})
-        self.assertEqual({item["recommended_decision"] for item in explicit}, {"reject"})
+        self.assertEqual({item["recommended_decision"] for item in explicit}, {"reject_recommendation"})
         self.assertTrue(all(item["would_finalize_decision"] is False for item in explicit))
         self.assertTrue(all(item["would_write_recommendation"] is False for item in explicit))
 
@@ -76,7 +87,7 @@ class PhotoSweeperSmokeTests(unittest.TestCase):
         self.assertTrue(all(item["would_write_recommendation"] is False for item in result["photos"]))
 
     def test_api_failure_fallback_becomes_manual_review_without_writes(self):
-        output = run_cli("--once", "--photo-id", "110", "--dry-run")
+        output = run_cli("--once", "--photo-id", "110", "--dry-run").stdout
         payload = json.loads(output)
         photo = payload["photos"][0]
 
@@ -88,15 +99,150 @@ class PhotoSweeperSmokeTests(unittest.TestCase):
         self.assertIs(photo["would_finalize_decision"], False)
 
     def test_clean_fixture_can_recommend_approve_without_final_decision_or_write(self):
-        output = run_cli("--once", "--photo-id", "101", "--dry-run")
+        output = run_cli("--once", "--photo-id", "101", "--dry-run").stdout
         payload = json.loads(output)
         photo = payload["photos"][0]
 
-        self.assertEqual(photo["normalized_result"]["verdict"], "approved")
-        self.assertEqual(photo["recommended_decision"], "approve")
+        self.assertEqual(photo["normalized_result"]["verdict"], "approve_recommendation")
+        self.assertEqual(photo["recommended_decision"], "approve_recommendation")
         self.assertEqual(photo["planned_action"], "report_only")
         self.assertIs(photo["would_write_recommendation"], False)
         self.assertIs(photo["would_finalize_decision"], False)
+
+    def test_normalizer_only_reject_side_final_terms_are_normalized(self):
+        approved = normalize_model_result({"verdict": "approved"}, default_model="fixture")
+        approve = normalize_model_result({"verdict": "approve"}, default_model="fixture")
+        reject = normalize_model_result({"verdict": "reject"}, default_model="fixture")
+        unknown = normalize_model_result({"verdict": "ship_it"}, default_model="fixture")
+
+        self.assertEqual(approved["validator"], "fail")
+        self.assertEqual(approved["verdict"], "review")
+        self.assertEqual(approved["normalization_applied"], "no")
+        self.assertEqual(approve["validator"], "fail")
+        self.assertEqual(approve["verdict"], "review")
+        self.assertEqual(approve["normalization_applied"], "no")
+        self.assertEqual(reject["verdict"], "reject_recommendation")
+        self.assertEqual(reject["normalization_applied"], "yes")
+        self.assertEqual(reject["validator"], "pass")
+        self.assertEqual(unknown["validator"], "fail")
+        self.assertEqual(unknown["verdict"], "review")
+
+    def test_codex_provider_report_fields_are_zero_write_text_json(self):
+        queue = load_queue()
+        with mock.patch.dict("os.environ", {"CODEX_OPENAI_API_KEY": "", "OPENAI_API_KEY": ""}, clear=False):
+            result = run_once(queue, limit=1, photo_id=None, dry_run=True, force=False, model_fixture=None, model_adapter="codex-openai-image")
+
+        self.assertEqual(result["provider"], "codex-openai-image")
+        self.assertEqual(result["model_route"], "gpt-5.5 + gpt-image-2 configured image route")
+        self.assertEqual(result["image_generation_events"], 0)
+        self.assertEqual(result["output_type"], "text_json")
+        self.assertIs(result["writes"], False)
+        self.assertEqual(result["/photos/decide"], "not called")
+        self.assertIs(result["write_enabled"], False)
+        self.assertEqual(result["photos"][0]["normalized_result"]["reason_code"], "api_auth_unavailable")
+
+    def test_provider_error_redaction_removes_tokens_sessions_and_signed_urls(self):
+        signed_marker = "X-Amz-" + "Signature"
+        body = (
+            "Authorization: Bearer secret-token session=abc oauth=value "
+            + "https://"
+            + "cdn.example/image.jpg?"
+            + signed_marker
+            + "=leak"
+        )
+        redacted = _redact_provider_error_body(body)
+
+        self.assertNotIn("secret-token", redacted)
+        self.assertNotIn("abc", redacted)
+        self.assertNotIn("oauth=value", redacted)
+        self.assertNotIn(signed_marker, redacted)
+        self.assertIn("[redacted-url]", redacted)
+
+    def test_provider_order_names_are_accepted_or_fail_closed_without_live_calls(self):
+        self.assertEqual(json.loads(run_cli("--once", "--provider", "mock", "--limit", "1").stdout)["provider"], "mock")
+
+        proc = run_cli("--once", "--provider", "openai-moderations", "--limit", "1", check=False)
+        self.assertEqual(proc.returncode, 2)
+        self.assertIn("not available", proc.stderr)
+
+        proc = run_cli("--once", "--provider", "openrouter-multimodal", "--limit", "1", check=False)
+        self.assertEqual(proc.returncode, 2)
+        self.assertIn("not available", proc.stderr)
+
+    def test_codex_payload_has_instructions_and_no_image_generation_request(self):
+        payload = _codex_request_payload("gpt-5.5", "data:image/png;base64,abc")
+        self.assertIn("instructions", payload)
+        self.assertEqual(payload["model"], "gpt-5.5")
+        dumped = json.dumps(payload)
+        self.assertIn("input_image", dumped)
+        self.assertNotIn("image_generation", dumped.lower())
+
+    def test_ppm_fixture_converts_to_png_data_url(self):
+        queue = load_queue()
+        ppm = queue[0]["local_fixture_path"]
+        data_url = _image_path_to_data_url(__import__("pathlib").Path(ppm))
+        self.assertTrue(data_url.startswith("data:image/png;base64,"))
+
+    def test_codex_adapter_parses_mocked_provider_without_printing_auth(self):
+        class FakeResponse:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+            def read(self):
+                return json.dumps(
+                    {
+                        "output_text": json.dumps(
+                            {
+                                "verdict": "reject",
+                                "confidence": 0.91,
+                                "reason_code": "sexual_content",
+                                "unsafe_categories": ["sexual_content"],
+                            }
+                        )
+                    }
+                ).encode("utf-8")
+
+        seen = {}
+
+        def fake_urlopen(request, timeout):
+            seen["authorization"] = request.headers.get("Authorization")
+            seen["body"] = request.data.decode("utf-8")
+            return FakeResponse()
+
+        queue = load_queue()
+        with mock.patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            result = CodexOpenAIAdapter(api_key="unit_test_key").review(queue[0], {})
+
+        self.assertEqual(result["verdict"], "reject_recommendation")
+        self.assertEqual(result["normalization_applied"], "yes")
+        self.assertEqual(result["validator"], "pass")
+        self.assertTrue(seen["authorization"].startswith("Bearer "))
+        self.assertIn('"instructions"', seen["body"])
+        self.assertNotIn("unit_test_key", json.dumps(result))
+
+    def test_minimax_parser_outputs_recommendation_language(self):
+        result = normalize_minimax_description("A clear portrait of a person smiling outdoors.")
+
+        self.assertEqual(result["verdict"], "approve_recommendation")
+        self.assertEqual(result["reason_code"], "clean_profile_style")
+        self.assertIn("+ parser", result["vision_model_used"])
+
+    def test_minimax_cli_adapter_parses_subprocess_output_without_raw_dump(self):
+        completed = subprocess.CompletedProcess(
+            args=["openclaw"],
+            returncode=0,
+            stdout=json.dumps({"description": "A blurry dark image where the person is not visible."}),
+            stderr="",
+        )
+        with mock.patch("subprocess.run", return_value=completed):
+            result = MiniMaxCLIAdapter().review({"local_fixture_path": "/tmp/fake.jpg"}, {})
+
+        self.assertEqual(result["verdict"], "review")
+        self.assertEqual(result["reason_code"], "low_quality_or_unusable")
+        self.assertEqual(result["vision_model_used"], "minimax/MiniMax-VL-01 + parser")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Adds the read-only `codex-openai-image` adapter path for ANewLuv photo moderation.
- Documents the worker/API identity boundary: API enforces identity, worker presents required seals, no local authority reconstruction, no single-seal bypass.
- Keeps OpenAI image-2 usage scoped to image-input analysis/moderation, not image generation.

## Scope
```txt
source: feat/anewluv-codex-openai-adapter
base: feat/anewluv-photo-moderation-worker
commit: 0b702c893
provider: codex-openai-image
model_route: gpt-5.5 + gpt-image-2 configured image route
endpoint: /v1/responses
image_generation_events: 0
```

## Safety / Non-goals
- No `/photos/decide` write path.
- No Xano queue writes/provider writes.
- No `/v1/images` generation lane.
- No Paithan local sketch included.

## Validation
- Local sealed branch was clean before push.
- Explicit refspec push completed and remote branch is up-to-date.
- Final moved-file scope confirmed before push.
