### PR TITLE
#342 add provider chain fail-closed routing

### DIFF
--- a/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/cli.py
+++ b/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/cli.py
@@ -12,6 +12,11 @@ from .xano_client import XanoConfig, XanoModerationClient
 
 MODEL_PROVIDER_CHOICES = (
     "mock",
+    "provider-chain",
+    "anewluv-provider-chain",
+    "mock-provider-chain",
+    "vision-llm-only",
+    "mock-vision-llm-only",
     "codex-openai-image",
     "codex-openai",
     "openclaw-codex-openai",

--- a/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/model.py
+++ b/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/model.py
@@ -12,7 +12,7 @@ import urllib.request
 from pathlib import Path
 from typing import Any
 
-from .moderation_contract import provider_instructions
+from .moderation_contract import HARD_SAFETY_HUMAN_ONLY_REASONS, provider_instructions
 from .normalization import default_profile_checks, normalize_minimax_description, normalize_model_result
 
 DEFAULT_MODEL_FIXTURE = Path(__file__).resolve().parent / "fixtures" / "mock_model_responses.json"
@@ -24,18 +24,41 @@ DEFAULT_MINIMAX_MODEL = "minimax/MiniMax-VL-01"
 
 
 
+PROVIDER_UNAVAILABLE_REASONS = {"api_failure_fallback", "api_auth_unavailable", "missing_image_reference", "provider_chain_failed"}
+STAGE1_INCONCLUSIVE_REASONS = {"manual_admin_decision", "manual_review_needed"}
+STAGE1_HARD_SAFETY_REASONS = HARD_SAFETY_HUMAN_ONLY_REASONS | {
+    "nudity",
+    "pornographic_explicit",
+    "underage_concern",
+    "hate_or_harassment",
+}
+
+
 class MockModelAdapter:
-    def __init__(self, manifest_path: Path | None = None, *, allowed_reason_codes: set[str] | None = None) -> None:
+    def __init__(
+        self,
+        manifest_path: Path | None = None,
+        *,
+        allowed_reason_codes: set[str] | None = None,
+        key_field: str = "model_fixture_key",
+        default_model: str = "mock_fixture",
+        provider_defaults: dict[str, Any] | None = None,
+    ) -> None:
         with (manifest_path or DEFAULT_MODEL_FIXTURE).open("r", encoding="utf-8") as handle:
             self._responses = json.load(handle)
         self.allowed_reason_codes = allowed_reason_codes or set()
+        self.key_field = key_field
+        self.default_model = default_model
+        self.provider_defaults = provider_defaults or {}
 
     def review(self, item: dict, deterministic_checks: dict) -> dict:
-        key = item.get("model_fixture_key") or "manual_review_needed"
+        key = item.get(self.key_field) or item.get("model_fixture_key") or "manual_review_needed"
         response = dict(self._responses.get(key, self._responses["manual_review_needed"]))
+        for field, value in self.provider_defaults.items():
+            response.setdefault(field, value)
         response.setdefault("moderation_api_used", False)
         response.setdefault("moderation_model", None)
-        response.setdefault("vision_model_used", "mock_fixture")
+        response.setdefault("vision_model_used", self.default_model)
         response.setdefault("fallback_model", None)
         response["deterministic_checks_used"] = [
             "image_reference_present",
@@ -46,7 +69,37 @@ class MockModelAdapter:
             "darkness_score",
             "sharpness_edge_score",
         ]
-        return normalize_model_result(response, default_model=response["vision_model_used"], allowed_reason_codes=self.allowed_reason_codes)
+        return normalize_model_result(response, default_model=self.default_model, allowed_reason_codes=self.allowed_reason_codes)
+
+
+class ProviderChainAdapter:
+    """Two-stage moderation chain: cheap moderation API, then vision LLM fallback."""
+
+    def __init__(self, *, stage1: Any | None, stage2: Any, vision_only: bool = False) -> None:
+        self.stage1 = stage1
+        self.stage2 = stage2
+        self.vision_only = vision_only
+
+    def review(self, item: dict, deterministic_checks: dict) -> dict:
+        if self.vision_only or self.stage1 is None:
+            return _guard_vision_only_result(self.stage2.review(item, deterministic_checks))
+
+        stage1_result = self.stage1.review(item, deterministic_checks)
+        if _stage1_can_short_circuit(stage1_result):
+            stage1_result["provider_chain_stage"] = "stage1_moderation_api"
+            stage1_result["provider_chain_decision"] = "stage1_short_circuit"
+            return stage1_result
+
+        stage2_result = self.stage2.review(item, deterministic_checks)
+        if _provider_unavailable(stage1_result) and _provider_unavailable(stage2_result):
+            return _provider_chain_failed(stage1_result, stage2_result)
+
+        stage2_result["moderation_api_used"] = bool(stage1_result.get("moderation_api_used"))
+        stage2_result["moderation_model"] = stage1_result.get("moderation_model")
+        stage2_result["provider_chain_stage"] = "stage2_vision_llm"
+        stage2_result["provider_chain_decision"] = "stage1_fallthrough"
+        stage2_result["stage1_result"] = _provider_result_summary(stage1_result)
+        return stage2_result
 
 
 class CodexOpenAIAdapter:
@@ -342,6 +395,89 @@ def _manual_failure(reason_code: str, model: str, note: str, *, fallback: str | 
     )
 
 
+def _stage1_can_short_circuit(result: dict) -> bool:
+    if result.get("validator") == "fail" or _provider_unavailable(result):
+        return False
+    verdict = result.get("verdict")
+    reason = str(result.get("reason_code") or result.get("raw_reason_code") or "").lower()
+    raw_reason = str(result.get("raw_reason_code") or reason).lower()
+    if verdict == "approve_recommendation" and reason == "clean_profile_style":
+        return True
+    if verdict == "escalate" or reason in HARD_SAFETY_HUMAN_ONLY_REASONS or raw_reason in STAGE1_HARD_SAFETY_REASONS:
+        return True
+    if verdict == "reject_recommendation" and reason not in STAGE1_INCONCLUSIVE_REASONS and raw_reason not in STAGE1_HARD_SAFETY_REASONS:
+        return True
+    return False
+
+
+def _provider_unavailable(result: dict) -> bool:
+    reason = str(result.get("reason_code") or "").lower()
+    raw_reason = str(result.get("raw_reason_code") or reason).lower()
+    return result.get("validator") == "fail" or reason in PROVIDER_UNAVAILABLE_REASONS or raw_reason in PROVIDER_UNAVAILABLE_REASONS
+
+
+def _guard_vision_only_result(result: dict) -> dict:
+    guarded = dict(result)
+    if guarded.get("verdict") in {"approve_recommendation", "review"}:
+        guarded["provider_chain_stage"] = "vision_llm_only"
+        return guarded
+
+    reason = str(guarded.get("reason_code") or guarded.get("raw_reason_code") or "manual_admin_decision").lower()
+    raw_reason = str(guarded.get("raw_reason_code") or reason).lower()
+    guarded.setdefault("raw_reason_code", raw_reason)
+    guarded["provider_chain_stage"] = "vision_llm_only"
+    guarded["provider_chain_decision"] = "vision_only_reject_escalated"
+    guarded["note"] = _append_note(
+        guarded.get("note"),
+        "Vision-only chain does not auto-reject; routed to escalation.",
+    )
+    if reason in HARD_SAFETY_HUMAN_ONLY_REASONS or raw_reason in STAGE1_HARD_SAFETY_REASONS:
+        guarded["verdict"] = "escalate"
+    else:
+        guarded["verdict"] = "review"
+        guarded["reason_code"] = "manual_admin_decision"
+    return guarded
+
+
+def _provider_chain_failed(stage1_result: dict, stage2_result: dict) -> dict:
+    return normalize_model_result(
+        {
+            "verdict": "review",
+            "confidence": 0.0,
+            "reason_code": "provider_chain_failed",
+            "note": "Moderation API and vision LLM providers were both unavailable; routed to agent review.",
+            "unsafe_categories": [],
+            "moderation_api_used": bool(stage1_result.get("moderation_api_used")),
+            "moderation_model": stage1_result.get("moderation_model"),
+            "vision_model_used": stage2_result.get("vision_model_used") or "unavailable",
+            "fallback_model": "provider_chain_failed",
+            "provider_chain_stage": "provider_chain_failed",
+            "provider_chain_decision": "provider_chain_failed",
+            "stage1_result": _provider_result_summary(stage1_result),
+            "stage2_result": _provider_result_summary(stage2_result),
+            "app_profile_photo_checks": default_profile_checks(needs_human_review=True),
+        },
+        default_model=stage2_result.get("vision_model_used") or "unavailable",
+    )
+
+
+def _provider_result_summary(result: dict) -> dict:
+    return {
+        "verdict": result.get("verdict"),
+        "reason_code": result.get("reason_code"),
+        "raw_reason_code": result.get("raw_reason_code"),
+        "validator": result.get("validator"),
+        "confidence": result.get("confidence"),
+        "moderation_model": result.get("moderation_model"),
+        "vision_model_used": result.get("vision_model_used"),
+    }
+
+
+def _append_note(existing: object, addition: str) -> str:
+    text = str(existing or "").strip()
+    return f"{text} {addition}".strip()
+
+
 def _safe_http_error_note(exc: urllib.error.HTTPError) -> str:
     try:
         body = exc.read(512).decode("utf-8", errors="replace")
@@ -379,4 +515,3 @@ def _strings(value: Any):
     elif isinstance(value, list):
         for child in value:
             yield from _strings(child)
-

--- a/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/runner.py
+++ b/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/runner.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any
 
 from .deterministic import inspect_image
-from .model import CodexOpenAIAdapter, MiniMaxCLIAdapter, MockModelAdapter
+from .model import CodexOpenAIAdapter, MiniMaxCLIAdapter, MockModelAdapter, ProviderChainAdapter
 from .policy import combine
 from .queue import normalize_item
 from .runtime_contract import RuntimeContract, is_within_grace_period, review_items_prompt_text
@@ -17,6 +17,8 @@ CODEX_OPENAI_ADAPTER_NAMES = {"codex-openai-image", "codex-openai", "openclaw-co
 OPENAI_MODERATIONS_ADAPTER_NAMES = {"openai-moderations"}
 MINIMAX_FALLBACK_ADAPTER_NAMES = {"minimax-cli", "minimax-fallback", "minimax-vl"}
 OPENROUTER_ADAPTER_NAMES = {"openrouter-multimodal"}
+PROVIDER_CHAIN_ADAPTER_NAMES = {"provider-chain", "anewluv-provider-chain", "mock-provider-chain"}
+VISION_ONLY_CHAIN_ADAPTER_NAMES = {"vision-llm-only", "mock-vision-llm-only"}
 
 SERVER_REASON_CODE_MAP = {
     "clean_profile_style": "unclear_subject",
@@ -344,10 +346,13 @@ def _escalation_route(photo: dict) -> str:
 
 
 def _escalation_reason(photo: dict, *, settings: dict[str, Any]) -> str:
+    normalized = photo.get("normalized_result", {})
     confidence = _confidence(photo)
     floor = settings.get("ai_escalate_below_confidence")
     if settings.get("ai_auto_decide_enabled") is False:
         return "auto_decide_disabled"
+    if normalized.get("provider_chain_decision") == "provider_chain_failed" or normalized.get("raw_reason_code") == "provider_chain_failed":
+        return "provider_chain_failed"
     if isinstance(floor, (int, float)) and confidence < float(floor):
         return "confidence_below_floor"
     if photo.get("planned_action") == "human_admin_review":
@@ -470,6 +475,27 @@ def _build_adapter(model_adapter: str, model_fixture: Path | None, *, runtime_co
     allowed_reason_codes = set(runtime_contract.reason_codes)
     if normalized == "mock":
         return MockModelAdapter(model_fixture, allowed_reason_codes=allowed_reason_codes)
+    if normalized in PROVIDER_CHAIN_ADAPTER_NAMES:
+        return ProviderChainAdapter(
+            stage1=MockModelAdapter(
+                model_fixture,
+                allowed_reason_codes=allowed_reason_codes,
+                key_field="moderation_fixture_key",
+                default_model="mock_moderation_api",
+                provider_defaults={
+                    "moderation_api_used": True,
+                    "moderation_model": "mock_moderation_api",
+                    "vision_model_used": "not_called",
+                },
+            ),
+            stage2=MockModelAdapter(model_fixture, allowed_reason_codes=allowed_reason_codes, default_model="mock_vision_llm"),
+        )
+    if normalized in VISION_ONLY_CHAIN_ADAPTER_NAMES:
+        return ProviderChainAdapter(
+            stage1=None,
+            stage2=MockModelAdapter(model_fixture, allowed_reason_codes=allowed_reason_codes, default_model="mock_vision_llm"),
+            vision_only=True,
+        )
     if normalized in CODEX_OPENAI_ADAPTER_NAMES:
         instructions = None
         if runtime_contract.review_items:
@@ -500,6 +526,12 @@ def _provider_report(model_adapter: str, *, dry_run: bool) -> dict:
     elif normalized in OPENROUTER_ADAPTER_NAMES:
         provider = "openrouter-multimodal"
         model_route = "openrouter-multimodal"
+    elif normalized in PROVIDER_CHAIN_ADAPTER_NAMES:
+        provider = "provider-chain"
+        model_route = "mock_moderation_api -> mock_vision_llm"
+    elif normalized in VISION_ONLY_CHAIN_ADAPTER_NAMES:
+        provider = "vision-llm-only"
+        model_route = "mock_vision_llm"
     else:
         provider = "mock"
         model_route = "mock_fixture"

--- a/Pryan-Fire/projects/backend/anewluv-photo-moderation/tests/test_smoke.py
+++ b/Pryan-Fire/projects/backend/anewluv-photo-moderation/tests/test_smoke.py
@@ -949,6 +949,52 @@ class ProviderChainPhaseFourTests(unittest.TestCase):
         self.assertEqual(photo["normalized_result"]["raw_reason_code"], "provider_chain_failed")
         self.assertEqual(photo["normalized_result"]["provider_chain_decision"], "provider_chain_failed")
 
+    def test_stage2_invalid_missing_provider_output_escalates_without_decision(self):
+        class FakeClient:
+            def __init__(self):
+                self.decisions = []
+                self.escalations = []
+                self.queue_item = None
+
+            def queue(self, *, page=1, per_page=None, limit=None):
+                return {
+                    "settings": {"ai_auto_decide_enabled": True, "ai_escalate_below_confidence": 0.7},
+                    "reason_codes": PHOTO_REASON_CODES,
+                    "review_items": PHOTO_FALLBACK_REVIEW_ITEMS,
+                    "items": [self.queue_item],
+                }
+
+            def ai_decide(self, payload):
+                self.decisions.append(payload)
+                return {"coerced": False}
+
+            def escalation_open(self, payload):
+                self.escalations.append(payload)
+                return {"escalation_id": 344}
+
+        fake = FakeClient()
+        result = self._run_chain_case(
+            "manual_review_needed",
+            "invalid_missing_reason",
+            dry_run=False,
+            xano_client=fake,
+            fixture_extra={
+                "invalid_missing_reason": {
+                    "verdict": "reject_recommendation",
+                    "confidence": 0.95,
+                    "note": "provider omitted reason code",
+                    "unsafe_categories": ["unknown"],
+                }
+            },
+        )
+        photo = result["photos"][0]
+
+        self.assertEqual(fake.decisions, [])
+        self.assertEqual(len(fake.escalations), 1)
+        self.assertEqual(fake.escalations[0]["route"], "agent_review")
+        self.assertEqual(photo["planned_action"], "agent_review")
+        self.assertEqual(photo["normalized_result"]["provider_chain_decision"], "stage1_fallthrough")
+
     def test_vision_only_chain_never_auto_rejects_clean_approval_still_allowed(self):
         class FakeClient:
             def __init__(self, key):

--- a/Pryan-Fire/projects/backend/anewluv-photo-moderation/tests/test_smoke.py
+++ b/Pryan-Fire/projects/backend/anewluv-photo-moderation/tests/test_smoke.py
@@ -522,6 +522,8 @@ class PhotoSweeperSmokeTests(unittest.TestCase):
 
     def test_provider_order_names_are_accepted_or_fail_closed_without_live_calls(self):
         self.assertEqual(json.loads(run_cli("--once", "--provider", "mock", "--limit", "1").stdout)["provider"], "mock")
+        self.assertEqual(json.loads(run_cli("--once", "--provider", "provider-chain", "--limit", "1").stdout)["provider"], "provider-chain")
+        self.assertEqual(json.loads(run_cli("--once", "--provider", "vision-llm-only", "--limit", "1").stdout)["provider"], "vision-llm-only")
 
         proc = run_cli("--once", "--provider", "openai-moderations", "--limit", "1", check=False)
         self.assertEqual(proc.returncode, 2)
@@ -790,6 +792,199 @@ class PhotoSweeperSmokeTests(unittest.TestCase):
         self.assertEqual(result["reason_code"], "manual_admin_decision")
         self.assertEqual(result["fallback_model"], "manual_review")
         self.assertIn("timed out", result["note"])
+
+
+class ProviderChainPhaseFourTests(unittest.TestCase):
+    def _run_chain_case(self, stage1_key, stage2_key, *, dry_run=True, xano_client=None, fixture_extra=None):
+        fixture = {
+            "clean_profile_style": {
+                "verdict": "approve_recommendation",
+                "confidence": 0.93,
+                "reason_code": "clean_profile_style",
+                "note": "clean",
+                "unsafe_categories": [],
+                "app_profile_photo_checks": {
+                    "is_profile_style_photo": True,
+                    "has_contact_info": False,
+                    "is_meme_or_screenshot": False,
+                    "is_blank_or_unusable": False,
+                    "ai_generated_or_synthetic": False,
+                    "needs_human_review": False,
+                },
+            },
+            "sexual_content": {
+                "verdict": "reject_recommendation",
+                "confidence": 0.91,
+                "reason_code": "sexual_content",
+                "note": "hard safety",
+                "unsafe_categories": ["sexual_content"],
+            },
+            "not_person_photo": {
+                "verdict": "reject_recommendation",
+                "confidence": 0.94,
+                "reason_code": "not_person_photo",
+                "note": "no person",
+                "unsafe_categories": ["not_person_photo"],
+                "app_profile_photo_checks": {"needs_human_review": False},
+            },
+            "manual_review_needed": {
+                "verdict": "review",
+                "confidence": 0.42,
+                "reason_code": "manual_review_needed",
+                "note": "inconclusive",
+                "unsafe_categories": [],
+            },
+            "api_failure_fallback": {
+                "verdict": "review",
+                "confidence": 0.0,
+                "reason_code": "api_failure_fallback",
+                "note": "provider unavailable",
+                "unsafe_categories": [],
+                "fallback_model": "mock_failure_fallback",
+            },
+            "ai_generated": {
+                "verdict": "reject_recommendation",
+                "confidence": 0.95,
+                "reason_code": "ai_generated",
+                "note": "synthetic person",
+                "unsafe_categories": ["ai_generated_or_synthetic"],
+                "app_profile_photo_checks": {
+                    "is_profile_style_photo": False,
+                    "has_contact_info": False,
+                    "is_meme_or_screenshot": False,
+                    "is_blank_or_unusable": False,
+                    "ai_generated_or_synthetic": True,
+                    "needs_human_review": False,
+                },
+            },
+        }
+        if fixture_extra:
+            fixture.update(fixture_extra)
+        queue_item = dict(load_queue()[0], photostatus_id=1, deleted=False, moderation_fixture_key=stage1_key, model_fixture_key=stage2_key)
+        with tempfile.NamedTemporaryFile("w", suffix=".json") as handle:
+            json.dump(fixture, handle)
+            handle.flush()
+            if xano_client is not None:
+                xano_client.queue_item = queue_item
+            return run_once([queue_item], limit=1, photo_id=None, dry_run=dry_run, force=False, model_fixture=Path(handle.name), model_adapter="provider-chain", xano_client=xano_client)
+
+    def test_stage1_clean_approval_short_circuits_without_stage2(self):
+        result = self._run_chain_case("clean_profile_style", "sexual_content")
+        photo = result["photos"][0]
+
+        self.assertEqual(photo["planned_action"], "report_only")
+        self.assertEqual(photo["recommended_decision"], "approve_recommendation")
+        self.assertEqual(photo["model_path"]["moderation_model"], "mock_moderation_api")
+        self.assertEqual(photo["model_path"]["vision_model_used"], "not_called")
+        self.assertEqual(photo["normalized_result"]["provider_chain_decision"], "stage1_short_circuit")
+
+    def test_stage1_hard_safety_short_circuits_to_human_without_stage2(self):
+        result = self._run_chain_case("sexual_content", "clean_profile_style")
+        photo = result["photos"][0]
+
+        self.assertEqual(photo["planned_action"], "human_admin_review")
+        self.assertIsNone(photo["recommended_decision"])
+        self.assertEqual(photo["model_path"]["vision_model_used"], "not_called")
+        self.assertEqual(photo["normalized_result"]["provider_chain_decision"], "stage1_short_circuit")
+
+    def test_stage1_clear_non_safety_reject_short_circuits(self):
+        result = self._run_chain_case("not_person_photo", "clean_profile_style")
+        photo = result["photos"][0]
+
+        self.assertEqual(photo["normalized_result"]["provider_chain_decision"], "stage1_short_circuit")
+        self.assertEqual(photo["model_path"]["vision_model_used"], "not_called")
+        self.assertEqual(photo["normalized_result"]["verdict"], "reject_recommendation")
+
+    def test_stage1_inconclusive_falls_through_to_stage2_vision_llm(self):
+        result = self._run_chain_case("manual_review_needed", "clean_profile_style")
+        photo = result["photos"][0]
+
+        self.assertEqual(photo["planned_action"], "report_only")
+        self.assertEqual(photo["model_path"]["moderation_model"], "mock_moderation_api")
+        self.assertEqual(photo["model_path"]["vision_model_used"], "mock_vision_llm")
+        self.assertEqual(photo["normalized_result"]["provider_chain_decision"], "stage1_fallthrough")
+        self.assertEqual(photo["normalized_result"]["stage1_result"]["reason_code"], "manual_admin_decision")
+
+    def test_stage1_failure_falls_through_to_stage2_vision_llm(self):
+        result = self._run_chain_case("api_failure_fallback", "clean_profile_style")
+        photo = result["photos"][0]
+
+        self.assertEqual(photo["planned_action"], "report_only")
+        self.assertEqual(photo["model_path"]["vision_model_used"], "mock_vision_llm")
+        self.assertEqual(photo["normalized_result"]["provider_chain_decision"], "stage1_fallthrough")
+        self.assertEqual(photo["normalized_result"]["stage1_result"]["raw_reason_code"], "api_failure_fallback")
+
+    def test_both_providers_failed_escalates_with_provider_chain_failed_reason(self):
+        class FakeClient:
+            def __init__(self):
+                self.decisions = []
+                self.escalations = []
+                self.queue_item = None
+
+            def queue(self, *, page=1, per_page=None, limit=None):
+                return {
+                    "settings": {"ai_auto_decide_enabled": True, "ai_escalate_below_confidence": 0.7},
+                    "reason_codes": PHOTO_REASON_CODES,
+                    "review_items": PHOTO_FALLBACK_REVIEW_ITEMS,
+                    "items": [self.queue_item],
+                }
+
+            def ai_decide(self, payload):
+                self.decisions.append(payload)
+                return {"coerced": False}
+
+            def escalation_open(self, payload):
+                self.escalations.append(payload)
+                return {"escalation_id": 342}
+
+        fake = FakeClient()
+        result = self._run_chain_case("api_failure_fallback", "api_failure_fallback", dry_run=False, xano_client=fake)
+        photo = result["photos"][0]
+
+        self.assertEqual(fake.decisions, [])
+        self.assertEqual(len(fake.escalations), 1)
+        self.assertEqual(fake.escalations[0]["route"], "agent_review")
+        self.assertEqual(result["decision_calls"][0]["reason"], "provider_chain_failed")
+        self.assertEqual(photo["planned_action"], "agent_review")
+        self.assertEqual(photo["normalized_result"]["raw_reason_code"], "provider_chain_failed")
+        self.assertEqual(photo["normalized_result"]["provider_chain_decision"], "provider_chain_failed")
+
+    def test_vision_only_chain_never_auto_rejects_clean_approval_still_allowed(self):
+        class FakeClient:
+            def __init__(self, key):
+                self.key = key
+                self.decisions = []
+                self.escalations = []
+
+            def queue(self, *, page=1, per_page=None, limit=None):
+                item = dict(load_queue()[0], photostatus_id=1, deleted=False, model_fixture_key=self.key)
+                return {
+                    "settings": {"ai_auto_decide_enabled": True, "ai_escalate_below_confidence": 0.7},
+                    "reason_codes": PHOTO_REASON_CODES,
+                    "review_items": PHOTO_FALLBACK_REVIEW_ITEMS,
+                    "items": [item],
+                }
+
+            def ai_decide(self, payload):
+                self.decisions.append(payload)
+                return {"coerced": False}
+
+            def escalation_open(self, payload):
+                self.escalations.append(payload)
+                return {"escalation_id": 343}
+
+        clean_client = FakeClient("clean_profile_style")
+        clean = run_once([], limit=1, photo_id=None, dry_run=False, force=False, model_fixture=None, model_adapter="vision-llm-only", xano_client=clean_client)
+        self.assertEqual(clean_client.decisions[0]["decision"], "approved")
+        self.assertEqual(clean["photos"][0]["normalized_result"]["provider_chain_stage"], "vision_llm_only")
+
+        reject_client = FakeClient("ai_generated_or_synthetic")
+        reject = run_once([], limit=1, photo_id=None, dry_run=False, force=False, model_fixture=None, model_adapter="vision-llm-only", xano_client=reject_client)
+        self.assertEqual(reject_client.decisions, [])
+        self.assertEqual(len(reject_client.escalations), 1)
+        self.assertEqual(reject_client.escalations[0]["route"], "agent_review")
+        self.assertEqual(reject["photos"][0]["planned_action"], "agent_review")
+        self.assertNotEqual(reject["photos"][0]["planned_action"], "auto_reject")
 
 
 class XanoPhaseOneTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

Implements #342 provider-chain and fail-closed escalation routing for the ANewLuv photo moderation worker.

## What changed

- Adds provider-chain adapter support:
  - Stage 1 mock moderation API path
  - Stage 2 mock vision LLM fallback path
  - vision-only guarded path
- Adds provider-chain decision metadata to normalized results.
- Adds fail-closed `provider_chain_failed` escalation reason when both providers are unavailable.
- Keeps #341 live settings gates in front of writes:
  - kill switch
  - confidence floor
  - grace period
  - per-run caps
- Ensures vision-only chain does not auto-reject.
- Adds CLI provider choices for provider-chain test routes.
- Adds tests for the #342 acceptance matrix.

## Evidence

From `Pryan-Fire/projects/backend/anewluv-photo-moderation`:

```txt
PYTHONPATH=src python3 -m unittest tests.test_smoke -v
Ran 71 tests in 1.752s
OK
```

## Exact proof bullets / tests

- Stage 1 clean approval short-circuits without Stage 2:
  - `test_stage1_clean_approval_short_circuits_without_stage2`
- Stage 1 hard safety escalates to human admin and does not call Stage 2:
  - `test_stage1_hard_safety_short_circuits_to_human_without_stage2`
- Stage 1 inconclusive calls Stage 2:
  - `test_stage1_inconclusive_falls_through_to_stage2_vision_llm`
- Stage 1 unreachable/failure calls Stage 2 fallback:
  - `test_stage1_failure_falls_through_to_stage2_vision_llm`
- Both providers unreachable escalates with `provider_chain_failed`:
  - `test_both_providers_failed_escalates_with_provider_chain_failed_reason`
- Invalid/missing provider output escalates, no decision:
  - `test_stage2_invalid_missing_provider_output_escalates_without_decision`
- Vision-only chain never auto-rejects:
  - `test_vision_only_chain_never_auto_rejects_clean_approval_still_allowed`
- Confidence below settings floor escalates before `ai_decide`:
  - `test_live_settings_confidence_floor_routes_to_escalation_before_ai_decide`
- #341 settings still govern the run:
  - `test_live_settings_auto_decide_disabled_skips_model_and_escalates_all`
  - `test_live_settings_max_decisions_cap_and_zero_are_honored`
  - `test_live_settings_grace_period_filters_client_side`
  - `test_live_settings_echo_is_reported_at_run_start`
- Audit/provider attempt breadcrumbs are preserved in normalized output:
  - provider-chain tests assert `provider_chain_decision`, `stage1_result`, `raw_reason_code`, `model_path`, and escalation reason paths.

## Notes

This stays scoped to the worker provider-chain behavior. It does not merge #344, does not add a duplicate docs overview, and does not touch the unrelated crypto/dashboard PR.