### PR TITLE
fix(anewluv): address codex adapter review leaks

### DIFF
--- a/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/model.py
+++ b/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/model.py
@@ -237,11 +237,17 @@ def _image_path_to_data_url(path: Path) -> str:
     if not path.exists():
         raise FileNotFoundError(str(path))
     send_path = path
+    converted_path: Path | None = None
     mime = mimetypes.guess_type(path.name)[0]
     if path.suffix.lower() == ".ppm" or mime not in {"image/jpeg", "image/png", "image/webp", "image/gif"}:
         send_path = _convert_to_png(path)
+        converted_path = send_path
         mime = "image/png"
-    encoded = base64.b64encode(send_path.read_bytes()).decode("ascii")
+    try:
+        encoded = base64.b64encode(send_path.read_bytes()).decode("ascii")
+    finally:
+        if converted_path is not None:
+            converted_path.unlink(missing_ok=True)
     return f"data:{mime};base64,{encoded}"
 
 
@@ -257,7 +263,7 @@ def _convert_to_png(path: Path) -> Path:
 
 
 def _extract_provider_json(payload: dict) -> dict:
-    text = payload.get("output_text") or "\n".join(_strings(payload))
+    text = _extract_provider_text(payload)
     try:
         parsed = json.loads(text)
     except json.JSONDecodeError:
@@ -266,6 +272,24 @@ def _extract_provider_json(payload: dict) -> dict:
         parsed.setdefault("vision_model_used", DEFAULT_CODEX_MODEL_ROUTE)
         return parsed
     return {"verdict": "review", "reason_code": "manual_review_needed", "vision_model_used": DEFAULT_CODEX_MODEL_ROUTE}
+
+
+def _extract_provider_text(payload: dict) -> str:
+    output_text = payload.get("output_text")
+    if isinstance(output_text, str):
+        return output_text
+
+    text_parts: list[str] = []
+    for item in payload.get("output") or []:
+        if not isinstance(item, dict):
+            continue
+        for content in item.get("content") or []:
+            if not isinstance(content, dict):
+                continue
+            if content.get("type") in {"output_text", "text"} and isinstance(content.get("text"), str):
+                text_parts.append(content["text"])
+
+    return "\n".join(text_parts)
 
 
 def _manual_failure(reason_code: str, model: str, note: str, *, fallback: str | None = None) -> dict:

--- a/Pryan-Fire/projects/backend/anewluv-photo-moderation/tests/test_smoke.py
+++ b/Pryan-Fire/projects/backend/anewluv-photo-moderation/tests/test_smoke.py
@@ -1,7 +1,9 @@
 import json
 import subprocess
 import sys
+import tempfile
 import unittest
+from pathlib import Path
 from unittest import mock
 
 from photo_sweeper.model import (
@@ -222,6 +224,60 @@ class PhotoSweeperSmokeTests(unittest.TestCase):
         self.assertTrue(seen["authorization"].startswith("Bearer "))
         self.assertIn('"instructions"', seen["body"])
         self.assertNotIn("unit_test_key", json.dumps(result))
+
+    def test_codex_openai_adapter_parses_raw_responses_output_items(self):
+        class FakeResponse:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+            def read(self):
+                return json.dumps(
+                    {
+                        "id": "resp_noise_that_must_not_be_parsed",
+                        "status": "completed",
+                        "output": [
+                            {
+                                "type": "message",
+                                "content": [
+                                    {
+                                        "type": "output_text",
+                                        "text": json.dumps(
+                                            {
+                                                "verdict": "approve_recommendation",
+                                                "confidence": 0.88,
+                                                "reason_code": "clean_profile_style",
+                                                "unsafe_categories": [],
+                                            }
+                                        ),
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                ).encode("utf-8")
+
+        with mock.patch("urllib.request.urlopen", return_value=FakeResponse()):
+            result = CodexOpenAIAdapter(api_key="unit_test_key").review(load_queue()[0], {})
+
+        self.assertEqual(result["verdict"], "approve_recommendation")
+        self.assertEqual(result["reason_code"], "clean_profile_style")
+        self.assertEqual(result["validator"], "pass")
+
+    def test_image_data_url_removes_converted_temp_png(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source = Path(tmpdir) / "source.ppm"
+            source.write_text("P3\n1 1\n255\n255 255 255\n", encoding="utf-8")
+            converted = Path(tmpdir) / "converted.png"
+            converted.write_bytes(b"png-bytes")
+
+            with mock.patch("photo_sweeper.model._convert_to_png", return_value=converted):
+                data_url = _image_path_to_data_url(source)
+
+            self.assertTrue(data_url.startswith("data:image/png;base64,"))
+            self.assertFalse(converted.exists())
 
     def test_minimax_parser_outputs_recommendation_language(self):
         result = normalize_minimax_description("A clear portrait of a person smiling outdoors.")


### PR DESCRIPTION
## Summary
- Fixes Codex review P1: parse raw OpenAI `/v1/responses` output item text instead of concatenating every string in the response object.
- Fixes Codex review P2: delete converted temp PNGs after data URL encoding.
- Adds regression tests for both review comments.

## Validation
```txt
/tmp/photo-sweeper-pr331-venv/bin/python -m pytest Pryan-Fire/projects/backend/anewluv-photo-moderation/tests/test_smoke.py -q
17 passed in 1.17s
```

## Scope
```txt
base: feat/anewluv-photo-moderation-worker
head: fix/anewluv-codex-review-cleanups
commit: 68ae74c2e
```
