### PR TITLE
feat: add photo moderation Jarvis reporting

### DIFF
--- a/Pryan-Fire/projects/backend/anewluv-photo-moderation/README.md
+++ b/Pryan-Fire/projects/backend/anewluv-photo-moderation/README.md
@@ -108,6 +108,22 @@ PYTHONPATH=src python3 -m photo_sweeper --once --photo-id 101 --force
 
 Cron cadence for live capped execution is documented as `*/30 * * * *` after owner approval.
 
+Jarvis/Discord status reporting is opt-in for routine runs so the worker does not spam the lane:
+
+```bash
+JARVIS_REPORT_CHANNEL=<discord-channel-id> photo-sweeper --once --live-write --limit 5 --report
+JARVIS_REPORT_CHANNEL=<discord-channel-id> photo-sweeper --once --live-write --agent-review --limit 5 --report
+```
+
+Supported reporting config names only:
+
+- `JARVIS_REPORT_CHANNEL` — preferred Discord channel id for Jarvis/status summaries.
+- `DISCORD_REPORT_CHANNEL` — fallback Discord channel id.
+- `DISCORD_WEBHOOK_URL` — fallback webhook destination if channel posting is not available.
+- `ANEWLUV_PHOTO_REPORT_ROUTINE=1` — enables routine reports without passing `--report`.
+
+Failure or escalation summaries post promptly when a destination is configured. Routine success summaries require `--report` or `ANEWLUV_PHOTO_REPORT_ROUTINE=1`. Reports include counts, model path, fallback usage, write counts, unresolved escalations, and next scheduled run when known; they do not include raw queue payloads, user email, or user id.
+
 The default queue source is `src/photo_sweeper/fixtures/queue_redacted.json`. Queue items are normalized before output, and `user_email` is omitted from CLI output.
 
 Mock model categories covered by fixture manifests:
@@ -136,7 +152,7 @@ PYTHONPATH=src python3 -m unittest discover -s tests -v
 Result:
 
 ```text
-Ran 6 tests
+Ran 84 tests
 
 OK
 ```

--- a/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/cli.py
+++ b/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/cli.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from .agent_review import run_agent_review_once
 from .lock import LockHeld, RunLock
 from .queue import load_queue
+from .reporting import maybe_report_run
 from .runner import run_once
 from .xano_client import XanoConfig, XanoModerationClient
 
@@ -87,6 +88,16 @@ def build_parser() -> argparse.ArgumentParser:
         default="mock",
         help="Deprecated alias for --provider. Kept for existing smoke scripts.",
     )
+    parser.add_argument(
+        "--report",
+        action="store_true",
+        help="Post a sanitized Jarvis/Discord status summary after the run. Routine posts are opt-in to avoid spam.",
+    )
+    parser.add_argument(
+        "--report-channel",
+        default=None,
+        help="Discord channel id for Jarvis/status reporting. Defaults to JARVIS_REPORT_CHANNEL or DISCORD_REPORT_CHANNEL.",
+    )
     return parser
 
 
@@ -147,5 +158,8 @@ def main(argv: list[str] | None = None) -> int:
     except ValueError as exc:
         print(str(exc), file=sys.stderr)
         return 2
+
+    report_kind = "agent_review" if args.agent_review else "initial_sweeper"
+    result["jarvis_report"] = maybe_report_run(report_kind, result, enabled=args.report, channel_id=args.report_channel)
     print(json.dumps(result, indent=2, sort_keys=True))
     return 0

--- a/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/reporting.py
+++ b/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/reporting.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import urllib.error
+import urllib.request
+from typing import Any, Callable, Mapping
+
+ReportPoster = Callable[[str, str], None]
+
+JARVIS_CHANNEL_ENV = "JARVIS_REPORT_CHANNEL"
+DISCORD_CHANNEL_ENV = "DISCORD_REPORT_CHANNEL"
+WEBHOOK_ENV = "DISCORD_WEBHOOK_URL"
+ROUTINE_ENV = "ANEWLUV_PHOTO_REPORT_ROUTINE"
+
+
+def maybe_report_run(
+    kind: str,
+    result: Mapping[str, Any],
+    *,
+    enabled: bool = False,
+    channel_id: str | None = None,
+    env: Mapping[str, str] | None = None,
+    poster: ReportPoster | None = None,
+) -> dict[str, Any]:
+    """Post a sanitized Jarvis/Discord status report when configured.
+
+    Routine reports are opt-in via --report or ANEWLUV_PHOTO_REPORT_ROUTINE=1.
+    Failure/escalation reports still post promptly when a destination is configured.
+    """
+    env = env or os.environ
+    destination = _destination(channel_id=channel_id, env=env)
+    if not destination:
+        return {"posted": False, "reason": "destination_not_configured"}
+
+    urgent = _is_urgent(kind, result)
+    routine_enabled = enabled or _truthy(env.get(ROUTINE_ENV))
+    if not routine_enabled and not urgent:
+        return {"posted": False, "reason": "routine_suppressed", "urgent": False}
+
+    message = format_report(kind, result, urgent=urgent)
+    try:
+        if poster:
+            poster(destination, message)
+        elif _looks_like_webhook(destination):
+            _post_webhook(destination, message)
+        else:
+            default_discord_report_poster(destination, message)
+    except Exception as exc:  # pragma: no cover - exact transport failures vary by host
+        return {"posted": False, "failed": True, "error": exc.__class__.__name__}
+    return {"posted": True, "urgent": urgent, "destination": _destination_label(destination), "bytes": len(message.encode("utf-8"))}
+
+
+def format_report(kind: str, result: Mapping[str, Any], *, urgent: bool = False) -> str:
+    if kind == "agent_review":
+        return _format_agent_review_report(result, urgent=urgent)
+    return _format_initial_sweeper_report(result, urgent=urgent)
+
+
+def default_discord_report_poster(channel_id: str, message: str) -> None:
+    subprocess.run(
+        ["openclaw", "message", "send", "--channel", "discord", "--target", f"channel:{channel_id}", "--message", message],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+
+def _format_initial_sweeper_report(result: Mapping[str, Any], *, urgent: bool) -> str:
+    summary = _mapping(result.get("summary"))
+    provider = str(result.get("provider") or _first(summary.get("model_api_path_used")) or "unknown")
+    write_counts = _mapping(summary.get("write_counts"))
+    failures = _list(summary.get("failures"))
+    status = "ALERT" if urgent else "STATUS"
+    return "\n".join(
+        [
+            f"Anewluv photo moderation initial sweeper {status}",
+            f"dry_run={_bool_text(summary.get('dry_run', result.get('dry_run')))} photos_scanned={_int(summary.get('photos_scanned'))}",
+            f"auto_approved={_int(summary.get('auto_approved'))} auto_rejected={_int(summary.get('auto_rejected'))} review={_int(summary.get('review'))}",
+            f"agent_review={_int(summary.get('agent_review'))} human_admin_review={_int(summary.get('human_admin_review'))} escalations_opened={_int(summary.get('escalations_opened'))}",
+            f"failures={len(failures)} race_skips={_int(summary.get('race_skips'))} fallback_usage={_int(summary.get('fallback_usage'))}",
+            f"model_api_path={provider} writes_ai_decide={_int(write_counts.get('ai_decide'))} writes_escalations={_int(write_counts.get('escalations_open'))}",
+            f"unresolved_escalations={_int(summary.get('unresolved_escalations'))} next_scheduled_run={summary.get('next_scheduled_run') or 'unknown'}",
+        ]
+    )
+
+
+def _format_agent_review_report(result: Mapping[str, Any], *, urgent: bool) -> str:
+    decisions = _list(result.get("decisions"))
+    status = "ALERT" if urgent else "STATUS"
+    decision_counts: dict[str, int] = {}
+    for item in decisions:
+        if isinstance(item, Mapping):
+            decision = str(item.get("decision") or item.get("status") or "unknown")
+            decision_counts[decision] = decision_counts.get(decision, 0) + 1
+    decision_text = ",".join(f"{key}:{decision_counts[key]}" for key in sorted(decision_counts)) or "none"
+    audit = _mapping(result.get("audit"))
+    return "\n".join(
+        [
+            f"Anewluv photo moderation agent-review sweeper {status}",
+            f"run_id={result.get('run_id') or 'unknown'} route={result.get('route') or 'agent_review'} polled={_int(result.get('polled'))}",
+            f"acked={_int(result.get('acked'))} race_skips={_int(result.get('race_skips'))} deferred={_int(result.get('deferred'))}",
+            f"decisions={decision_text}",
+            f"audit_posted={_bool_text(audit.get('posted'))} audit_failed={_bool_text(audit.get('failed'))}",
+        ]
+    )
+
+
+def _is_urgent(kind: str, result: Mapping[str, Any]) -> bool:
+    if kind == "agent_review":
+        return _int(result.get("deferred")) > 0 or _int(result.get("race_skips")) > 0
+    summary = _mapping(result.get("summary"))
+    return bool(_list(summary.get("failures"))) or _int(summary.get("escalations_opened")) > 0 or _int(summary.get("unresolved_escalations")) > 0
+
+
+def _destination(*, channel_id: str | None, env: Mapping[str, str]) -> str | None:
+    for value in (channel_id, env.get(JARVIS_CHANNEL_ENV), env.get(DISCORD_CHANNEL_ENV), env.get(WEBHOOK_ENV)):
+        if value and str(value).strip():
+            return str(value).strip()
+    return None
+
+
+def _post_webhook(url: str, message: str) -> None:
+    data = ("{\"content\": " + _json_string(message) + "}").encode("utf-8")
+    request = urllib.request.Request(url, data=data, headers={"Content-Type": "application/json"}, method="POST")
+    with urllib.request.urlopen(request, timeout=10) as response:  # noqa: S310 - operator configured webhook URL
+        if response.status >= 400:
+            raise urllib.error.HTTPError(url, response.status, "webhook post failed", response.headers, None)
+
+
+def _json_string(value: str) -> str:
+    # Avoid importing json in the hot path just for a single string payload.
+    return '"' + value.replace('\\', '\\\\').replace('"', '\\"').replace('\n', '\\n') + '"'
+
+
+def _looks_like_webhook(value: str) -> bool:
+    return value.startswith("https://") or value.startswith("http://")
+
+
+def _destination_label(value: str) -> str:
+    return "webhook" if _looks_like_webhook(value) else "discord_channel"
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _first(value: Any) -> Any:
+    if isinstance(value, list) and value:
+        return value[0]
+    return value
+
+
+def _bool_text(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def _truthy(value: str | None) -> bool:
+    return str(value or "").strip().lower() in {"1", "true", "yes", "on"}

--- a/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/reporting.py
+++ b/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/reporting.py
@@ -28,7 +28,8 @@ def maybe_report_run(
     Routine reports are opt-in via --report or ANEWLUV_PHOTO_REPORT_ROUTINE=1.
     Failure/escalation reports still post promptly when a destination is configured.
     """
-    env = env or os.environ
+    if env is None:
+        env = os.environ
     destination = _destination(channel_id=channel_id, env=env)
     if not destination:
         return {"posted": False, "reason": "destination_not_configured"}
@@ -108,7 +109,8 @@ def _format_agent_review_report(result: Mapping[str, Any], *, urgent: bool) -> s
 
 def _is_urgent(kind: str, result: Mapping[str, Any]) -> bool:
     if kind == "agent_review":
-        return _int(result.get("deferred")) > 0 or _int(result.get("race_skips")) > 0
+        audit = _mapping(result.get("audit"))
+        return bool(audit.get("failed")) or _int(result.get("deferred")) > 0 or _int(result.get("race_skips")) > 0
     summary = _mapping(result.get("summary"))
     return bool(_list(summary.get("failures"))) or _int(summary.get("escalations_opened")) > 0 or _int(summary.get("unresolved_escalations")) > 0
 

--- a/Pryan-Fire/projects/backend/anewluv-photo-moderation/tests/test_smoke.py
+++ b/Pryan-Fire/projects/backend/anewluv-photo-moderation/tests/test_smoke.py
@@ -21,6 +21,7 @@ from photo_sweeper.moderation_contract import IMAGE_TYPE_CLASSIFICATIONS, WORKER
 from photo_sweeper.policy import combine
 from photo_sweeper.queue import load_queue
 from photo_sweeper.agent_review import run_agent_review_once
+from photo_sweeper.reporting import format_report, maybe_report_run
 from photo_sweeper.runner import run_once
 from photo_sweeper.xano_client import TokenCache, XanoClientError, XanoConfig, XanoModerationClient
 
@@ -1954,6 +1955,76 @@ class XanoPhaseOneTests(unittest.TestCase):
         self.assertIs(call["skipped"], True)
         self.assertEqual(result["summary"]["race_skips"], 1)
         self.assertEqual(result["summary"]["failures"], [{"photo_id": 101, "status": "race_skip"}])
+
+
+class JarvisReportingTests(unittest.TestCase):
+    def test_initial_sweeper_report_formats_required_stats_without_photo_payloads(self):
+        result = run_once(load_queue(), limit=5, photo_id=None, dry_run=True, force=False, model_fixture=None)
+
+        message = format_report("initial_sweeper", result)
+
+        self.assertIn("initial sweeper STATUS", message)
+        self.assertIn("photos_scanned=5", message)
+        self.assertIn("auto_approved=0", message)
+        self.assertIn("auto_rejected=0", message)
+        self.assertIn("agent_review=1", message)
+        self.assertIn("human_admin_review=3", message)
+        self.assertIn("fallback_usage=0", message)
+        self.assertIn("next_scheduled_run=unknown", message)
+        self.assertNotIn("user_email", message)
+        self.assertNotIn("selected_photo_ids", message)
+
+    def test_routine_report_is_suppressed_without_opt_in(self):
+        posts = []
+        result = run_once(load_queue(), limit=1, photo_id=None, dry_run=True, force=False, model_fixture=None)
+
+        report = maybe_report_run("initial_sweeper", result, env={"JARVIS_REPORT_CHANNEL": "148"}, poster=lambda channel, message: posts.append((channel, message)))
+
+        self.assertEqual(report["reason"], "routine_suppressed")
+        self.assertEqual(posts, [])
+
+    def test_report_posts_when_enabled(self):
+        posts = []
+        result = run_once(load_queue(), limit=1, photo_id=None, dry_run=True, force=False, model_fixture=None)
+
+        report = maybe_report_run("initial_sweeper", result, enabled=True, env={"JARVIS_REPORT_CHANNEL": "148"}, poster=lambda channel, message: posts.append((channel, message)))
+
+        self.assertTrue(report["posted"])
+        self.assertEqual(posts[0][0], "148")
+        self.assertIn("photos_scanned=1", posts[0][1])
+
+    def test_escalation_or_failure_posts_as_urgent_without_routine_opt_in(self):
+        posts = []
+        result = {"summary": {"dry_run": False, "photos_scanned": 1, "escalations_opened": 1, "failures": [], "write_counts": {}}}
+
+        report = maybe_report_run("initial_sweeper", result, env={"JARVIS_REPORT_CHANNEL": "148"}, poster=lambda channel, message: posts.append((channel, message)))
+
+        self.assertTrue(report["posted"])
+        self.assertTrue(report["urgent"])
+        self.assertIn("initial sweeper ALERT", posts[0][1])
+        self.assertIn("escalations_opened=1", posts[0][1])
+
+    def test_agent_review_report_includes_polling_and_decision_stats(self):
+        summary = {
+            "run_id": "run-7",
+            "route": "agent_review",
+            "polled": 3,
+            "acked": 2,
+            "race_skips": 0,
+            "deferred": 1,
+            "decisions": [{"decision": "approved"}, {"decision": "rejected"}, {"status": "deferred"}],
+            "audit": {"posted": True},
+        }
+
+        message = format_report("agent_review", summary, urgent=True)
+
+        self.assertIn("agent-review sweeper ALERT", message)
+        self.assertIn("polled=3", message)
+        self.assertIn("acked=2", message)
+        self.assertIn("deferred=1", message)
+        self.assertIn("approved:1", message)
+        self.assertIn("rejected:1", message)
+        self.assertIn("audit_posted=true", message)
 
 
 class AgentReviewLoopTests(unittest.TestCase):

--- a/Pryan-Fire/projects/backend/anewluv-photo-moderation/tests/test_smoke.py
+++ b/Pryan-Fire/projects/backend/anewluv-photo-moderation/tests/test_smoke.py
@@ -2026,6 +2026,39 @@ class JarvisReportingTests(unittest.TestCase):
         self.assertIn("rejected:1", message)
         self.assertIn("audit_posted=true", message)
 
+    def test_agent_review_audit_failure_is_urgent(self):
+        posts = []
+        summary = {
+            "run_id": "run-8",
+            "route": "agent_review",
+            "polled": 5,
+            "acked": 0,
+            "race_skips": 0,
+            "deferred": 0,
+            "decisions": [],
+            "audit": {"posted": False, "failed": True, "error": "HTTPError"},
+        }
+        report = maybe_report_run(
+            "agent_review", summary,
+            env={"JARVIS_REPORT_CHANNEL": "148"},
+            poster=lambda channel, message: posts.append((channel, message)),
+        )
+        self.assertTrue(report["posted"])
+        self.assertTrue(report["urgent"])
+        self.assertIn("ALERT", posts[0][1])
+
+    def test_empty_env_dict_is_not_replaced_by_host_env(self):
+        posts = []
+        result = {"summary": {"dry_run": False, "photos_scanned": 1, "escalations_opened": 0, "failures": [], "write_counts": {}}}
+        # pass empty env — destination lookup must not fall back to os.environ
+        report = maybe_report_run(
+            "initial_sweeper", result,
+            env={},
+            poster=lambda channel, message: posts.append((channel, message)),
+        )
+        self.assertEqual(report["reason"], "destination_not_configured")
+        self.assertEqual(posts, [])
+
 
 class AgentReviewLoopTests(unittest.TestCase):
     def test_agent_review_polls_agent_review_route_and_acks_with_idempotency(self):


### PR DESCRIPTION
## Summary
- Adds opt-in Jarvis/Discord status reporting for the initial photo-sweeper and agent-review sweeper.
- Posts urgent failure/escalation summaries when a destination is configured, while suppressing routine success spam unless `--report` or `ANEWLUV_PHOTO_REPORT_ROUTINE=1` is set.
- Documents reporting env/config names and adds tests covering required stats and redaction behavior.

## Test
- `PYTHONPATH=src python3 -m unittest discover -s tests -q` — 84 tests passed
- `python3 -m compileall -q src`

## Issue
- Closes #321 when merged into the photo-worker line.