### PR TITLE
#319 add photo sweeper cron lock and idempotency

### DIFF
--- a/Pryan-Fire/projects/backend/anewluv-photo-moderation/README.md
+++ b/Pryan-Fire/projects/backend/anewluv-photo-moderation/README.md
@@ -96,6 +96,8 @@ photo-sweeper --once --photo-id <id> --dry-run
 photo-sweeper --once --photo-id <id> --force
 ```
 
+Live-write cron runs must use the overlap lock and capped limit. The default live lock is `/tmp/anewluv-photo-sweeper.lock`; do not pass `--no-lock` outside tests. Cron install and rollback notes for #319 are in `docs/cron-lock-idempotency-2026-05-01.md`.
+
 Without installing, use:
 
 ```bash
@@ -103,6 +105,8 @@ PYTHONPATH=src python3 -m photo_sweeper --once --dry-run --limit 10
 PYTHONPATH=src python3 -m photo_sweeper --once --photo-id 101 --dry-run
 PYTHONPATH=src python3 -m photo_sweeper --once --photo-id 101 --force
 ```
+
+Cron cadence for live capped execution is documented as `*/30 * * * *` after owner approval.
 
 The default queue source is `src/photo_sweeper/fixtures/queue_redacted.json`. Queue items are normalized before output, and `user_email` is omitted from CLI output.
 

--- a/Pryan-Fire/projects/backend/anewluv-photo-moderation/docs/cron-lock-idempotency-2026-05-01.md
+++ b/Pryan-Fire/projects/backend/anewluv-photo-moderation/docs/cron-lock-idempotency-2026-05-01.md
@@ -1,0 +1,83 @@
+# Cron Lock + Idempotency (#319)
+
+## Scope
+
+This pass seals the worker against overlapping cron runs and duplicate photo processing before escalation or autonomous review gets more authority.
+
+## Cron schedule
+
+Run every 30 minutes:
+
+```cron
+*/30 * * * * cd /data/repos/The-Nexus/Pryan-Fire/projects/backend/anewluv-photo-moderation && /usr/bin/env PYTHONPATH=src photo-sweeper --once --live-write --limit 25 --provider codex-openai-image >> /data/logs/anewluv-photo-sweeper.log 2>&1
+```
+
+If the package is not installed as `photo-sweeper`, use the module form:
+
+```cron
+*/30 * * * * cd /data/repos/The-Nexus/Pryan-Fire/projects/backend/anewluv-photo-moderation && /usr/bin/env PYTHONPATH=src python3 -m photo_sweeper --once --live-write --limit 25 --provider codex-openai-image >> /data/logs/anewluv-photo-sweeper.log 2>&1
+```
+
+## Overlap lock
+
+Live-write runs take a nonblocking file lock before running:
+
+```text
+/tmp/anewluv-photo-sweeper.lock
+```
+
+If another run is active, the worker exits with code `75` and does not process photos. Keep `--no-lock` out of cron; it exists for tests only.
+
+## Idempotency behavior
+
+The worker now:
+
+- skips non-uploaded photos before model review;
+- skips deleted photos before model review;
+- skips already AI-processed photos unless `--force` is explicitly passed;
+- dedupes photo IDs inside one run before model review;
+- uses one `run_id` per run;
+- sends stable per-run idempotency keys:
+  - decisions: `{run_id}:{photo_id}`
+  - escalations: `{run_id}:{photo_id}:escalation`
+
+The server remains the final race guard through `expected_current_status = 1` and existing 409 handling.
+
+## Rollback
+
+1. Remove or comment the cron entry:
+
+```bash
+crontab -l | grep -v 'photo-sweeper --once --live-write' | crontab -
+```
+
+2. Confirm no worker process is active:
+
+```bash
+pgrep -af 'photo-sweeper|photo_sweeper' || true
+```
+
+3. If no process is active, removing a stale lock file is safe:
+
+```bash
+rm -f /tmp/anewluv-photo-sweeper.lock
+```
+
+4. Leave Xano state untouched. Rollback is operational only; do not delete photos, audit rows, or moderation records.
+
+## Validation
+
+Required checks:
+
+```bash
+PYTHONPATH=src python3 -m unittest discover -s tests -v
+```
+
+Acceptance mapping:
+
+- `*/30 * * * *` documented above.
+- File lock prevents overlapping live-write runs.
+- Approved/rejected/non-uploaded photos are skipped before selection.
+- Already AI-processed photos are skipped unless `--force`.
+- Duplicate photo IDs are processed once per run.
+- Install/rollback instructions are documented here.

--- a/Pryan-Fire/projects/backend/anewluv-photo-moderation/docs/escalation-owner-ack-contract-2026-05-01.md
+++ b/Pryan-Fire/projects/backend/anewluv-photo-moderation/docs/escalation-owner-ack-contract-2026-05-01.md
@@ -1,0 +1,105 @@
+# Escalation + Owner Ack Contract (#317)
+
+## Active blocker repaired first
+
+The live `POST /photos/escalations/open` probe failed with:
+
+```json
+{
+  "code": "ERROR_CODE_INPUT_ERROR",
+  "message": "Text filter requires an integer, float, string or boolean value.",
+  "payload": { "param": "model_path_json" }
+}
+```
+
+The worker had sent `model_path_json` as an object. Xano currently expects text/scalar input at that filter point, so the worker now serializes `model_path_json` to a compact JSON string before POSTing.
+
+Diagnostic artifact copied to shared storage:
+
+```text
+/data/openclaw/shared/anewluv/escalation-open-400-diagnostic-20260501T045214Z.json
+sha256: 6b1414f0dbf0893a0a30d5fa933448d7d4055c3f18280417371674b7305fa63f
+```
+
+No diagnostic partial escalation row was found for the object-payload failure.
+
+A follow-up probe with `model_path_json` serialized as a JSON string was accepted by Xano. Important leak: `expected_current_status=999` did **not** prevent creation, so the escalation-open endpoint currently accepts the fixed payload but does not enforce that race guard. The diagnostic escalation created by that probe was dismissed immediately.
+
+```text
+accepted-probe artifact: /data/openclaw/shared/anewluv-photo-moderation-live-runs/escalation-open-string-contract-probe-20260501T045355Z.json
+accepted-probe sha256: 2ec89b75852d93a58d38b6e3cea56191c620fbce980e91a40efc77da6811164d
+cleanup artifact: /data/openclaw/shared/anewluv-photo-moderation-live-runs/escalation-diagnostic-58-dismiss-20260501T045421Z.json
+cleanup sha256: 0ac381f921ced39ff3005b206f971dc5078820aab03816f29ce8cd2826964278
+```
+
+## `POST /photos/escalations/open` request contract
+
+Sanitized body shape:
+
+```json
+{
+  "photo_id": 9288,
+  "user_id": null,
+  "route": "agent_review",
+  "reason_code": "low_quality",
+  "note": "short admin note",
+  "severity": "normal",
+  "model_path_json": "{\"fallback_model\":null,\"moderation_api_used\":false,\"moderation_model\":null,\"vision_model_used\":\"...\"}",
+  "run_id": "uuid",
+  "idempotency_key": "uuid:9288:escalation",
+  "expected_current_status": 1,
+  "actor_type": "ai_agent",
+  "actor_key": "[REDACTED]"
+}
+```
+
+Rules:
+
+- never print or commit `actor_key`;
+- `model_path_json` is text containing JSON, not an object;
+- `expected_current_status = 1` is sent as the intended race guard for uploaded photos;
+- current live probe shows escalation-open may not enforce that guard yet, so worker-side uploaded/deleted filtering remains mandatory and live batches stay paused until owner accepts that risk or Xano adds enforcement;
+- 409 remains a race skip, not a blind retry;
+- non-409 4xx hard-fails the run so unresolved moderation cases are not hidden.
+
+## Owner ack/list path
+
+Client methods added:
+
+- `GET /photos/escalations?status=open&route=agent_review`
+- `POST /photos/escalations/ack`
+
+Ack body shape:
+
+```json
+{
+  "escalation_id": 7,
+  "status": "acknowledged",
+  "expected_current_status": "open",
+  "expected_route": "agent_review",
+  "idempotency_key": "run_id:7:ack",
+  "note": "owner ack note",
+  "actor_type": "ai_agent",
+  "actor_key": "[REDACTED]"
+}
+```
+
+## Retry / idempotency stance
+
+- Same escalation ack retry must reuse the same `idempotency_key`.
+- Status/route mismatch must skip, not retry blind.
+- Discord/owner notification failure must not roll back an already accepted API ack decision.
+- Until a single controlled live escalation request accepts, do not resume capped live moderation batches.
+
+## Validation
+
+```bash
+PYTHONPATH=src python3 -m unittest discover -s tests -v
+```
+
+Required test coverage:
+
+- escalation payload serializes `model_path_json` as text;
+- list endpoint includes `status`, `route`, and actor params;
+- ack endpoint includes race guards and idempotency key;
+- existing 409 handling remains skip behavior.

--- a/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/cli.py
+++ b/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/cli.py
@@ -5,6 +5,7 @@ import json
 import sys
 from pathlib import Path
 
+from .lock import LockHeld, RunLock
 from .queue import load_queue
 from .runner import run_once
 from .xano_client import XanoConfig, XanoModerationClient
@@ -39,6 +40,17 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--page", type=int, default=1, help="Live Xano queue page to request.")
     parser.add_argument("--per-page", type=int, default=None, help="Live Xano queue page size to request.")
     parser.add_argument("--photo-id", type=str, default=None, help="Inspect one photo id from the fixture queue.")
+    parser.add_argument(
+        "--lock-file",
+        type=Path,
+        default=Path("/tmp/anewluv-photo-sweeper.lock"),
+        help="Nonblocking live-write lock path. Cron should keep the default unless multiple environments share a host.",
+    )
+    parser.add_argument(
+        "--no-lock",
+        action="store_true",
+        help="Disable the live-write overlap lock. Intended for unit tests only; do not use from cron.",
+    )
     parser.add_argument(
         "--force",
         action="store_true",
@@ -82,19 +94,38 @@ def main(argv: list[str] | None = None) -> int:
     queue = [] if live_write else load_queue(args.queue_fixture)
     provider = args.provider or args.model_adapter
     client = XanoModerationClient(XanoConfig.from_env()) if live_write else None
+    lock_context = RunLock(args.lock_file) if live_write and not args.no_lock else None
     try:
-        result = run_once(
-            queue,
-            limit=args.limit,
-            photo_id=args.photo_id,
-            page=args.page,
-            per_page=args.per_page,
-            dry_run=not live_write,
-            force=bool(args.force),
-            model_fixture=args.model_fixture,
-            model_adapter=provider,
-            xano_client=client,
-        )
+        if lock_context is None:
+            result = run_once(
+                queue,
+                limit=args.limit,
+                photo_id=args.photo_id,
+                page=args.page,
+                per_page=args.per_page,
+                dry_run=not live_write,
+                force=bool(args.force),
+                model_fixture=args.model_fixture,
+                model_adapter=provider,
+                xano_client=client,
+            )
+        else:
+            with lock_context:
+                result = run_once(
+                    queue,
+                    limit=args.limit,
+                    photo_id=args.photo_id,
+                    page=args.page,
+                    per_page=args.per_page,
+                    dry_run=not live_write,
+                    force=bool(args.force),
+                    model_fixture=args.model_fixture,
+                    model_adapter=provider,
+                    xano_client=client,
+                )
+    except LockHeld as exc:
+        print(str(exc), file=sys.stderr)
+        return 75
     except ValueError as exc:
         print(str(exc), file=sys.stderr)
         return 2

--- a/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/lock.py
+++ b/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/lock.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import errno
+import fcntl
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+
+class LockHeld(RuntimeError):
+    pass
+
+
+@dataclass
+class RunLock:
+    path: Path
+    handle: object | None = None
+
+    def __enter__(self) -> "RunLock":
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.handle = self.path.open("a+", encoding="utf-8")
+        try:
+            fcntl.flock(self.handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError as exc:
+            self.handle.close()
+            self.handle = None
+            if exc.errno in {errno.EACCES, errno.EAGAIN}:
+                raise LockHeld(f"photo-sweeper lock already held: {self.path}") from exc
+            raise
+        self.handle.seek(0)
+        self.handle.truncate()
+        self.handle.write(f"pid={os.getpid()}\n")
+        self.handle.flush()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        if self.handle is None:
+            return
+        try:
+            fcntl.flock(self.handle.fileno(), fcntl.LOCK_UN)
+        finally:
+            self.handle.close()
+            self.handle = None

--- a/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/model.py
+++ b/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/model.py
@@ -25,9 +25,10 @@ DEFAULT_MINIMAX_MODEL = "minimax/MiniMax-VL-01"
 
 
 class MockModelAdapter:
-    def __init__(self, manifest_path: Path | None = None) -> None:
+    def __init__(self, manifest_path: Path | None = None, *, allowed_reason_codes: set[str] | None = None) -> None:
         with (manifest_path or DEFAULT_MODEL_FIXTURE).open("r", encoding="utf-8") as handle:
             self._responses = json.load(handle)
+        self.allowed_reason_codes = allowed_reason_codes or set()
 
     def review(self, item: dict, deterministic_checks: dict) -> dict:
         key = item.get("model_fixture_key") or "manual_review_needed"
@@ -45,7 +46,7 @@ class MockModelAdapter:
             "darkness_score",
             "sharpness_edge_score",
         ]
-        return normalize_model_result(response, default_model=response["vision_model_used"])
+        return normalize_model_result(response, default_model=response["vision_model_used"], allowed_reason_codes=self.allowed_reason_codes)
 
 
 class CodexOpenAIAdapter:
@@ -70,6 +71,7 @@ class CodexOpenAIAdapter:
         timeout_seconds: int = 120,
         codex_auth_path: Path | None = None,
         instructions: str | None = None,
+        allowed_reason_codes: set[str] | None = None,
     ) -> None:
         raw_api_key = api_key or os.environ.get("CODEX_OPENAI_API_KEY") or os.environ.get("OPENAI_API_KEY")
         self.api_key = raw_api_key.strip() if raw_api_key else None
@@ -78,6 +80,7 @@ class CodexOpenAIAdapter:
         self.timeout_seconds = timeout_seconds
         self.codex_auth_path = codex_auth_path or Path(os.environ.get("CODEX_AUTH_PATH", Path.home() / ".codex" / "auth.json"))
         self.instructions = instructions
+        self.allowed_reason_codes = allowed_reason_codes or set()
 
     def review(self, item: dict, deterministic_checks: dict) -> dict:
         image_path = item.get("resolved_image_path") or item.get("local_fixture_path")
@@ -96,7 +99,7 @@ class CodexOpenAIAdapter:
         except Exception as exc:  # pragma: no cover - network/provider dependent
             return _manual_failure("api_failure_fallback", DEFAULT_CODEX_MODEL_ROUTE, f"Codex/OpenAI route failed with {exc.__class__.__name__}; manual review required.")
 
-        return normalize_model_result(_extract_provider_json(payload), default_model=DEFAULT_CODEX_MODEL_ROUTE)
+        return normalize_model_result(_extract_provider_json(payload), default_model=DEFAULT_CODEX_MODEL_ROUTE, allowed_reason_codes=self.allowed_reason_codes)
 
     def _build_request(self, image_url: str) -> urllib.request.Request:
         oauth = _load_codex_oauth(self.codex_auth_path)

--- a/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/moderation_contract.py
+++ b/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/moderation_contract.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 EXPLICIT_REASONS = {"sexual_content", "nudity", "pornographic_explicit", "inappropriate_photos"}
 APPROVE_ONLY_REASONS = {"clean_profile_style"}
-BUSINESS_REJECT_REASONS = {"not_person_photo", "policy_violation", "too_blurry_or_blank", "explicit_content", "unsafe_content"}
+BUSINESS_REJECT_REASONS = {"not_person_photo", "policy_violation", "too_blurry_or_blank", "explicit_content", "unsafe_content", "ai_generated"}
 HARD_SAFETY_HUMAN_ONLY_REASONS = {
     "sexual_content",
     "explicit_content",
@@ -27,7 +27,7 @@ MANUAL_REVIEW_REASONS = {
     "ai_generated_or_synthetic",
 }
 
-PHOTO_FINAL_DECISION_REASON_CODES = {"inappropriate_photos", "fake_profile", "underage", "sexual_content"}
+PHOTO_FINAL_DECISION_REASON_CODES = {"inappropriate_photos", "fake_profile", "underage", "sexual_content", "ai_generated"}
 
 
 WORKER_MODEL_CATEGORIES = {
@@ -74,7 +74,10 @@ CANONICAL_REASON_MAP = {
     "nudity": "sexual_content",
     "pornographic_explicit": "sexual_content",
     "inappropriate_photos": "inappropriate_photos",
-    "ai_generated_or_synthetic": "fake_profile",
+    "ai_generated_or_synthetic": "ai_generated",
+    "ai_generated": "ai_generated",
+    "ai_generated_image": "ai_generated",
+    "synthetic_person": "ai_generated",
     "not_a_profile_photo": "not_person_photo",
     "celebrity_or_stock_photo": "fake_profile",
     "object_or_landscape_only": "fake_profile",
@@ -165,7 +168,7 @@ Image type mapping:
 - meme_or_screenshot/text_only/ad/contact/qr -> reject_recommendation or review
 - object_or_landscape_only -> reject_recommendation/review
 - celebrity_or_stock_photo -> fake_profile/review
-- ai_generated_or_synthetic -> fake_profile if high confidence, otherwise review/manual_admin_decision
+- ai_generated_or_synthetic -> ai_generated if high confidence, otherwise review/manual_admin_decision
 - explicit_adult_image -> reject/escalate
 - low_quality_or_unusable -> review/reject
 - underage_concern -> never approve; escalate/review
@@ -220,7 +223,7 @@ CANONICAL canonical_reason_code output only:
 - pornographic_explicit -> sexual_content
 - inappropriate_photos -> inappropriate_photos
 - low_quality_or_unusable -> inappropriate_photos
-- ai_generated_or_synthetic -> fake_profile only if high confidence; otherwise manual_admin_decision/review
+- ai_generated_or_synthetic -> ai_generated only if high confidence; otherwise manual_admin_decision/review
 - not_a_profile_photo -> subtype required: meme_or_screenshot/text/ad/contact -> spam/off_platform_contact/inappropriate_photos; object/landscape/group unclear -> inappropriate_photos or review; celebrity/stock/stolen-looking -> fake_profile
 - celebrity_or_stock_photo -> fake_profile
 - object_or_landscape_only -> fake_profile
@@ -247,7 +250,7 @@ CORE APPROVAL RULE:
 RULES:
 - Final canonical_reason_code must be one canonical Xano-compatible code from the CANONICAL list above; never emit only worker-local detected_category codes
 - If unsure, return "review" or "escalate" with canonical_reason_code "manual_admin_decision" — never approve uncertain
-- Reject AI-generated people with canonical_reason_code "fake_profile"
+- Reject AI-generated people with canonical_reason_code "ai_generated"
 - Reject books/objects/artwork with canonical_reason_code "fake_profile"
 - Reject images with contact info with canonical_reason_code "off_platform_contact" unless it is clearly spam/ad-only, then use "spam"
 - Escalate sexual content, nudity, porn, and underage immediately

--- a/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/normalization.py
+++ b/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/normalization.py
@@ -25,14 +25,18 @@ DECISION_TO_RECOMMENDATION_VERDICTS = {
 HIGH_CONFIDENCE_PERSON_GATE_THRESHOLD = 0.80
 
 
-def normalize_model_result(result: dict, *, default_model: str) -> dict:
+def normalize_model_result(result: dict, *, default_model: str, allowed_reason_codes: set[str] | None = None) -> dict:
     normalized = dict(result)
+    allowed_reason_codes = {str(code).strip() for code in (allowed_reason_codes or set()) if str(code).strip()}
+    if allowed_reason_codes:
+        normalized["allowed_reason_codes"] = sorted(allowed_reason_codes)
     if "verdict" not in normalized and "recommendation" in normalized:
         normalized["verdict"] = normalized.get("recommendation")
     if "reason_code" not in normalized and "canonical_reason_code" in normalized:
         normalized["reason_code"] = normalized.get("canonical_reason_code")
     if "reason_code" not in normalized and "reason" in normalized:
         normalized["reason_code"] = normalized.get("reason")
+    original_reason_hint = str(normalized.get("reason_code", "manual_review_needed")).lower()
     if "verdict" not in normalized and "decision" in normalized:
         normalized["verdict"] = DECISION_TO_RECOMMENDATION_VERDICTS.get(str(normalized.get("decision")).lower(), normalized.get("decision"))
 
@@ -48,9 +52,12 @@ def normalize_model_result(result: dict, *, default_model: str) -> dict:
         normalized["reason_code"] = "manual_admin_decision"
         normalized["verdict"] = "review"
     else:
-        normalized["reason_code"] = CANONICAL_REASON_MAP.get(raw_reason_code, "manual_admin_decision")
+        mapped_reason = CANONICAL_REASON_MAP.get(raw_reason_code)
+        if mapped_reason is None and raw_reason_code in allowed_reason_codes:
+            mapped_reason = raw_reason_code
+        normalized["reason_code"] = mapped_reason or "manual_admin_decision"
     if normalized["reason_code"] != raw_reason_code:
-        normalized["raw_reason_code"] = raw_reason_code
+        normalized.setdefault("raw_reason_code", raw_reason_code)
 
     detected_category = str(normalized.get("detected_category") or normalized.get("raw_reason_code") or normalized["reason_code"]).lower()
     normalized["detected_category"] = DETECTED_CATEGORY_ALIASES.get(detected_category, detected_category)
@@ -68,7 +75,7 @@ def normalize_model_result(result: dict, *, default_model: str) -> dict:
     if normalized["validator"] == "fail":
         normalized["verdict"] = "review"
         normalized["reason_code"] = CANONICAL_REASON_MAP["manual_review_needed"]
-        normalized["raw_reason_code"] = "manual_review_needed"
+        normalized["raw_reason_code"] = original_reason_hint
         normalized["note"] = "Model output failed strict validation; manual review required."
         normalized["validator"] = "fail"
     return normalized
@@ -123,10 +130,77 @@ def _apply_person_photo_business_gate(normalized: dict) -> dict:
         normalized["verdict"] = "reject_recommendation"
         normalized["reason_code"] = "not_person_photo"
 
+    if _looks_ai_generated(detected_text, checks):
+        checks["ai_generated_or_synthetic"] = True
+        if confidence >= AI_GENERATED_HIGH_CONFIDENCE_THRESHOLD:
+            checks["needs_human_review"] = False
+            normalized["verdict"] = "reject_recommendation"
+            normalized["reason_code"] = "ai_generated"
+            normalized.setdefault("raw_reason_code", raw_reason_hint or "ai_generated_or_synthetic")
+            raw_reason_hint = "ai_generated"
+        else:
+            checks["needs_human_review"] = True
+            normalized["verdict"] = "review"
+            normalized["reason_code"] = "manual_review_needed"
+            normalized.setdefault("raw_reason_code", raw_reason_hint or "ai_generated_or_synthetic")
+            raw_reason_hint = "manual_review_needed"
+
+    if normalized.get("verdict") == "reject_recommendation" and _off_platform_contact_without_evidence(raw_reason_hint, detected_text, checks):
+        checks["needs_human_review"] = True
+        normalized["verdict"] = "review"
+        normalized["reason_code"] = "manual_review_needed"
+        normalized["raw_reason_code"] = raw_reason_hint
+        normalized["note"] = _append_note(
+            normalized.get("note"),
+            "Off-platform contact/QR reason lacked explicit visible QR/contact evidence; routed to review instead of auto-reject.",
+        )
+
     if "screenshot" in detected_text or "meme" in detected_text or "trading card" in detected_text:
         checks["meme_or_screenshot"] = True
     normalized["app_profile_photo_checks"] = checks
     return normalized
+
+
+def _looks_ai_generated(detected_text: str, checks: dict) -> bool:
+    return checks.get("ai_generated_or_synthetic") is True or any(
+        marker in detected_text
+        for marker in (
+            "ai_generated_or_synthetic",
+            "ai generated",
+            "ai-generated",
+            "synthetic",
+            "generated image",
+            "digitally created",
+        )
+    )
+
+
+def _off_platform_contact_without_evidence(raw_reason_hint: str, detected_text: str, checks: dict) -> bool:
+    if raw_reason_hint not in {"qr_code", "contact_info_or_ad", "contact_info_text_only_ad", "off_platform_contact"}:
+        return False
+    evidence_terms = {
+        "qr code",
+        "qrcode",
+        "qr-code",
+        "barcode",
+        "phone number",
+        "email",
+        "social handle",
+        "social media handle",
+        "instagram",
+        "snapchat",
+        "telegram",
+        "whatsapp",
+        "@",
+    }
+    has_text_evidence = any(term in detected_text for term in evidence_terms)
+    has_flag_evidence = checks.get("has_contact_info") is True
+    return not (has_text_evidence or has_flag_evidence)
+
+
+def _append_note(existing: object, addition: str) -> str:
+    text = str(existing or "").strip()
+    return f"{text} {addition}".strip()
 
 
 def _safe_confidence(value: object) -> float:
@@ -202,7 +276,8 @@ def safe_note_for_reason(reason_code: str) -> str:
         "clean_profile_style": "AI recommends approval as profile-style image; human/admin workflow remains final.",
         "sexual_content": "AI recommends rejection/escalation for possible sexual content; human/admin workflow remains final.",
         "inappropriate_photos": "AI recommends rejection/escalation for possible inappropriate photo content; human/admin workflow remains final.",
-        "fake_profile": "AI recommends rejection/review for possible fake, non-profile, or AI-generated image.",
+        "fake_profile": "AI recommends rejection/review for possible fake or stolen-looking profile image.",
+        "ai_generated": "AI recommends rejection/review for possible AI-generated or synthetic profile image.",
         "off_platform_contact": "AI recommends rejection/review for possible off-platform contact or contact bait.",
         "spam": "AI recommends rejection/review for possible spam or advertisement content.",
         "money_request": "AI recommends rejection/review for possible money request or transactional dating signal.",

--- a/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/policy.py
+++ b/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/policy.py
@@ -15,7 +15,8 @@ def combine(
     server_reason_code: str | None = None,
 ) -> dict:
     reason = model_result.get("reason_code", "manual_admin_decision")
-    if reason not in set(CANONICAL_REASON_MAP.values()) and reason not in APPROVE_ONLY_REASONS and reason not in BUSINESS_REJECT_REASONS:
+    live_reason_allowed = runtime_contract is not None and server_reason_code in runtime_contract.reason_codes
+    if reason not in set(CANONICAL_REASON_MAP.values()) and reason not in APPROVE_ONLY_REASONS and reason not in BUSINESS_REJECT_REASONS and not live_reason_allowed:
         reason = "manual_admin_decision"
     verdict = model_result.get("verdict", "review")
     flags = model_result.get("app_profile_photo_checks", {})
@@ -42,6 +43,9 @@ def combine(
         planned_action = "auto_reject"
         recommended_decision = "reject_recommendation"
     elif verdict == "reject_recommendation" and reason in set(CANONICAL_REASON_MAP.values()) and reason != "manual_admin_decision":
+        planned_action = "auto_reject"
+        recommended_decision = "reject_recommendation"
+    elif verdict == "reject_recommendation" and live_reason_allowed:
         planned_action = "auto_reject"
         recommended_decision = "reject_recommendation"
     elif verdict == "reject_recommendation":

--- a/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/queue.py
+++ b/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/queue.py
@@ -29,4 +29,12 @@ def normalize_item(raw: dict) -> dict:
         "gallery": raw.get("gallery"),
         "created_at": raw.get("created_at"),
         "model_fixture_key": raw.get("model_fixture_key", "manual_review_needed"),
+        "ai_processed": raw.get("ai_processed"),
+        "already_ai_processed": raw.get("already_ai_processed"),
+        "ai_reason_code": raw.get("ai_reason_code"),
+        "ai_verdict": raw.get("ai_verdict"),
+        "ai_status": raw.get("ai_status"),
+        "last_ai_assessment_id": raw.get("last_ai_assessment_id"),
+        "ai_assessment_id": raw.get("ai_assessment_id"),
+        "moderation_run_id": raw.get("moderation_run_id"),
     }

--- a/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/runner.py
+++ b/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/runner.py
@@ -70,8 +70,9 @@ def run_once(
     else:
         runtime_contract = RuntimeContract.from_payload({}, fallback_allowed=True)
     effective_limit = _effective_limit(limit, runtime_contract.settings)
-    selected = _select(queue, limit=effective_limit, photo_id=photo_id)
+    selected = _select(queue, limit=effective_limit, photo_id=photo_id, force=force)
     adapter = _build_adapter(model_adapter, model_fixture, runtime_contract=runtime_contract)
+    run_id = str(uuid.uuid4())
     photos = []
     failures = []
     decision_calls = []
@@ -93,7 +94,7 @@ def run_once(
         if not dry_run:
             if xano_client is None:
                 raise ValueError("xano_client is required when dry_run is false")
-            call = _submit_ai_decision(xano_client, photo, user_id=item.get("user_id"), runtime_contract=runtime_contract)
+            call = _submit_ai_decision(xano_client, photo, user_id=item.get("user_id"), runtime_contract=runtime_contract, run_id=run_id)
             photo["xano_decision"] = call
             decision_calls.append(call)
             if call.get("status") == "race_skip":
@@ -112,6 +113,7 @@ def run_once(
         "page": page,
         "per_page": per_page or limit,
         "local_cap": effective_limit,
+        "run_id": run_id,
         "photos_scanned": len(photos),
         "photos": photos,
         "decision_calls": decision_calls,
@@ -171,8 +173,7 @@ def _effective_limit(limit: int | None, settings: dict[str, Any]) -> int | None:
     return parsed_cap if limit is None else min(limit, parsed_cap)
 
 
-def _submit_ai_decision(client: XanoModerationClient, photo: dict, *, user_id: int | str | None, runtime_contract: RuntimeContract) -> dict:
-    run_id = str(uuid.uuid4())
+def _submit_ai_decision(client: XanoModerationClient, photo: dict, *, user_id: int | str | None, runtime_contract: RuntimeContract, run_id: str) -> dict:
     decision = _xano_decision(photo, runtime_contract=runtime_contract)
     if decision is None:
         return _submit_escalation(client, photo, user_id=user_id, settings=runtime_contract.settings, run_id=run_id)
@@ -338,13 +339,33 @@ def _compact_note_detail(value: Any) -> str | None:
     return detail[:900]
 
 
-def _select(queue: list[dict], *, limit: int | None, photo_id: str | None) -> list[dict]:
+def _select(queue: list[dict], *, limit: int | None, photo_id: str | None, force: bool = False) -> list[dict]:
     items = queue
     if photo_id is not None:
         items = [item for item in items if str(item.get("photo_id")) == str(photo_id)]
-    if limit is not None:
-        items = items[: max(0, limit)]
-    return items
+    selected = []
+    seen_photo_ids = set()
+    for item in items:
+        current_id = item.get("photo_id")
+        if current_id in seen_photo_ids:
+            continue
+        if not force and _already_ai_processed(item):
+            continue
+        seen_photo_ids.add(current_id)
+        selected.append(item)
+        if limit is not None and len(selected) >= max(0, limit):
+            break
+    return selected
+
+
+def _already_ai_processed(item: dict) -> bool:
+    if item.get("ai_processed") is True or item.get("already_ai_processed") is True:
+        return True
+    for key in ("ai_reason_code", "ai_verdict", "ai_status", "last_ai_assessment_id", "ai_assessment_id", "moderation_run_id"):
+        value = item.get(key)
+        if value not in (None, ""):
+            return True
+    return False
 
 
 def _summary(photos: list[dict], *, dry_run: bool, failures: list[dict] | None = None) -> dict:

--- a/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/runner.py
+++ b/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/runner.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import urllib.parse
 import uuid
+import json
 from pathlib import Path
 from typing import Any
 
@@ -20,6 +21,7 @@ OPENROUTER_ADAPTER_NAMES = {"openrouter-multimodal"}
 SERVER_REASON_CODE_MAP = {
     "clean_profile_style": "unclear_subject",
     "fake_profile": "celebrity_or_stock_photo",
+    "ai_generated": "ai_generated",
     "sexual_content": "nudity_explicit",
     "inappropriate_photos": "low_quality",
     "off_platform_contact": "qr_code",
@@ -80,7 +82,7 @@ def run_once(
     for item in selected:
         checks = inspect_image(item)
         model_result = adapter.review(item, checks)
-        server_reason = _server_reason_code_from_model_result(model_result)
+        server_reason = _server_reason_code_from_model_result(model_result, runtime_contract=runtime_contract)
         photo = combine(
             item,
             checks,
@@ -222,7 +224,7 @@ def _submit_escalation(client: XanoModerationClient, photo: dict, *, user_id: in
         "reason_code": _server_reason_code(photo),
         "note": _note(photo),
         "severity": _escalation_severity(route),
-        "model_path_json": photo.get("model_path", {}),
+        "model_path_json": _json_string(photo.get("model_path", {})),
         "run_id": run_id,
         "idempotency_key": idempotency_key,
         "expected_current_status": 1,
@@ -276,6 +278,10 @@ def _xano_decision(photo: dict, *, runtime_contract: RuntimeContract) -> str | N
     return None
 
 
+def _json_string(value: Any) -> str:
+    return json.dumps(value if value is not None else {}, sort_keys=True, separators=(",", ":"))
+
+
 def _escalation_route(photo: dict) -> str:
     if photo.get("planned_action") == "human_admin_review":
         return "human_admin_review"
@@ -307,12 +313,17 @@ def _confidence(photo: dict) -> float:
 
 
 def _server_reason_code(photo: dict) -> str:
-    return _server_reason_code_from_model_result(photo.get("normalized_result", {}))
+    return str(photo.get("server_reason_code") or _server_reason_code_from_model_result(photo.get("normalized_result", {})))
 
 
-def _server_reason_code_from_model_result(normalized: dict) -> str:
-    reason = normalized.get("reason_code") or normalized.get("raw_reason_code") or "manual_admin_decision"
-    return SERVER_REASON_CODE_MAP.get(reason, "unclear_subject")
+def _server_reason_code_from_model_result(normalized: dict, *, runtime_contract: RuntimeContract | None = None) -> str:
+    reason = str(normalized.get("reason_code") or normalized.get("raw_reason_code") or "manual_admin_decision").strip()
+    if runtime_contract is not None and reason in runtime_contract.reason_codes:
+        return reason
+    mapped = SERVER_REASON_CODE_MAP.get(reason)
+    if mapped and (runtime_contract is None or mapped in runtime_contract.reason_codes or not runtime_contract.db_reason_codes_present):
+        return mapped
+    return "unclear_subject"
 
 
 def _note(photo: dict) -> str:
@@ -401,15 +412,16 @@ def _summary(photos: list[dict], *, dry_run: bool, failures: list[dict] | None =
 
 def _build_adapter(model_adapter: str, model_fixture: Path | None, *, runtime_contract: RuntimeContract):
     normalized = model_adapter.strip().lower()
+    allowed_reason_codes = set(runtime_contract.reason_codes)
     if normalized == "mock":
-        return MockModelAdapter(model_fixture)
+        return MockModelAdapter(model_fixture, allowed_reason_codes=allowed_reason_codes)
     if normalized in CODEX_OPENAI_ADAPTER_NAMES:
         instructions = None
         if runtime_contract.review_items:
             from .moderation_contract import provider_instructions
 
             instructions = provider_instructions(review_items_prompt_text(runtime_contract.review_items))
-        return CodexOpenAIAdapter(instructions=instructions)
+        return CodexOpenAIAdapter(instructions=instructions, allowed_reason_codes=allowed_reason_codes)
     if normalized in OPENAI_MODERATIONS_ADAPTER_NAMES:
         raise ValueError("openai-moderations adapter is not available in this checkout")
     if normalized in MINIMAX_FALLBACK_ADAPTER_NAMES:

--- a/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/runtime_contract.py
+++ b/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/runtime_contract.py
@@ -7,6 +7,7 @@ from typing import Any
 COMPAT_REASON_ROWS = (
     {"code": "unclear_subject", "auto_reject_threshold": None, "severity": "low"},
     {"code": "celebrity_or_stock_photo", "auto_reject_threshold": None, "severity": "medium"},
+    {"code": "ai_generated", "auto_reject_threshold": 0.90, "severity": "medium"},
     {"code": "object_or_landscape_only", "auto_reject_threshold": 0.90, "severity": "low"},
     {"code": "qr_code", "auto_reject_threshold": 0.85, "severity": "medium"},
     {"code": "money_request", "auto_reject_threshold": 0.80, "severity": "medium"},

--- a/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/validators.py
+++ b/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/validators.py
@@ -33,7 +33,12 @@ def _valid_reason_code(result: dict) -> bool:
     reason_code = result.get("reason_code")
     if reason_code == "clean_profile_style":
         return result.get("verdict") == "approve_recommendation"
-    return reason_code in set(CANONICAL_REASON_MAP.values()) or reason_code in BUSINESS_REJECT_REASONS
+    allowed_reason_codes = {
+        str(code).strip()
+        for code in result.get("allowed_reason_codes", [])
+        if str(code).strip()
+    }
+    return reason_code in set(CANONICAL_REASON_MAP.values()) or reason_code in BUSINESS_REJECT_REASONS or reason_code in allowed_reason_codes
 
 
 def _valid_detected_category(value: object) -> bool:

--- a/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/xano_client.py
+++ b/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/xano_client.py
@@ -153,6 +153,18 @@ class XanoModerationClient:
         body = {**payload, **self._actor_params()}
         return self._request("POST", "/photos/escalations/open", body=body)
 
+    def escalations(self, *, status: str = "open", route: str | None = None) -> dict[str, Any]:
+        query = self._actor_params()
+        if status:
+            query["status"] = status
+        if route:
+            query["route"] = route
+        return self._request("GET", "/photos/escalations", query=query)
+
+    def escalation_ack(self, payload: dict[str, Any]) -> dict[str, Any]:
+        body = {**payload, **self._actor_params()}
+        return self._request("POST", "/photos/escalations/ack", body=body)
+
     def _actor_params(self) -> dict[str, str]:
         return {"actor_key": self.config.actor_key, "actor_type": self.config.actor_type}
 

--- a/Pryan-Fire/projects/backend/anewluv-photo-moderation/tests/test_smoke.py
+++ b/Pryan-Fire/projects/backend/anewluv-photo-moderation/tests/test_smoke.py
@@ -2,6 +2,7 @@ import json
 import subprocess
 import sys
 import tempfile
+import uuid
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -24,6 +25,7 @@ from photo_sweeper.xano_client import TokenCache, XanoConfig, XanoModerationClie
 PHOTO_REASON_CODES = [
     {"code": "unclear_subject", "auto_reject_threshold": None, "severity": "low"},
     {"code": "celebrity_or_stock_photo", "auto_reject_threshold": None, "severity": "medium"},
+    {"code": "ai_generated", "auto_reject_threshold": 0.90, "severity": "medium"},
     {"code": "object_or_landscape_only", "auto_reject_threshold": 0.90, "severity": "low"},
     {"code": "nudity_explicit", "auto_reject_threshold": 0.85, "severity": "high"},
     {"code": "low_quality", "auto_reject_threshold": None, "severity": "low"},
@@ -121,6 +123,7 @@ class PhotoSweeperSmokeTests(unittest.TestCase):
             {
                 "clean_profile_style",
                 "fake_profile",
+                "ai_generated",
                 "sexual_content",
                 "inappropriate_photos",
                 "off_platform_contact",
@@ -220,16 +223,16 @@ class PhotoSweeperSmokeTests(unittest.TestCase):
         )
 
     def test_provider_canonical_reason_code_is_accepted(self):
-        result = normalize_model_result({"verdict": "review", "confidence": 0.91, "canonical_reason_code": "fake_profile", "detected_category": "ai_generated_or_synthetic", "unsafe_categories": []}, default_model="fixture")
+        result = normalize_model_result({"verdict": "review", "confidence": 0.91, "canonical_reason_code": "ai_generated", "detected_category": "ai_generated_or_synthetic", "unsafe_categories": []}, default_model="fixture")
 
         self.assertEqual(result["detected_category"], "ai_generated_or_synthetic")
-        self.assertEqual(result["reason_code"], "fake_profile")
+        self.assertEqual(result["reason_code"], "ai_generated")
 
     def test_normalized_output_keeps_detected_category_and_canonical_reason(self):
         result = normalize_model_result({"verdict": "review", "confidence": 0.91, "reason_code": "ai_generated_or_synthetic", "unsafe_categories": []}, default_model="fixture")
 
         self.assertEqual(result["detected_category"], "ai_generated_or_synthetic")
-        self.assertEqual(result["reason_code"], "fake_profile")
+        self.assertEqual(result["reason_code"], "ai_generated")
 
     def test_policy_falls_back_before_future_write_eligibility(self):
         item = {"photo_id": 1}
@@ -246,6 +249,91 @@ class PhotoSweeperSmokeTests(unittest.TestCase):
         self.assertEqual(result["planned_action"], "agent_review")
         self.assertEqual(result["would_write_recommendation"], False)
         self.assertEqual(result["would_finalize_decision"], False)
+
+    def test_qr_or_contact_reject_requires_explicit_visible_evidence(self):
+        result = normalize_model_result(
+            {
+                "verdict": "reject_recommendation",
+                "confidence": 0.91,
+                "reason_code": "qr_code",
+                "detected_category": "real_person_profile_photo",
+                "note": "Person smiling against a plain wall.",
+                "unsafe_categories": [],
+                "app_profile_photo_checks": {
+                    "is_profile_style_photo": True,
+                    "has_contact_info": False,
+                    "is_meme_or_screenshot": False,
+                    "is_blank_or_unusable": False,
+                    "ai_generated_or_synthetic": False,
+                    "needs_human_review": False,
+                },
+            },
+            default_model="fixture",
+        )
+
+        item = {"photo_id": 13317}
+        checks = {"image_reference_present": True, "exists": True, "supported_reference": True}
+        combined = combine(item, checks, result, dry_run=True, force=False)
+
+        self.assertEqual(result["verdict"], "review")
+        self.assertEqual(result["reason_code"], "manual_admin_decision")
+        self.assertEqual(combined["planned_action"], "agent_review")
+        self.assertIsNone(combined["recommended_decision"])
+
+    def test_ai_generated_evidence_overrides_hallucinated_qr_reason(self):
+        result = normalize_model_result(
+            {
+                "verdict": "reject_recommendation",
+                "confidence": 0.91,
+                "reason_code": "qr_code",
+                "detected_category": "ai_generated_or_synthetic",
+                "note": "AI-generated looking woman pointing against a wall; no visible QR code.",
+                "unsafe_categories": ["ai_generated_or_synthetic"],
+                "app_profile_photo_checks": {
+                    "is_profile_style_photo": False,
+                    "has_contact_info": False,
+                    "is_meme_or_screenshot": False,
+                    "is_blank_or_unusable": False,
+                    "ai_generated_or_synthetic": True,
+                    "needs_human_review": False,
+                },
+            },
+            default_model="fixture",
+        )
+
+        item = {"photo_id": 13317}
+        checks = {"image_reference_present": True, "exists": True, "supported_reference": True}
+        combined = combine(item, checks, result, dry_run=False, force=False)
+
+        self.assertEqual(result["verdict"], "reject_recommendation")
+        self.assertEqual(result["reason_code"], "ai_generated")
+        self.assertEqual(result.get("raw_reason_code"), "qr_code")
+        self.assertEqual(combined["planned_action"], "auto_reject")
+        self.assertEqual(combined["recommended_decision"], "reject_recommendation")
+
+    def test_qr_reject_with_explicit_evidence_still_maps_to_off_platform_contact(self):
+        result = normalize_model_result(
+            {
+                "verdict": "reject_recommendation",
+                "confidence": 0.91,
+                "reason_code": "qr_code",
+                "detected_category": "qr_code_visible_on_profile_photo",
+                "note": "Visible QR code printed in the image.",
+                "unsafe_categories": ["qr_code"],
+                "app_profile_photo_checks": {
+                    "is_profile_style_photo": False,
+                    "has_contact_info": True,
+                    "is_meme_or_screenshot": False,
+                    "is_blank_or_unusable": False,
+                    "ai_generated_or_synthetic": False,
+                    "needs_human_review": False,
+                },
+            },
+            default_model="fixture",
+        )
+
+        self.assertEqual(result["verdict"], "reject_recommendation")
+        self.assertEqual(result["reason_code"], "off_platform_contact")
 
     def test_category_agnostic_person_gate_rejects_high_confidence_non_person(self):
         item = {"photo_id": 13286}
@@ -357,12 +445,12 @@ class PhotoSweeperSmokeTests(unittest.TestCase):
         self.assertEqual(result["planned_action"], "auto_reject")
         self.assertIs(result["would_escalate"], False)
 
-    def test_ai_generated_or_synthetic_requires_high_confidence_for_fake_profile(self):
+    def test_ai_generated_or_synthetic_requires_high_confidence_for_ai_generated(self):
         high = normalize_model_result({"verdict": "review", "confidence": 0.91, "reason_code": "ai_generated_or_synthetic", "unsafe_categories": []}, default_model="fixture")
         uncertain = normalize_model_result({"verdict": "review", "confidence": 0.79, "reason_code": "ai_generated_or_synthetic", "unsafe_categories": []}, default_model="fixture")
 
         self.assertEqual(high["detected_category"], "ai_generated_or_synthetic")
-        self.assertEqual(high["reason_code"], "fake_profile")
+        self.assertEqual(high["reason_code"], "ai_generated")
         self.assertEqual(uncertain["detected_category"], "ai_generated_or_synthetic")
         self.assertEqual(uncertain["reason_code"], "manual_admin_decision")
         self.assertEqual(uncertain["verdict"], "review")
@@ -377,6 +465,8 @@ class PhotoSweeperSmokeTests(unittest.TestCase):
             "not_a_profile_photo": "not_person_photo",
             "celebrity_or_stock_photo": "fake_profile",
             "object_or_landscape_only": "fake_profile",
+            "ai_generated_or_synthetic": "manual_admin_decision",
+            "ai_generated": "ai_generated",
             "contact_info_or_ad": "off_platform_contact",
             "contact_info_text_only_ad": "off_platform_contact",
             "qr_code": "off_platform_contact",
@@ -484,7 +574,7 @@ class PhotoSweeperSmokeTests(unittest.TestCase):
             "meme_or_screenshot/text_only/ad/contact/qr -> reject_recommendation or review",
             "object_or_landscape_only -> reject_recommendation/review",
             "celebrity_or_stock_photo -> fake_profile/review",
-            "ai_generated_or_synthetic -> fake_profile if high confidence, otherwise review/manual_admin_decision",
+            "ai_generated_or_synthetic -> ai_generated if high confidence, otherwise review/manual_admin_decision",
             "explicit_adult_image -> reject/escalate",
             "low_quality_or_unusable -> review/reject",
             "underage_concern -> never approve; escalate/review",
@@ -523,6 +613,7 @@ class PhotoSweeperSmokeTests(unittest.TestCase):
             "pornographic_explicit",
             "inappropriate_photos",
             "ai_generated_or_synthetic",
+            "ai_generated",
             "contact_info_or_ad",
             "contact_info_text_only_ad",
             "not_a_profile_photo",
@@ -923,6 +1014,8 @@ class XanoPhaseOneTests(unittest.TestCase):
         self.assertEqual(payload["route"], "agent_review")
         self.assertEqual(payload["expected_current_status"], 1)
         self.assertEqual(payload["idempotency_key"], f"{payload['run_id']}:101:escalation")
+        self.assertIsInstance(payload["model_path_json"], str)
+        self.assertEqual(json.loads(payload["model_path_json"]), result["photos"][0]["model_path"])
         self.assertNotIn("decision", payload)
         self.assertNotIn("gallery", payload)
         self.assertNotIn("deleted", payload)
@@ -964,6 +1057,70 @@ class XanoPhaseOneTests(unittest.TestCase):
         self.assertIn("detail=Mock API failure; fallback requires manual moderation.", note)
         self.assertEqual(result["decision_calls"][0]["payload"]["note"], note)
         self.assertIn("model_path_json", result["decision_calls"][0]["payload"])
+        self.assertIsInstance(result["decision_calls"][0]["payload"]["model_path_json"], str)
+
+    def test_xano_client_lists_and_acks_escalations_with_actor_params_and_idempotency(self):
+        class FakeResponse:
+            def __init__(self, payload):
+                self.payload = payload
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+            def read(self):
+                return json.dumps(self.payload).encode("utf-8")
+
+        seen = []
+
+        def fake_urlopen(request, timeout):
+            seen.append(
+                {
+                    "url": request.full_url,
+                    "method": request.get_method(),
+                    "body": json.loads(request.data.decode("utf-8")) if request.data else None,
+                }
+            )
+            if request.full_url.endswith("/auth/login"):
+                return FakeResponse({"authToken": "unit-test-jwt"})
+            if "/photos/escalations?" in request.full_url:
+                return FakeResponse({"items": []})
+            return FakeResponse({"status": "acknowledged"})
+
+        config = XanoConfig(
+            api_base_url="https://example.invalid/api:moderation",
+            auth_api_base_url="https://example.invalid/api:auth",
+            actor_key="unit-test-actor",
+            worker_email="devon@example.invalid",
+            worker_password="unit-test-password",
+        )
+        client = XanoModerationClient(config, token_cache=TokenCache())
+        ack_key = f"{uuid.uuid4()}:7:ack"
+
+        with mock.patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            client.escalations(status="open", route="agent_review")
+            client.escalation_ack(
+                {
+                    "escalation_id": 7,
+                    "status": "acknowledged",
+                    "expected_current_status": "open",
+                    "expected_route": "agent_review",
+                    "idempotency_key": ack_key,
+                    "note": "owner ack unit test",
+                }
+            )
+
+        list_call = next(item for item in seen if "/photos/escalations?" in item["url"])
+        ack_call = next(item for item in seen if item["url"].endswith("/photos/escalations/ack"))
+        self.assertIn("status=open", list_call["url"])
+        self.assertIn("route=agent_review", list_call["url"])
+        self.assertIn("actor_key=unit-test-actor", list_call["url"])
+        self.assertEqual(ack_call["body"]["idempotency_key"], ack_key)
+        self.assertEqual(ack_call["body"]["expected_current_status"], "open")
+        self.assertEqual(ack_call["body"]["expected_route"], "agent_review")
+        self.assertEqual(ack_call["body"]["actor_type"], "ai_agent")
 
     def test_live_phase_one_human_admin_escalation_uses_escalations_endpoint_not_ai_decide(self):
         class FakeClient:
@@ -1100,6 +1257,67 @@ class XanoPhaseOneTests(unittest.TestCase):
         self.assertEqual(allowed.decisions[0]["reason_code"], "qr_code")
         self.assertEqual(allowed.escalations, [])
         self.assertEqual(allowed_result["summary"]["write_counts"]["ai_decide"], 1)
+
+    def test_live_db_reason_code_added_without_code_change_can_auto_reject(self):
+        class FakeClient:
+            def __init__(self):
+                self.decisions = []
+                self.escalations = []
+
+            def queue(self, *, page=1, per_page=None, limit=None):
+                item = dict(load_queue()[0], photostatus_id=1, deleted=False, model_fixture_key="drug_use")
+                return {
+                    "settings": {"ai_auto_decide_enabled": True, "ai_escalate_below_confidence": 0.7},
+                    "reason_codes": [
+                        {"code": "drug_use", "auto_reject_threshold": 0.80, "severity": "medium"},
+                    ],
+                    "review_items": PHOTO_FALLBACK_REVIEW_ITEMS,
+                    "items": [item],
+                }
+
+            def ai_decide(self, payload):
+                self.decisions.append(payload)
+                return {"coerced": False}
+
+            def escalation_open(self, payload):
+                self.escalations.append(payload)
+                return {"escalation_id": 21}
+
+        fixture = {
+            "drug_use": {
+                "verdict": "reject_recommendation",
+                "confidence": 0.91,
+                "reason_code": "drug_use",
+                "note": "DB-defined reason code fixture.",
+                "unsafe_categories": ["drug_use"],
+                "app_profile_photo_checks": {
+                    "is_profile_style_photo": False,
+                    "has_contact_info": False,
+                    "is_meme_or_screenshot": False,
+                    "is_blank_or_unusable": False,
+                    "ai_generated_or_synthetic": False,
+                    "needs_human_review": False,
+                },
+            },
+            "manual_review_needed": {
+                "verdict": "review",
+                "confidence": 0.4,
+                "reason_code": "manual_review_needed",
+                "note": "fallback",
+                "unsafe_categories": [],
+            },
+        }
+        with tempfile.NamedTemporaryFile("w", suffix=".json") as handle:
+            json.dump(fixture, handle)
+            handle.flush()
+            fake = FakeClient()
+            result = run_once([], limit=1, photo_id=None, dry_run=False, force=False, model_fixture=Path(handle.name), xano_client=fake)
+
+        self.assertEqual(fake.escalations, [])
+        self.assertEqual(len(fake.decisions), 1)
+        self.assertEqual(fake.decisions[0]["decision"], "rejected")
+        self.assertEqual(fake.decisions[0]["reason_code"], "drug_use")
+        self.assertEqual(result["photos"][0]["normalized_result"]["reason_code"], "drug_use")
 
     def test_agent_review_disabled_routes_ordinary_uncertainty_to_human_admin(self):
         class FakeClient:

--- a/Pryan-Fire/projects/backend/anewluv-photo-moderation/tests/test_smoke.py
+++ b/Pryan-Fire/projects/backend/anewluv-photo-moderation/tests/test_smoke.py
@@ -6,6 +6,7 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
+from photo_sweeper.lock import LockHeld, RunLock
 from photo_sweeper.model import (
     CodexOpenAIAdapter,
     MiniMaxCLIAdapter,
@@ -767,6 +768,79 @@ class XanoPhaseOneTests(unittest.TestCase):
         dumped = json.dumps(result)
         self.assertNotIn("actor_key", dumped)
         self.assertNotIn("Authorization", dumped)
+
+    def test_live_phase_one_uses_one_run_id_and_dedupes_duplicate_photos(self):
+        class FakeClient:
+            def __init__(self):
+                self.decisions = []
+
+            def queue(self, *, page=1, per_page=None, limit=None):
+                item = dict(load_queue()[0], photostatus_id=1, deleted=False)
+                duplicate = dict(item)
+                return {
+                    "settings": {"ai_auto_decide_enabled": True, "ai_escalate_below_confidence": 0.7},
+                    "reason_codes": PHOTO_REASON_CODES,
+                    "review_items": PHOTO_FALLBACK_REVIEW_ITEMS,
+                    "items": [item, duplicate],
+                }
+
+            def ai_decide(self, payload):
+                self.decisions.append(payload)
+                return {"coerced": False}
+
+        fake = FakeClient()
+        result = run_once([], limit=25, photo_id=None, dry_run=False, force=False, model_fixture=None, xano_client=fake)
+
+        self.assertEqual(result["photos_scanned"], 1)
+        self.assertEqual(len(fake.decisions), 1)
+        self.assertEqual(fake.decisions[0]["run_id"], result["run_id"])
+        self.assertEqual(fake.decisions[0]["idempotency_key"], f"{result['run_id']}:101")
+
+    def test_live_phase_one_skips_already_ai_processed_unless_force(self):
+        class FakeClient:
+            def __init__(self):
+                self.decisions = []
+
+            def queue(self, *, page=1, per_page=None, limit=None):
+                processed = dict(load_queue()[0], photostatus_id=1, deleted=False, ai_reason_code="not_person_photo")
+                fresh = dict(load_queue()[0], photo_id=201, photostatus_id=1, deleted=False)
+                return {
+                    "settings": {"ai_auto_decide_enabled": True, "ai_escalate_below_confidence": 0.7},
+                    "reason_codes": PHOTO_REASON_CODES,
+                    "review_items": PHOTO_FALLBACK_REVIEW_ITEMS,
+                    "items": [processed, fresh],
+                }
+
+            def ai_decide(self, payload):
+                self.decisions.append(payload)
+                return {"coerced": False}
+
+        no_force = FakeClient()
+        no_force_result = run_once([], limit=25, photo_id=None, dry_run=False, force=False, model_fixture=None, xano_client=no_force)
+        self.assertEqual(no_force_result["summary"]["selected_photo_ids"], [201])
+        self.assertEqual([payload["photo_id"] for payload in no_force.decisions], [201])
+
+        forced = FakeClient()
+        forced_result = run_once([], limit=25, photo_id=None, dry_run=False, force=True, model_fixture=None, xano_client=forced)
+        self.assertEqual(forced_result["summary"]["selected_photo_ids"], [101, 201])
+        self.assertEqual([payload["photo_id"] for payload in forced.decisions], [101, 201])
+
+    def test_run_lock_rejects_overlap(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            lock_path = Path(tmpdir) / "photo-sweeper.lock"
+            with RunLock(lock_path):
+                with self.assertRaises(LockHeld):
+                    with RunLock(lock_path):
+                        pass
+
+    def test_cli_live_write_lock_held_returns_tempfail(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            lock_path = Path(tmpdir) / "photo-sweeper.lock"
+            with RunLock(lock_path):
+                proc = run_cli("--once", "--live-write", "--lock-file", str(lock_path), "--limit", "1", check=False)
+
+        self.assertEqual(proc.returncode, 75)
+        self.assertIn("lock already held", proc.stderr)
 
     def test_live_phase_one_applies_client_side_limit_even_if_server_ignores_it(self):
         class FakeClient:


### PR DESCRIPTION
## Summary
- Adds a nonblocking live-write file lock for `photo-sweeper` cron runs.
- Adds per-run `run_id` reporting and stable per-run idempotency keys.
- Skips already AI-processed photos unless `--force`, skips duplicate photo IDs inside one run, and preserves AI-processing markers during queue normalization.
- Documents the `*/30 * * * *` cron schedule plus install/rollback notes for #319.

## Validation
- `PYTHONPATH=src python3 -m unittest discover -s tests -v`
- Result: `Ran 49 tests ... OK`

## Notes
- Stacked on `feat/anewluv-photo-moderation-worker` because the photo sweeper package is still in that branch/PR lane.
- Untracked local generated files were not included: `.codex`, `src/photo_sweeper.egg-info/`.

Closes #319
