### PR TITLE
#346 add autonomous agent review loop

### DIFF
--- a/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/agent_review.py
+++ b/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/agent_review.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import time
+import uuid
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from .xano_client import XanoClientError, XanoModerationClient, XanoRaceSkip
+
+AGENT_REVIEW_ROUTE = "agent_review"
+OPEN_STATUS = "open"
+AuditPoster = Callable[[str, str], None]
+Sleeper = Callable[[float], None]
+
+
+@dataclass(frozen=True)
+class AgentReviewDecision:
+    status: str
+    reason_code: str | None
+    note: str
+
+
+def run_agent_review_once(
+    client: XanoModerationClient,
+    *,
+    limit: int | None = None,
+    run_id: str | None = None,
+    audit_poster: AuditPoster | None = None,
+    sleeper: Sleeper = time.sleep,
+) -> dict[str, Any]:
+    run_id = run_id or str(uuid.uuid4())
+    settings = _safe_settings(client)
+    if settings.get("agent_review_enabled") is False:
+        return _summary(run_id=run_id, polled=0, decisions=[])
+
+    payload = client.escalations(status=OPEN_STATUS, route=AGENT_REVIEW_ROUTE)
+    rows = _rows(payload)
+    if limit is not None:
+        rows = rows[: max(0, int(limit))]
+
+    decisions: list[dict[str, Any]] = []
+    for row in rows:
+        escalation_id = row.get("id") or row.get("escalation_id")
+        if escalation_id is None:
+            decisions.append({"status": "skipped", "reason": "missing_escalation_id", "row": _redacted_row(row)})
+            continue
+        decision = decide_escalation(row)
+        ack_payload = _ack_payload(decision, escalation_id=escalation_id, run_id=run_id)
+        result = _ack_with_backoff(client, ack_payload, sleeper=sleeper)
+        record = {
+            "escalation_id": escalation_id,
+            "photo_id": _photo_id(row),
+            "status": result["status"],
+            "decision": decision.status,
+            "reason_code": decision.reason_code,
+            "idempotency_key": ack_payload["idempotency_key"],
+            "ack_payload": ack_payload,
+        }
+        if result.get("skipped"):
+            record["skipped"] = True
+        if result.get("deferred"):
+            record["deferred"] = True
+        decisions.append(record)
+
+    channel_id = str(settings.get("agent_review_discord_channel_id") or "").strip()
+    audit = _post_audit(decisions, channel_id=channel_id, audit_poster=audit_poster)
+    summary = _summary(run_id=run_id, polled=len(rows), decisions=decisions)
+    summary["audit"] = audit
+    return summary
+
+
+def decide_escalation(row: dict[str, Any]) -> AgentReviewDecision:
+    assessment = _assessment(row)
+    decision = str(assessment.get("recommended_decision") or assessment.get("decision") or assessment.get("verdict") or "").lower()
+    reason_code = _first_str(
+        assessment.get("reason_code"),
+        assessment.get("server_reason_code"),
+        assessment.get("canonical_reason_code"),
+        row.get("reason_code"),
+    )
+    confidence = _confidence(assessment)
+
+    if decision in {"approved", "approve", "approve_recommendation"} and confidence >= 0.80:
+        return AgentReviewDecision("approved", reason_code, f"Zifnab autonomous approval at confidence {confidence:.2f}.")
+    if decision in {"rejected", "reject", "reject_recommendation"} and confidence >= 0.80:
+        return AgentReviewDecision("rejected", reason_code, f"Zifnab autonomous rejection at confidence {confidence:.2f}.")
+    return AgentReviewDecision("needs_human_admin", reason_code, "Zifnab autonomous review deferred to human admin.")
+
+
+def default_discord_audit_poster(channel_id: str, message: str) -> None:
+    subprocess.run(
+        ["openclaw", "message", "send", "--channel", "discord", "--target", f"channel:{channel_id}", "--message", message],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+
+def _safe_settings(client: XanoModerationClient) -> dict[str, Any]:
+    try:
+        raw = client.moderation_settings()
+    except Exception:
+        return {}
+    settings = raw.get("settings") if isinstance(raw, dict) else None
+    if isinstance(settings, dict):
+        return settings
+    if isinstance(raw, dict):
+        return raw
+    return {}
+
+
+def _ack_payload(decision: AgentReviewDecision, *, escalation_id: Any, run_id: str) -> dict[str, Any]:
+    payload = {
+        "escalation_id": escalation_id,
+        "status": decision.status,
+        "expected_current_status": OPEN_STATUS,
+        "expected_route": AGENT_REVIEW_ROUTE,
+        "idempotency_key": f"{run_id}:{escalation_id}",
+        "note": decision.note,
+    }
+    if decision.reason_code:
+        payload["override_reason_code"] = decision.reason_code
+    return payload
+
+
+def _ack_with_backoff(client: XanoModerationClient, payload: dict[str, Any], *, sleeper: Sleeper) -> dict[str, Any]:
+    for attempt in range(4):
+        try:
+            client.escalation_ack(payload)
+            return {"status": "acked"}
+        except XanoRaceSkip:
+            return {"status": "race_skip", "skipped": True}
+        except XanoClientError as exc:
+            if getattr(exc, "status_code", None) and int(exc.status_code) >= 500 and attempt < 3:
+                sleeper(2**attempt)
+                continue
+            return {"status": "deferred", "deferred": True, "error": str(exc)}
+    return {"status": "deferred", "deferred": True}
+
+
+def _post_audit(decisions: list[dict[str, Any]], *, channel_id: str, audit_poster: AuditPoster | None) -> dict[str, Any]:
+    posted = [item for item in decisions if item.get("status") == "acked"]
+    if not posted or not channel_id:
+        return {"posted": False, "reason": "empty" if not posted else "channel_not_configured"}
+    always = [item for item in posted if item.get("decision") == "needs_human_admin"]
+    if len(posted) <= 5:
+        lines = [_audit_line(item) for item in posted]
+    else:
+        top = always or posted[:5]
+        lines = [f"Zifnab photo escalation review: {len(posted)} decisions"] + [_audit_line(item) for item in top]
+    message = "\n".join(lines)
+    try:
+        (audit_poster or default_discord_audit_poster)(channel_id, message)
+    except Exception as exc:
+        return {"posted": False, "failed": True, "error": exc.__class__.__name__}
+    return {"posted": True, "count": len(lines)}
+
+
+def _audit_line(item: dict[str, Any]) -> str:
+    return (
+        f"photo_id={item.get('photo_id')} decision={item.get('decision')} "
+        f"reason_code={item.get('reason_code') or 'none'} idempotency_key={item.get('idempotency_key')}"
+    )
+
+
+def _summary(*, run_id: str, polled: int, decisions: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "run_id": run_id,
+        "route": AGENT_REVIEW_ROUTE,
+        "polled": polled,
+        "acked": sum(1 for item in decisions if item.get("status") == "acked"),
+        "race_skips": sum(1 for item in decisions if item.get("status") == "race_skip"),
+        "deferred": sum(1 for item in decisions if item.get("status") == "deferred"),
+        "decisions": decisions,
+    }
+
+
+def _rows(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    for key in ("items", "rows", "data", "result"):
+        value = payload.get(key) if isinstance(payload, dict) else None
+        if isinstance(value, list):
+            return [dict(item) for item in value if isinstance(item, dict)]
+    return []
+
+
+def _assessment(row: dict[str, Any]) -> dict[str, Any]:
+    value = row.get("last_ai_assessment") or row.get("ai_assessment") or row.get("normalized_result") or {}
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except json.JSONDecodeError:
+            return {}
+    return value if isinstance(value, dict) else {}
+
+
+def _photo_id(row: dict[str, Any]) -> Any:
+    photo = row.get("photo") if isinstance(row.get("photo"), dict) else {}
+    return row.get("photo_id") or photo.get("id") or photo.get("photo_id")
+
+
+def _confidence(assessment: dict[str, Any]) -> float:
+    try:
+        return max(0.0, min(1.0, float(assessment.get("confidence", 0.0))))
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _first_str(*values: Any) -> str | None:
+    for value in values:
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def _redacted_row(row: dict[str, Any]) -> dict[str, Any]:
+    return {"id": row.get("id"), "escalation_id": row.get("escalation_id"), "photo_id": _photo_id(row)}

--- a/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/cli.py
+++ b/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/cli.py
@@ -5,6 +5,7 @@ import json
 import sys
 from pathlib import Path
 
+from .agent_review import run_agent_review_once
 from .lock import LockHeld, RunLock
 from .queue import load_queue
 from .runner import run_once
@@ -35,6 +36,7 @@ def build_parser() -> argparse.ArgumentParser:
         description="Dry-run Anewluv photo moderation recommendation worker.",
     )
     parser.add_argument("--once", action="store_true", help="Run one dry-run sweep.")
+    parser.add_argument("--agent-review", action="store_true", help="Run one autonomous agent-review escalation sweep.")
     parser.add_argument("--dry-run", action="store_true", help="Emit recommendations without writes.")
     parser.add_argument(
         "--live-write",
@@ -96,6 +98,18 @@ def main(argv: list[str] | None = None) -> int:
         return 2
 
     live_write = bool(args.live_write)
+    if args.agent_review:
+        if not live_write:
+            print("--agent-review requires --live-write.", file=sys.stderr)
+            return 2
+        try:
+            result = run_agent_review_once(XanoModerationClient(XanoConfig.from_env()), limit=args.limit)
+        except ValueError as exc:
+            print(str(exc), file=sys.stderr)
+            return 2
+        print(json.dumps(result, indent=2, sort_keys=True))
+        return 0
+
     provider = args.provider or args.model_adapter
     if live_write and provider in {"provider-chain", "anewluv-provider-chain", "mock-provider-chain", "vision-llm-only", "mock-vision-llm-only"}:
         print(f"{provider} uses mock provider-chain adapters and is blocked for --live-write; use --dry-run or a real provider adapter.", file=sys.stderr)

--- a/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/cli.py
+++ b/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/cli.py
@@ -98,18 +98,6 @@ def main(argv: list[str] | None = None) -> int:
         return 2
 
     live_write = bool(args.live_write)
-    if args.agent_review:
-        if not live_write:
-            print("--agent-review requires --live-write.", file=sys.stderr)
-            return 2
-        try:
-            result = run_agent_review_once(XanoModerationClient(XanoConfig.from_env()), limit=args.limit)
-        except ValueError as exc:
-            print(str(exc), file=sys.stderr)
-            return 2
-        print(json.dumps(result, indent=2, sort_keys=True))
-        return 0
-
     provider = args.provider or args.model_adapter
     if live_write and provider in {"provider-chain", "anewluv-provider-chain", "mock-provider-chain", "vision-llm-only", "mock-vision-llm-only"}:
         print(f"{provider} uses mock provider-chain adapters and is blocked for --live-write; use --dry-run or a real provider adapter.", file=sys.stderr)
@@ -118,20 +106,12 @@ def main(argv: list[str] | None = None) -> int:
     lock_context = RunLock(args.lock_file) if live_write and not args.no_lock else None
     try:
         if lock_context is None:
-            result = run_once(
-                queue,
-                limit=args.limit,
-                photo_id=args.photo_id,
-                page=args.page,
-                per_page=args.per_page,
-                dry_run=not live_write,
-                force=bool(args.force),
-                model_fixture=args.model_fixture,
-                model_adapter=provider,
-                xano_client=XanoModerationClient(XanoConfig.from_env()) if live_write else None,
-            )
-        else:
-            with lock_context:
+            if args.agent_review:
+                if not live_write:
+                    print("--agent-review requires --live-write.", file=sys.stderr)
+                    return 2
+                result = run_agent_review_once(XanoModerationClient(XanoConfig.from_env()), limit=args.limit)
+            else:
                 result = run_once(
                     queue,
                     limit=args.limit,
@@ -142,8 +122,25 @@ def main(argv: list[str] | None = None) -> int:
                     force=bool(args.force),
                     model_fixture=args.model_fixture,
                     model_adapter=provider,
-                    xano_client=XanoModerationClient(XanoConfig.from_env()),
+                    xano_client=XanoModerationClient(XanoConfig.from_env()) if live_write else None,
                 )
+        else:
+            with lock_context:
+                if args.agent_review:
+                    result = run_agent_review_once(XanoModerationClient(XanoConfig.from_env()), limit=args.limit)
+                else:
+                    result = run_once(
+                        queue,
+                        limit=args.limit,
+                        photo_id=args.photo_id,
+                        page=args.page,
+                        per_page=args.per_page,
+                        dry_run=not live_write,
+                        force=bool(args.force),
+                        model_fixture=args.model_fixture,
+                        model_adapter=provider,
+                        xano_client=XanoModerationClient(XanoConfig.from_env()),
+                    )
     except LockHeld as exc:
         print(str(exc), file=sys.stderr)
         return 75

--- a/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/xano_client.py
+++ b/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/xano_client.py
@@ -16,7 +16,9 @@ TOKEN_TTL_SECONDS = 24 * 60 * 60
 
 
 class XanoClientError(RuntimeError):
-    pass
+    def __init__(self, message: str, *, status_code: int | None = None) -> None:
+        super().__init__(message)
+        self.status_code = status_code
 
 
 class XanoRaceSkip(XanoClientError):
@@ -219,7 +221,7 @@ class XanoModerationClient:
             body = _read_error_body(exc)
             if exc.code == 409 or "expected_current_status" in body:
                 raise XanoRaceSkip("expected_current_status mismatch") from exc
-            raise XanoClientError(f"Xano {method} {urllib.parse.urlparse(url).path} returned HTTP {exc.code}") from exc
+            raise XanoClientError(f"Xano {method} {urllib.parse.urlparse(url).path} returned HTTP {exc.code}", status_code=exc.code) from exc
         except urllib.error.URLError as exc:
             raise XanoClientError(f"Xano {method} {urllib.parse.urlparse(url).path} failed: {exc.__class__.__name__}") from exc
 

--- a/Pryan-Fire/projects/backend/anewluv-photo-moderation/tests/test_smoke.py
+++ b/Pryan-Fire/projects/backend/anewluv-photo-moderation/tests/test_smoke.py
@@ -2023,6 +2023,15 @@ class AgentReviewLoopTests(unittest.TestCase):
         self.assertEqual(sleeps, [1, 2, 4])
         self.assertEqual(len(fake.acks), 4)
 
+    def test_cli_agent_review_lock_held_returns_tempfail_before_xano_env(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            lock_path = Path(tmpdir) / "photo-sweeper-agent-review.lock"
+            with RunLock(lock_path):
+                proc = run_cli("--once", "--live-write", "--agent-review", "--lock-file", str(lock_path), "--limit", "1", check=False)
+
+        self.assertEqual(proc.returncode, 75)
+        self.assertIn("lock already held", proc.stderr)
+
 
 class FakeAgentReviewClient:
     def __init__(self, rows, *, settings=None, race_skip=False, server_errors=0):

--- a/Pryan-Fire/projects/backend/anewluv-photo-moderation/tests/test_smoke.py
+++ b/Pryan-Fire/projects/backend/anewluv-photo-moderation/tests/test_smoke.py
@@ -20,8 +20,9 @@ from photo_sweeper.normalization import normalize_minimax_description, normalize
 from photo_sweeper.moderation_contract import IMAGE_TYPE_CLASSIFICATIONS, WORKER_MODEL_CATEGORIES
 from photo_sweeper.policy import combine
 from photo_sweeper.queue import load_queue
+from photo_sweeper.agent_review import run_agent_review_once
 from photo_sweeper.runner import run_once
-from photo_sweeper.xano_client import TokenCache, XanoConfig, XanoModerationClient
+from photo_sweeper.xano_client import TokenCache, XanoClientError, XanoConfig, XanoModerationClient
 
 PHOTO_REASON_CODES = [
     {"code": "unclear_subject", "auto_reject_threshold": None, "severity": "low"},
@@ -1953,6 +1954,101 @@ class XanoPhaseOneTests(unittest.TestCase):
         self.assertIs(call["skipped"], True)
         self.assertEqual(result["summary"]["race_skips"], 1)
         self.assertEqual(result["summary"]["failures"], [{"photo_id": 101, "status": "race_skip"}])
+
+
+class AgentReviewLoopTests(unittest.TestCase):
+    def test_agent_review_polls_agent_review_route_and_acks_with_idempotency(self):
+        fake = FakeAgentReviewClient([
+            {
+                "id": 501,
+                "photo_id": 101,
+                "reason_code": "unclear_subject",
+                "last_ai_assessment": {"recommended_decision": "approve_recommendation", "confidence": 0.91, "reason_code": "unclear_subject"},
+            }
+        ])
+
+        result = run_agent_review_once(fake, run_id="run-1")
+
+        self.assertEqual(fake.polls, [{"status": "open", "route": "agent_review"}])
+        self.assertEqual(result["acked"], 1)
+        self.assertEqual(fake.acks[0]["status"], "approved")
+        self.assertEqual(fake.acks[0]["expected_current_status"], "open")
+        self.assertEqual(fake.acks[0]["expected_route"], "agent_review")
+        self.assertEqual(fake.acks[0]["idempotency_key"], "run-1:501")
+
+    def test_agent_review_409_is_skip_not_error(self):
+        fake = FakeAgentReviewClient([{"id": 502, "photo_id": 102}], race_skip=True)
+
+        result = run_agent_review_once(fake, run_id="run-2")
+
+        self.assertEqual(result["race_skips"], 1)
+        self.assertEqual(result["decisions"][0]["status"], "race_skip")
+        self.assertIs(result["decisions"][0]["skipped"], True)
+
+    def test_agent_review_empty_discord_channel_still_acks_without_post(self):
+        fake = FakeAgentReviewClient([{"id": 503, "photo_id": 103}], settings={"agent_review_discord_channel_id": ""})
+        posts = []
+
+        result = run_agent_review_once(fake, run_id="run-3", audit_poster=lambda channel, message: posts.append((channel, message)))
+
+        self.assertEqual(result["acked"], 1)
+        self.assertEqual(posts, [])
+        self.assertEqual(result["audit"], {"posted": False, "reason": "channel_not_configured"})
+
+    def test_agent_review_discord_failure_does_not_rollback_ack(self):
+        fake = FakeAgentReviewClient([{"id": 504, "photo_id": 104}], settings={"agent_review_discord_channel_id": "148"})
+
+        result = run_agent_review_once(fake, run_id="run-4", audit_poster=lambda channel, message: (_ for _ in ()).throw(RuntimeError("discord down")))
+
+        self.assertEqual(len(fake.acks), 1)
+        self.assertEqual(result["acked"], 1)
+        self.assertTrue(result["audit"]["failed"])
+
+    def test_agent_review_disabled_does_not_poll_queue(self):
+        fake = FakeAgentReviewClient([{"id": 505, "photo_id": 105}], settings={"agent_review_enabled": False})
+
+        result = run_agent_review_once(fake, run_id="run-5")
+
+        self.assertEqual(result["polled"], 0)
+        self.assertEqual(fake.polls, [])
+        self.assertEqual(fake.acks, [])
+
+    def test_agent_review_5xx_retries_then_defers(self):
+        fake = FakeAgentReviewClient([{"id": 506, "photo_id": 106}], server_errors=4)
+        sleeps = []
+
+        result = run_agent_review_once(fake, run_id="run-6", sleeper=sleeps.append)
+
+        self.assertEqual(result["deferred"], 1)
+        self.assertEqual(sleeps, [1, 2, 4])
+        self.assertEqual(len(fake.acks), 4)
+
+
+class FakeAgentReviewClient:
+    def __init__(self, rows, *, settings=None, race_skip=False, server_errors=0):
+        self.rows = rows
+        self.settings = {"agent_review_enabled": True, **(settings or {})}
+        self.race_skip = race_skip
+        self.server_errors = server_errors
+        self.polls = []
+        self.acks = []
+
+    def moderation_settings(self):
+        return {"settings": self.settings}
+
+    def escalations(self, *, status="open", route=None):
+        self.polls.append({"status": status, "route": route})
+        return {"items": self.rows}
+
+    def escalation_ack(self, payload):
+        self.acks.append(payload)
+        if self.race_skip:
+            from photo_sweeper.xano_client import XanoRaceSkip
+
+            raise XanoRaceSkip("expected_current_status mismatch")
+        if len(self.acks) <= self.server_errors:
+            raise XanoClientError("Xano POST /photos/escalations/ack returned HTTP 500", status_code=500)
+        return {"ok": True}
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add an autonomous `agent_review` escalation loop for Zifnab: poll open `agent_review` escalations, decide deterministically from the last AI assessment, and ack with `expected_current_status`, `expected_route`, and per-run idempotency keys.
- Add 409 race-skip handling plus bounded 5xx retry/defer behavior for escalation acknowledgements.
- Add one-way Discord audit visibility with no rollback if posting fails; empty `agent_review_discord_channel_id` suppresses posts while decisions still ack.
- Add CLI entry: `photo-sweeper --once --live-write --agent-review --limit <N>`.

## Evidence
```txt
PYTHONPATH=src python3 -m unittest tests.test_smoke -v
Ran 78 tests in 1.847s
OK

PYTHONPATH=src python3 -m photo_sweeper --once --agent-review
cli_exit=2
--agent-review requires --live-write.
```

## Notes
- No human-in-Discord loop is introduced; Discord is audit-only.
- Cron recommendation for first live pass: run every 5 minutes with the CLI above after maintainer deployment approval.

Closes #346.