### PR TITLE
fix: harden post-close asset accounting

### DIFF
--- a/Pryan-Fire/hughs-forge/scripts/automation_engine.py
+++ b/Pryan-Fire/hughs-forge/scripts/automation_engine.py
@@ -512,39 +512,29 @@ def handle_auto_execute(wallet_name: str, trigger: Dict, config: Dict, state: Di
     tracker["last_attempt_at"] = datetime.utcnow().isoformat() + "Z"
     success = execute_position_close(wallet_name, trigger, config, state)
     execution_result = trigger.get("_execution_result", {})
+    execution_record = {
+        "status": "executed" if success else "failed",
+        "trigger_type": trigger_type,
+        "pnl_pct": pnl_pct,
+        "pool_name": pool_name,
+        "signatures": execution_result.get("signatures", []),
+        "close_signatures": execution_result.get("close_signatures", []),
+        "swap_signatures": execution_result.get("swap_signatures", []),
+        "post_close_swap": execution_result.get("post_close_swap"),
+        "dry_run": execution_result.get("dry_run", False),
+    }
     if success:
-        automation_state.setdefault("executions", {})[pubkey] = {
-            "status": "executed",
-            "executed_at": datetime.utcnow().isoformat() + "Z",
-            "trigger_type": trigger_type,
-            "pnl_pct": pnl_pct,
-            "pool_name": pool_name,
-            "signatures": execution_result.get("signatures", []),
-            "close_signatures": execution_result.get("close_signatures", []),
-            "swap_signatures": execution_result.get("swap_signatures", []),
-            "post_close_swap": execution_result.get("post_close_swap"),
-            "dry_run": execution_result.get("dry_run", False),
-        }
-        tracker["executed_at"] = datetime.utcnow().isoformat() + "Z"
+        execution_record["executed_at"] = datetime.utcnow().isoformat() + "Z"
+        automation_state.setdefault("executions", {})[pubkey] = execution_record
+        tracker["executed_at"] = execution_record["executed_at"]
         del exec_tracker[pubkey]
     else:
+        execution_record["failed_at"] = datetime.utcnow().isoformat() + "Z"
+        execution_record["error"] = execution_result.get("error", "close_failed")
+        automation_state.setdefault("executions", {})[pubkey] = execution_record
         tracker["last_status"] = "failed"
-        tracker["last_error"] = execution_result.get("error", "close_failed")
+        tracker["last_error"] = execution_record["error"]
         tracker["pool_name"] = pool_name
-        if execution_result.get("close_signatures") or execution_result.get("post_close_swap"):
-            automation_state.setdefault("executions", {})[pubkey] = {
-                "status": "failed",
-                "failed_at": datetime.utcnow().isoformat() + "Z",
-                "trigger_type": trigger_type,
-                "pnl_pct": pnl_pct,
-                "pool_name": pool_name,
-                "error": execution_result.get("error", "close_failed"),
-                "signatures": execution_result.get("signatures", []),
-                "close_signatures": execution_result.get("close_signatures", []),
-                "swap_signatures": execution_result.get("swap_signatures", []),
-                "post_close_swap": execution_result.get("post_close_swap"),
-                "dry_run": execution_result.get("dry_run", False),
-            }
     return success
 
 

--- a/Pryan-Fire/hughs-forge/services/meteora-trader/scripts/close-position.mjs
+++ b/Pryan-Fire/hughs-forge/services/meteora-trader/scripts/close-position.mjs
@@ -11,7 +11,6 @@ import { createRequire } from 'node:module';
 const require = createRequire(import.meta.url);
 
 const USDC_MINT = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
-const SOL_MINT = 'So11111111111111111111111111111111111111112';
 
 function loadSolanaDeps() {
   const { Connection, Keypair, PublicKey, sendAndConfirmTransaction } = require('@solana/web3.js');
@@ -74,11 +73,11 @@ async function tokenBalanceAtoms(connection, owner, mintAddress, PublicKey) {
 async function snapshotBalances(connection, owner, assets, PublicKey) {
   const balances = {};
   for (const asset of assets) {
-    if (asset.mint === SOL_MINT) {
-      balances[asset.mint] = BigInt(await connection.getBalance(owner, 'confirmed'));
-    } else {
-      balances[asset.mint] = await tokenBalanceAtoms(connection, owner, asset.mint, PublicKey);
-    }
+    // DLMM positions use SPL token accounts. The SOL_MINT address represents
+    // wrapped SOL (WSOL), not native lamports; native wallet balance includes
+    // rent refunds, fees, and unrelated SOL movement, so it must not feed the
+    // post-close swap amount.
+    balances[asset.mint] = await tokenBalanceAtoms(connection, owner, asset.mint, PublicKey);
   }
   return balances;
 }


### PR DESCRIPTION
## Summary
Follow-up hardening after PR #324 merged while the fresh Codex review surfaced one P1 and one auditability cleanup:

- Treat WSOL as an SPL token-account balance, not native wallet lamports, when deriving post-close swap amounts.
- Persist every auto-execute attempt result under `automation.executions`, including failed attempts, so close signatures / unswapped assets are durable and obvious.

## Why
Native SOL balance includes rent refunds, transaction fees, and unrelated SOL movement. Using it as the WSOL swap amount can produce bogus post-close swap payloads. The close→swap path must account only for token-account deltas.

## Tests
- `python3 -m pytest Pryan-Fire/hughs-forge/scripts/test_automation_engine.py -q` — 32 passed
- `python3 -m pytest Pryan-Fire/hughs-forge/services/trade-orchestrator/tests/test_rpc_integration.py -q` — 15 passed
- `node --check Pryan-Fire/hughs-forge/services/meteora-trader/scripts/close-position.mjs`
- `node --check Pryan-Fire/hughs-forge/services/meteora-trader/scripts/ultra-swap.mjs`
- `git diff --check`

Guardrails unchanged: no live defaults changed; dry-run/fail-closed behavior remains intact.

Follow-up to #293 / #324.
