### PR TITLE
#341 honor live moderation settings per run

### DIFF
--- a/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/runner.py
+++ b/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/runner.py
@@ -73,14 +73,31 @@ def run_once(
         runtime_contract = RuntimeContract.from_payload({}, fallback_allowed=True)
     effective_limit = _effective_limit(limit, runtime_contract.settings)
     selected = _select(queue, limit=effective_limit, photo_id=photo_id, force=force)
-    adapter = _build_adapter(model_adapter, model_fixture, runtime_contract=runtime_contract)
+    auto_decide_disabled = runtime_contract.settings.get("ai_auto_decide_enabled") is False
+    adapter = None if auto_decide_disabled else _build_adapter(model_adapter, model_fixture, runtime_contract=runtime_contract)
     run_id = str(uuid.uuid4())
     photos = []
     failures = []
     decision_calls = []
 
     for item in selected:
+        if auto_decide_disabled:
+            photo = _settings_disabled_photo(item, dry_run=dry_run, force=force)
+            photo["server_reason_code"] = _server_reason_code(photo)
+            if not dry_run:
+                if xano_client is None:
+                    raise ValueError("xano_client is required when dry_run is false")
+                call = _submit_escalation(xano_client, photo, user_id=item.get("user_id"), settings=runtime_contract.settings, run_id=run_id)
+                photo["xano_decision"] = call
+                decision_calls.append(call)
+                if call.get("status") == "race_skip":
+                    failures.append({"photo_id": photo["photo_id"], "status": "race_skip"})
+            photos.append(photo)
+            continue
+
         checks = inspect_image(item)
+        if adapter is None:
+            raise ValueError("model adapter is required when ai_auto_decide_enabled is true")
         model_result = adapter.review(item, checks)
         server_reason = _server_reason_code_from_model_result(model_result, runtime_contract=runtime_contract)
         photo = combine(
@@ -109,6 +126,7 @@ def run_once(
         "force_requested": force,
         **_provider_report(model_adapter, dry_run=dry_run),
         "settings_echo_present": bool(runtime_contract.settings),
+        "settings_echo": runtime_contract.settings,
         "db_reason_codes_present": runtime_contract.db_reason_codes_present,
         "db_review_items_present": runtime_contract.db_review_items_present,
         "queue_fetched": fetched_count,
@@ -210,6 +228,43 @@ def _submit_ai_decision(client: XanoModerationClient, photo: dict, *, user_id: i
         "expected_current_status": 1,
         "coerced": response.get("coerced"),
         "payload": payload,
+    }
+
+
+def _settings_disabled_photo(item: dict, *, dry_run: bool, force: bool) -> dict:
+    model_result = {
+        "verdict": "review",
+        "confidence": 0.0,
+        "reason_code": "manual_admin_decision",
+        "raw_reason_code": "auto_decide_disabled",
+        "note": "ai_auto_decide_enabled is false; skipped model call and routed to escalation.",
+        "unsafe_categories": [],
+        "moderation_api_used": False,
+        "moderation_model": None,
+        "vision_model_used": "settings_precheck",
+        "fallback_model": "manual_review",
+        "validator": "pass",
+        "app_profile_photo_checks": {"needs_human_review": True},
+    }
+    return {
+        "photo_id": item["photo_id"],
+        "queue_source": item.get("queue_source", "GET /photos/queue"),
+        "dry_run": dry_run,
+        "force_requested": force,
+        "write_enabled": not dry_run,
+        "model_path": {
+            "moderation_api_used": False,
+            "moderation_model": None,
+            "vision_model_used": "settings_precheck",
+            "fallback_model": "manual_review",
+        },
+        "deterministic_checks": {"skipped": True, "reason": "ai_auto_decide_enabled"},
+        "normalized_result": model_result,
+        "planned_action": "agent_review",
+        "recommended_decision": None,
+        "would_write_recommendation": False,
+        "would_finalize_decision": False,
+        "would_escalate": True,
     }
 
 
@@ -357,6 +412,8 @@ def _select(queue: list[dict], *, limit: int | None, photo_id: str | None, force
     selected = []
     seen_photo_ids = set()
     for item in items:
+        if limit is not None and len(selected) >= max(0, limit):
+            break
         current_id = item.get("photo_id")
         if current_id in seen_photo_ids:
             continue
@@ -364,8 +421,6 @@ def _select(queue: list[dict], *, limit: int | None, photo_id: str | None, force
             continue
         seen_photo_ids.add(current_id)
         selected.append(item)
-        if limit is not None and len(selected) >= max(0, limit):
-            break
     return selected
 
 

--- a/Pryan-Fire/projects/backend/anewluv-photo-moderation/tests/test_smoke.py
+++ b/Pryan-Fire/projects/backend/anewluv-photo-moderation/tests/test_smoke.py
@@ -4,6 +4,7 @@ import sys
 import tempfile
 import uuid
 import unittest
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest import mock
 
@@ -1238,6 +1239,145 @@ class XanoPhaseOneTests(unittest.TestCase):
         self.assertNotIn("decision", fake.escalations[0])
         self.assertEqual(result["decision_calls"][0]["status"], "escalated")
         self.assertEqual(result["decision_calls"][0]["reason"], "auto_decide_disabled")
+
+    def test_live_settings_auto_decide_disabled_skips_model_and_escalates_all(self):
+        class FakeClient:
+            def __init__(self):
+                self.decisions = []
+                self.escalations = []
+
+            def queue(self, *, page=1, per_page=None, limit=None):
+                return {
+                    "settings": {"ai_auto_decide_enabled": False, "ai_escalate_below_confidence": 0.7},
+                    "reason_codes": PHOTO_REASON_CODES,
+                    "review_items": PHOTO_FALLBACK_REVIEW_ITEMS,
+                    "items": [dict(load_queue()[0], photostatus_id=1, deleted=False), dict(load_queue()[1], photostatus_id=1, deleted=False)],
+                }
+
+            def ai_decide(self, payload):
+                self.decisions.append(payload)
+                return {"coerced": False}
+
+            def escalation_open(self, payload):
+                self.escalations.append(payload)
+                return {"escalation_id": len(self.escalations)}
+
+        fake = FakeClient()
+        with mock.patch("photo_sweeper.model.MockModelAdapter.review", side_effect=AssertionError("model call should be skipped")):
+            result = run_once([], limit=None, photo_id=None, dry_run=False, force=False, model_fixture=None, xano_client=fake)
+
+        self.assertEqual(fake.decisions, [])
+        self.assertEqual(len(fake.escalations), 2)
+        self.assertEqual([call["reason"] for call in result["decision_calls"]], ["auto_decide_disabled", "auto_decide_disabled"])
+        self.assertEqual(result["photos_scanned"], 2)
+        self.assertEqual(result["photos"][0]["model_path"]["vision_model_used"], "settings_precheck")
+
+    def test_live_settings_max_decisions_cap_and_zero_are_honored(self):
+        class FakeClient:
+            def __init__(self, cap):
+                self.cap = cap
+                self.decisions = []
+                self.escalations = []
+
+            def queue(self, *, page=1, per_page=None, limit=None):
+                return {
+                    "settings": {"ai_auto_decide_enabled": True, "ai_escalate_below_confidence": 0.7, "ai_max_decisions_per_run": self.cap},
+                    "reason_codes": PHOTO_REASON_CODES,
+                    "review_items": PHOTO_FALLBACK_REVIEW_ITEMS,
+                    "items": [dict(item, photostatus_id=1, deleted=False) for item in load_queue()[:3]],
+                }
+
+            def ai_decide(self, payload):
+                self.decisions.append(payload)
+                return {"coerced": False}
+
+            def escalation_open(self, payload):
+                self.escalations.append(payload)
+                return {"escalation_id": len(self.escalations)}
+
+        capped = FakeClient(2)
+        capped_result = run_once([], limit=None, photo_id=None, dry_run=False, force=False, model_fixture=None, xano_client=capped)
+        self.assertEqual(capped_result["local_cap"], 2)
+        self.assertEqual(capped_result["photos_scanned"], 2)
+
+        zero = FakeClient(0)
+        zero_result = run_once([], limit=None, photo_id=None, dry_run=False, force=False, model_fixture=None, xano_client=zero)
+        self.assertEqual(zero_result["local_cap"], 0)
+        self.assertEqual(zero_result["photos_scanned"], 0)
+        self.assertEqual(zero.decisions, [])
+
+    def test_live_settings_grace_period_filters_client_side(self):
+        now = datetime.now(timezone.utc)
+        old_item = dict(load_queue()[0], photostatus_id=1, deleted=False, created_at=(now - timedelta(minutes=45)).isoformat())
+        fresh_item = dict(load_queue()[1], photostatus_id=1, deleted=False, created_at=(now - timedelta(minutes=5)).isoformat())
+
+        class FakeClient:
+            def __init__(self):
+                self.decisions = []
+
+            def queue(self, *, page=1, per_page=None, limit=None):
+                return {
+                    "settings": {"ai_auto_decide_enabled": True, "ai_escalate_below_confidence": 0.7, "ai_grace_period_minutes": 30},
+                    "reason_codes": PHOTO_REASON_CODES,
+                    "review_items": PHOTO_FALLBACK_REVIEW_ITEMS,
+                    "items": [fresh_item, old_item],
+                }
+
+            def ai_decide(self, payload):
+                self.decisions.append(payload)
+                return {"coerced": False}
+
+        fake = FakeClient()
+        result = run_once([], limit=None, photo_id=None, dry_run=False, force=False, model_fixture=None, xano_client=fake)
+
+        self.assertEqual(result["queue_fetched"], 2)
+        self.assertEqual(result["photos_scanned"], 1)
+        self.assertEqual(result["photos"][0]["photo_id"], old_item["photo_id"])
+
+    def test_live_settings_echo_is_reported_at_run_start(self):
+        class FakeClient:
+            def queue(self, *, page=1, per_page=None, limit=None):
+                return {
+                    "settings": {"ai_auto_decide_enabled": True, "ai_escalate_below_confidence": 0.7, "agent_review_discord_channel_id": ""},
+                    "reason_codes": PHOTO_REASON_CODES,
+                    "review_items": PHOTO_FALLBACK_REVIEW_ITEMS,
+                    "items": [],
+                }
+
+        result = run_once([], limit=None, photo_id=None, dry_run=False, force=False, model_fixture=None, xano_client=FakeClient())
+
+        self.assertTrue(result["settings_echo_present"])
+        self.assertEqual(result["settings_echo"]["ai_escalate_below_confidence"], 0.7)
+        self.assertIn("agent_review_discord_channel_id", result["settings_echo"])
+
+    def test_live_settings_confidence_floor_routes_to_escalation_before_ai_decide(self):
+        class FakeClient:
+            def __init__(self):
+                self.decisions = []
+                self.escalations = []
+
+            def queue(self, *, page=1, per_page=None, limit=None):
+                return {
+                    "settings": {"ai_auto_decide_enabled": True, "ai_escalate_below_confidence": 0.99},
+                    "reason_codes": PHOTO_REASON_CODES,
+                    "review_items": PHOTO_FALLBACK_REVIEW_ITEMS,
+                    "items": [dict(load_queue()[0], photostatus_id=1, deleted=False)],
+                }
+
+            def ai_decide(self, payload):
+                self.decisions.append(payload)
+                return {"coerced": False}
+
+            def escalation_open(self, payload):
+                self.escalations.append(payload)
+                return {"escalation_id": 9}
+
+        fake = FakeClient()
+        result = run_once([], limit=1, photo_id=None, dry_run=False, force=False, model_fixture=None, xano_client=fake)
+
+        self.assertEqual(fake.decisions, [])
+        self.assertEqual(len(fake.escalations), 1)
+        self.assertEqual(result["decision_calls"][0]["reason"], "confidence_below_floor")
 
     def test_db_reason_code_threshold_controls_auto_reject(self):
         class FakeClient:


### PR DESCRIPTION
## Summary
- Enforce live `moderation_settings` every worker run.
- `ai_auto_decide_enabled=false` now skips model calls entirely and routes selected photos to `/photos/escalations/open`.
- `ai_max_decisions_per_run` is applied as a local cap, including `0`.
- `ai_grace_period_minutes` is checked client-side against each row's `created_at`.
- `ai_escalate_below_confidence` prevents `/photos/ai_decide` and routes to escalation when confidence is below the live floor.
- Worker report now includes a `settings_echo` object at run start for operator/debug evidence.

## Proof
- `PYTHONPATH=src python3 -m unittest tests.test_smoke -v` → 63 tests OK
- Targeted settings tests cover auto-decide disabled, max cap/zero cap, grace-period filtering, settings echo, confidence-floor escalation, and existing settings forced-escalation behavior.

## Notes
- Based on active worker stack branch `feat/anewluv-photo-moderation-worker`.
- Keeps #344 draft until the full worker stack has evidence.
