### PR TITLE
fix(anewluv): trim OpenAI adapter auth key

### DIFF
--- a/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/model.py
+++ b/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/model.py
@@ -68,7 +68,8 @@ class CodexOpenAIAdapter:
         model: str = DEFAULT_CODEX_MODEL,
         timeout_seconds: int = 120,
     ) -> None:
-        self.api_key = api_key or os.environ.get("CODEX_OPENAI_API_KEY") or os.environ.get("OPENAI_API_KEY")
+        raw_api_key = api_key or os.environ.get("CODEX_OPENAI_API_KEY") or os.environ.get("OPENAI_API_KEY")
+        self.api_key = raw_api_key.strip() if raw_api_key else None
         self.endpoint = endpoint
         self.model = model
         self.timeout_seconds = timeout_seconds

--- a/Pryan-Fire/projects/backend/anewluv-photo-moderation/tests/test_smoke.py
+++ b/Pryan-Fire/projects/backend/anewluv-photo-moderation/tests/test_smoke.py
@@ -185,6 +185,11 @@ class PhotoSweeperSmokeTests(unittest.TestCase):
         data_url = _image_path_to_data_url(__import__("pathlib").Path(ppm))
         self.assertTrue(data_url.startswith("data:image/png;base64,"))
 
+    def test_codex_openai_adapter_strips_env_key_whitespace(self):
+        adapter = CodexOpenAIAdapter(api_key=" unit_test_key\r\n")
+
+        self.assertEqual(adapter.api_key, "unit_test_key")
+
     def test_codex_adapter_parses_mocked_provider_without_printing_auth(self):
         class FakeResponse:
             def __enter__(self):


### PR DESCRIPTION
## Summary
- Trims whitespace from env-loaded Codex/OpenAI adapter API keys before building the Authorization header.
- Adds a regression test for CR/LF padded key values.

## Validation
```txt
/tmp/photo-sweeper-pr331-venv/bin/python -m pytest Pryan-Fire/projects/backend/anewluv-photo-moderation/tests/test_smoke.py -q
18 passed in 1.32s
```

## Live smoke finding
The zero-write provider smoke reached adapter auth construction but failed before the provider call because the env-loaded key had trailing whitespace. No production writes were attempted.
