### PR TITLE
#342 fix provider-chain review blockers

### DIFF
--- a/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/cli.py
+++ b/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/cli.py
@@ -101,7 +101,6 @@ def main(argv: list[str] | None = None) -> int:
         print(f"{provider} uses mock provider-chain adapters and is blocked for --live-write; use --dry-run or a real provider adapter.", file=sys.stderr)
         return 2
     queue = [] if live_write else load_queue(args.queue_fixture)
-    client = XanoModerationClient(XanoConfig.from_env()) if live_write else None
     lock_context = RunLock(args.lock_file) if live_write and not args.no_lock else None
     try:
         if lock_context is None:
@@ -115,7 +114,7 @@ def main(argv: list[str] | None = None) -> int:
                 force=bool(args.force),
                 model_fixture=args.model_fixture,
                 model_adapter=provider,
-                xano_client=client,
+                xano_client=XanoModerationClient(XanoConfig.from_env()) if live_write else None,
             )
         else:
             with lock_context:
@@ -129,7 +128,7 @@ def main(argv: list[str] | None = None) -> int:
                     force=bool(args.force),
                     model_fixture=args.model_fixture,
                     model_adapter=provider,
-                    xano_client=client,
+                    xano_client=XanoModerationClient(XanoConfig.from_env()),
                 )
     except LockHeld as exc:
         print(str(exc), file=sys.stderr)

--- a/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/cli.py
+++ b/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/cli.py
@@ -96,8 +96,11 @@ def main(argv: list[str] | None = None) -> int:
         return 2
 
     live_write = bool(args.live_write)
-    queue = [] if live_write else load_queue(args.queue_fixture)
     provider = args.provider or args.model_adapter
+    if live_write and provider in {"provider-chain", "anewluv-provider-chain", "mock-provider-chain", "vision-llm-only", "mock-vision-llm-only"}:
+        print(f"{provider} uses mock provider-chain adapters and is blocked for --live-write; use --dry-run or a real provider adapter.", file=sys.stderr)
+        return 2
+    queue = [] if live_write else load_queue(args.queue_fixture)
     client = XanoModerationClient(XanoConfig.from_env()) if live_write else None
     lock_context = RunLock(args.lock_file) if live_write and not args.no_lock else None
     try:

--- a/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/model.py
+++ b/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/model.py
@@ -445,6 +445,7 @@ def _provider_chain_failed(stage1_result: dict, stage2_result: dict) -> dict:
             "verdict": "review",
             "confidence": 0.0,
             "reason_code": "provider_chain_failed",
+            "raw_reason_code": "provider_chain_failed",
             "note": "Moderation API and vision LLM providers were both unavailable; routed to agent review.",
             "unsafe_categories": [],
             "moderation_api_used": bool(stage1_result.get("moderation_api_used")),
@@ -458,6 +459,7 @@ def _provider_chain_failed(stage1_result: dict, stage2_result: dict) -> dict:
             "app_profile_photo_checks": default_profile_checks(needs_human_review=True),
         },
         default_model=stage2_result.get("vision_model_used") or "unavailable",
+        allowed_reason_codes={"provider_chain_failed"},
     )
 
 

--- a/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/runner.py
+++ b/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/runner.py
@@ -377,6 +377,8 @@ def _server_reason_code(photo: dict) -> str:
 
 
 def _server_reason_code_from_model_result(normalized: dict, *, runtime_contract: RuntimeContract | None = None) -> str:
+    if normalized.get("provider_chain_decision") == "provider_chain_failed" or normalized.get("raw_reason_code") == "provider_chain_failed":
+        return "provider_chain_failed"
     reason = str(normalized.get("reason_code") or normalized.get("raw_reason_code") or "manual_admin_decision").strip()
     if runtime_contract is not None and reason in runtime_contract.reason_codes:
         return reason

--- a/Pryan-Fire/projects/backend/anewluv-photo-moderation/tests/test_smoke.py
+++ b/Pryan-Fire/projects/backend/anewluv-photo-moderation/tests/test_smoke.py
@@ -68,6 +68,12 @@ class PhotoSweeperSmokeTests(unittest.TestCase):
         self.assertIs(payload["photos"][0]["would_write_recommendation"], False)
         self.assertIs(payload["photos"][0]["would_finalize_decision"], False)
 
+    def test_cli_blocks_mock_provider_chain_for_live_write(self):
+        proc = run_cli("--once", "--live-write", "--provider", "provider-chain", check=False)
+
+        self.assertEqual(proc.returncode, 2)
+        self.assertIn("blocked for --live-write", proc.stderr)
+
     def test_nudity_sexual_and_explicit_categories_are_recommendations_not_final_decisions(self):
         queue = load_queue()
         result = run_once(queue, limit=None, photo_id=None, dry_run=True, force=False, model_fixture=None)
@@ -945,7 +951,10 @@ class ProviderChainPhaseFourTests(unittest.TestCase):
         self.assertEqual(len(fake.escalations), 1)
         self.assertEqual(fake.escalations[0]["route"], "agent_review")
         self.assertEqual(result["decision_calls"][0]["reason"], "provider_chain_failed")
+        self.assertEqual(fake.escalations[0]["reason_code"], "provider_chain_failed")
         self.assertEqual(photo["planned_action"], "agent_review")
+        self.assertEqual(photo["server_reason_code"], "provider_chain_failed")
+        self.assertEqual(photo["normalized_result"]["reason_code"], "provider_chain_failed")
         self.assertEqual(photo["normalized_result"]["raw_reason_code"], "provider_chain_failed")
         self.assertEqual(photo["normalized_result"]["provider_chain_decision"], "provider_chain_failed")
 


### PR DESCRIPTION
## Summary\n\nFollow-up for #352 after hidden Codex line comments surfaced during the merge window. #352 was merged at head 3d4be1ade before these two review blockers landed; this PR carries only the blocker fixes on top of current feat/anewluv-photo-moderation-worker.\n\n## Fixes\n\n- P1: block mock provider-chain aliases under --live-write before Xano client setup.\n  - Blocks: provider-chain, anewluv-provider-chain, mock-provider-chain, vision-llm-only, mock-vision-llm-only.\n  - Dry-run/test usage remains available.\n- P2: preserve provider_chain_failed as canonical through normalization, server_reason_code, and escalation payload reason_code.\n\n## Evidence\n\nFrom Pryan-Fire/projects/backend/anewluv-photo-moderation:\n\n```txt\nPYTHONPATH=src python3 -m unittest tests.test_smoke -v\nRan 72 tests in 1.768s\nOK\n```\n\n## Notes\n\nNo docs changes, no extra scope. Devon will not self-merge.