### PR TITLE
#366 deterministic fuzzy reason parser + confidence audit

### DIFF
--- a/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/model.py
+++ b/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/model.py
@@ -40,6 +40,7 @@ class MockModelAdapter:
         manifest_path: Path | None = None,
         *,
         allowed_reason_codes: set[str] | None = None,
+        reason_vocabulary: tuple[dict[str, Any], ...] | list[dict[str, Any]] | None = None,
         key_field: str = "model_fixture_key",
         default_model: str = "mock_fixture",
         provider_defaults: dict[str, Any] | None = None,
@@ -47,6 +48,7 @@ class MockModelAdapter:
         with (manifest_path or DEFAULT_MODEL_FIXTURE).open("r", encoding="utf-8") as handle:
             self._responses = json.load(handle)
         self.allowed_reason_codes = allowed_reason_codes or set()
+        self.reason_vocabulary = tuple(reason_vocabulary or ())
         self.key_field = key_field
         self.default_model = default_model
         self.provider_defaults = provider_defaults or {}
@@ -69,7 +71,12 @@ class MockModelAdapter:
             "darkness_score",
             "sharpness_edge_score",
         ]
-        return normalize_model_result(response, default_model=self.default_model, allowed_reason_codes=self.allowed_reason_codes)
+        return normalize_model_result(
+            response,
+            default_model=self.default_model,
+            allowed_reason_codes=self.allowed_reason_codes,
+            reason_vocabulary=self.reason_vocabulary,
+        )
 
 
 class ProviderChainAdapter:
@@ -125,6 +132,7 @@ class CodexOpenAIAdapter:
         codex_auth_path: Path | None = None,
         instructions: str | None = None,
         allowed_reason_codes: set[str] | None = None,
+        reason_vocabulary: tuple[dict[str, Any], ...] | list[dict[str, Any]] | None = None,
     ) -> None:
         raw_api_key = api_key or os.environ.get("CODEX_OPENAI_API_KEY") or os.environ.get("OPENAI_API_KEY")
         self.api_key = raw_api_key.strip() if raw_api_key else None
@@ -134,6 +142,7 @@ class CodexOpenAIAdapter:
         self.codex_auth_path = codex_auth_path or Path(os.environ.get("CODEX_AUTH_PATH", Path.home() / ".codex" / "auth.json"))
         self.instructions = instructions
         self.allowed_reason_codes = allowed_reason_codes or set()
+        self.reason_vocabulary = tuple(reason_vocabulary or ())
 
     def review(self, item: dict, deterministic_checks: dict) -> dict:
         image_path = item.get("resolved_image_path") or item.get("local_fixture_path")
@@ -152,7 +161,12 @@ class CodexOpenAIAdapter:
         except Exception as exc:  # pragma: no cover - network/provider dependent
             return _manual_failure("api_failure_fallback", DEFAULT_CODEX_MODEL_ROUTE, f"Codex/OpenAI route failed with {exc.__class__.__name__}; manual review required.")
 
-        return normalize_model_result(_extract_provider_json(payload), default_model=DEFAULT_CODEX_MODEL_ROUTE, allowed_reason_codes=self.allowed_reason_codes)
+        return normalize_model_result(
+            _extract_provider_json(payload),
+            default_model=DEFAULT_CODEX_MODEL_ROUTE,
+            allowed_reason_codes=self.allowed_reason_codes,
+            reason_vocabulary=self.reason_vocabulary,
+        )
 
     def _build_request(self, image_url: str) -> urllib.request.Request:
         oauth = _load_codex_oauth(self.codex_auth_path)

--- a/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/normalization.py
+++ b/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/normalization.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import re
+
 from .moderation_contract import CANONICAL_REASON_MAP, DEFAULT_PROFILE_CHECKS
 from .validators import is_valid_normalized_result
 
@@ -24,6 +26,46 @@ DECISION_TO_RECOMMENDATION_VERDICTS = {
 
 HIGH_CONFIDENCE_PERSON_GATE_THRESHOLD = 0.80
 
+DERIVED_CONFIDENCE_BY_REASON = {
+    "clean_profile_style": 0.88,
+    "sexual_content": 0.93,
+    "underage": 0.94,
+    "minor_targeting": 0.92,
+    "hate_speech": 0.90,
+    "harassment": 0.88,
+    "money_request": 0.86,
+    "off_platform_contact": 0.84,
+    "spam": 0.82,
+    "bot_behavior": 0.82,
+    "ai_generated": 0.86,
+    "fake_profile": 0.84,
+    "not_person_photo": 0.84,
+    "inappropriate_photos": 0.78,
+    "too_blurry_or_blank": 0.74,
+}
+
+FUZZY_REASON_MARKERS = (
+    ("underage_concern", ("under age", "underage", "minor", "child", "teen", "youth")),
+    ("minor_targeting", ("targets minors", "targeting minors", "minor targeting", "sexualizes youth")),
+    ("pornographic_explicit", ("pornographic", "hard porn", "explicit porn", "sexual act", "intercourse")),
+    ("sexual_content", ("sexual content", "nudity", "nude", "genital", "masturbat")),
+    ("hate_or_harassment", ("hate speech", "slur", "harassment", "threat", "bullying", "abuse")),
+    ("money_request", ("cashapp", "venmo", "paypal", "money request", "sugar")),
+    ("qr_code", ("qr code", "qrcode", "qr-code", "barcode")),
+    ("contact_info_or_ad", ("phone number", "email", "instagram", "snapchat", "telegram", "whatsapp", "social handle", "off platform")),
+    ("ai_generated_or_synthetic", ("ai generated", "ai-generated", "synthetic", "digitally created", "rendered", "generated image")),
+    ("celebrity_or_stock_photo", ("stock photo", "celebrity", "stolen photo", "model image")),
+    ("meme_or_screenshot", ("screenshot", "meme")),
+    ("low_quality_or_unusable", ("blurry", "blurred", "low quality", "dark", "obscured", "not visible", "unusable")),
+    ("not_a_profile_photo", ("not a profile photo", "no person", "not person", "object only", "landscape only")),
+    ("manual_review_needed", ("uncertain", "unclear", "ambiguous", "cannot determine", "not sure")),
+)
+
+REASON_TEXT_FIELDS = ("reason_code", "canonical_reason_code", "reason", "detected_category", "note")
+LEVENSHTEIN_SIMILARITY_THRESHOLD = 0.82
+LEVENSHTEIN_MAX_DISTANCE = 2
+SUBSTRING_MIN_TOKEN_LEN = 4
+
 
 def normalize_model_result(result: dict, *, default_model: str, allowed_reason_codes: set[str] | None = None) -> dict:
     normalized = dict(result)
@@ -32,10 +74,23 @@ def normalize_model_result(result: dict, *, default_model: str, allowed_reason_c
         normalized["allowed_reason_codes"] = sorted(allowed_reason_codes)
     if "verdict" not in normalized and "recommendation" in normalized:
         normalized["verdict"] = normalized.get("recommendation")
-    if "reason_code" not in normalized and "canonical_reason_code" in normalized:
-        normalized["reason_code"] = normalized.get("canonical_reason_code")
-    if "reason_code" not in normalized and "reason" in normalized:
-        normalized["reason_code"] = normalized.get("reason")
+
+    resolved_raw_reason, reason_resolution = _resolve_reason_hint(normalized, allowed_reason_codes)
+    if resolved_raw_reason:
+        normalized["reason_code"] = resolved_raw_reason
+    normalized["match_source"] = reason_resolution.get("mode")
+    normalized["match_evidence"] = reason_resolution
+
+    confidence_value, confidence_source, confidence_evidence = _resolve_confidence(
+        normalized.get("confidence"),
+        reason_hint=resolved_raw_reason,
+        verdict_hint=str(normalized.get("verdict") or normalized.get("recommendation") or normalized.get("decision") or "review").lower(),
+        reason_resolution=reason_resolution,
+    )
+    normalized["confidence"] = confidence_value
+    normalized["confidence_source"] = confidence_source
+    normalized["confidence_evidence"] = confidence_evidence
+
     original_reason_hint = str(normalized.get("reason_code", "manual_review_needed")).lower()
     if "verdict" not in normalized and "decision" in normalized:
         normalized["verdict"] = DECISION_TO_RECOMMENDATION_VERDICTS.get(str(normalized.get("decision")).lower(), normalized.get("decision"))
@@ -46,7 +101,6 @@ def normalize_model_result(result: dict, *, default_model: str, allowed_reason_c
     normalized["verdict"] = FINAL_TO_RECOMMENDATION_VERDICTS.get(raw_verdict, raw_verdict)
     normalized["normalization_applied"] = "yes" if normalized["verdict"] != raw_verdict else "no"
 
-    normalized.setdefault("confidence", 0.0)
     raw_reason_code = str(normalized.get("reason_code", "manual_review_needed")).lower()
     if raw_reason_code == "ai_generated_or_synthetic" and float(normalized.get("confidence") or 0.0) < AI_GENERATED_HIGH_CONFIDENCE_THRESHOLD:
         normalized["reason_code"] = "manual_admin_decision"
@@ -58,6 +112,32 @@ def normalize_model_result(result: dict, *, default_model: str, allowed_reason_c
         normalized["reason_code"] = mapped_reason or "manual_admin_decision"
     if normalized["reason_code"] != raw_reason_code:
         normalized.setdefault("raw_reason_code", raw_reason_code)
+
+    raw_reason_hint = str(normalized.get("raw_reason_code") or raw_reason_code).lower()
+    if normalized.get("reason_code") in {"underage", "minor_targeting"} or raw_reason_hint in {"underage_concern", "underage", "minor_targeting"}:
+        checks = dict(normalized.get("app_profile_photo_checks") or default_profile_checks(needs_human_review=True))
+        checks["needs_human_review"] = True
+        normalized["app_profile_photo_checks"] = checks
+        normalized["verdict"] = "escalate"
+        normalized["needs_human_admin"] = True
+        normalized["fail_closed_route"] = "needs_human_admin"
+        if normalized.get("reason_code") not in {"underage", "minor_targeting"}:
+            normalized["reason_code"] = "underage" if "underage" in raw_reason_hint else "minor_targeting"
+
+    if confidence_source == "derived_ambiguous_fail_closed" and normalized.get("verdict") in {"approve_recommendation", "reject_recommendation", "review", "escalate"}:
+        checks = dict(normalized.get("app_profile_photo_checks") or default_profile_checks(needs_human_review=True))
+        checks["needs_human_review"] = True
+        normalized["app_profile_photo_checks"] = checks
+        normalized["verdict"] = "escalate"
+        normalized["reason_code"] = "manual_admin_decision"
+        normalized.setdefault("raw_reason_code", raw_reason_code or "manual_review_needed")
+        normalized["stale_assessment"] = True
+        normalized["needs_human_admin"] = True
+        normalized["fail_closed_route"] = "needs_human_admin"
+        normalized["note"] = _append_note(
+            normalized.get("note"),
+            "Confidence was missing/invalid and deterministic parser remained ambiguous; fail-closed to human-admin escalation.",
+        )
 
     detected_category = str(normalized.get("detected_category") or normalized.get("raw_reason_code") or normalized["reason_code"]).lower()
     normalized["detected_category"] = DETECTED_CATEGORY_ALIASES.get(detected_category, detected_category)
@@ -79,6 +159,274 @@ def normalize_model_result(result: dict, *, default_model: str, allowed_reason_c
         normalized["note"] = "Model output failed strict validation; manual review required."
         normalized["validator"] = "fail"
     return normalized
+
+
+def _resolve_reason_hint(normalized: dict, allowed_reason_codes: set[str]) -> tuple[str, dict]:
+    canonical_values = set(CANONICAL_REASON_MAP.values())
+    candidate_tokens: list[tuple[str, str]] = []
+    for field in ("reason_code", "canonical_reason_code", "reason", "detected_category"):
+        normalized_token = _normalize_reason_token(normalized.get(field))
+        if not normalized_token:
+            continue
+        candidate_tokens.append((field, normalized_token))
+        if normalized_token in CANONICAL_REASON_MAP or normalized_token in canonical_values or normalized_token in allowed_reason_codes:
+            return normalized_token, {
+                "mode": "exact_normalized",
+                "field": field,
+                "token": normalized_token,
+            }
+
+    reason_vocab = set(CANONICAL_REASON_MAP.keys()) | canonical_values | set(allowed_reason_codes)
+    substring_match = _best_substring_reason_match(candidate_tokens, reason_vocab)
+    if substring_match is not None:
+        return substring_match[0], {
+            "mode": "normalized_substring",
+            "field": substring_match[1],
+            "token": substring_match[0],
+            "matched_fragment": substring_match[2],
+            "score": substring_match[3],
+        }
+
+    combined_text = " ".join(str(normalized.get(field, "")) for field in REASON_TEXT_FIELDS if normalized.get(field) is not None).lower()
+    marker_match = _marker_reason_from_text(combined_text)
+    if marker_match is not None:
+        return marker_match[0], {
+            "mode": "fuzzy_marker",
+            "field": marker_match[1],
+            "token": marker_match[0],
+            "matched_marker": marker_match[2],
+        }
+
+    fuzzy_vocab_match = _best_allowed_reason_match(combined_text, reason_vocab)
+    if fuzzy_vocab_match is not None:
+        return fuzzy_vocab_match[0], {
+            "mode": "fuzzy_token",
+            "field": "text",
+            "token": fuzzy_vocab_match[0],
+            "score": fuzzy_vocab_match[1],
+            "matched_tokens": fuzzy_vocab_match[2],
+            "token_matches": fuzzy_vocab_match[3],
+        }
+
+    allowed_match = _best_allowed_reason_match(combined_text, allowed_reason_codes)
+    if allowed_match is not None:
+        return allowed_match[0], {
+            "mode": "allowed_reason_fuzzy",
+            "field": "text",
+            "token": allowed_match[0],
+            "score": allowed_match[1],
+            "matched_tokens": allowed_match[2],
+            "token_matches": allowed_match[3],
+        }
+
+    fallback_token = _normalize_reason_token(normalized.get("reason_code") or normalized.get("canonical_reason_code") or normalized.get("reason"))
+    if fallback_token:
+        return fallback_token, {
+            "mode": "fallback_token",
+            "field": "reason_code",
+            "token": fallback_token,
+        }
+
+    return "manual_review_needed", {
+        "mode": "unresolved",
+        "field": "none",
+        "token": "manual_review_needed",
+    }
+
+
+def _resolve_confidence(
+    confidence_value: object,
+    *,
+    reason_hint: str,
+    verdict_hint: str,
+    reason_resolution: dict,
+) -> tuple[float, str, dict]:
+    provider_conf = _normalize_confidence(confidence_value)
+    if provider_conf is not None:
+        return provider_conf, "provider", {
+            "mode": "provider",
+            "reason_hint": reason_hint,
+            "reason_resolution": reason_resolution,
+            "semantic_layer": "skipped_non_deterministic",
+        }
+
+    canonical_reason = CANONICAL_REASON_MAP.get(reason_hint, reason_hint)
+    derived = DERIVED_CONFIDENCE_BY_REASON.get(canonical_reason)
+    if derived is None:
+        if verdict_hint in {"approve", "approved", "approve_recommendation"}:
+            derived = 0.82
+        elif verdict_hint in {"reject", "rejected", "reject_recommendation", "escalate"}:
+            derived = 0.78
+        elif canonical_reason == "manual_admin_decision":
+            derived = 0.0
+        else:
+            derived = 0.64
+
+    unresolved = canonical_reason in {"manual_admin_decision", "manual_review_needed"} or reason_resolution.get("mode") in {"unresolved", "fallback_token"}
+    if unresolved:
+        return 0.0, "derived_ambiguous_fail_closed", {
+            "mode": "derived_ambiguous_fail_closed",
+            "reason_hint": reason_hint,
+            "canonical_reason": canonical_reason,
+            "reason_resolution": reason_resolution,
+            "fail_closed_route": "needs_human_admin",
+            "semantic_layer": "skipped_non_deterministic",
+        }
+
+    return float(derived), "derived_reason_map", {
+        "mode": "derived_reason_map",
+        "reason_hint": reason_hint,
+        "canonical_reason": canonical_reason,
+        "reason_resolution": reason_resolution,
+        "semantic_layer": "skipped_non_deterministic",
+    }
+
+
+def _normalize_confidence(value: object) -> float | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    if parsed < 0.0 or parsed > 1.0:
+        return None
+    return parsed
+
+
+def _normalize_reason_token(value: object) -> str:
+    if value is None:
+        return ""
+    text = str(value).strip().lower()
+    if not text:
+        return ""
+    text = re.sub(r"[^a-z0-9]+", "_", text)
+    return text.strip("_")
+
+
+def _marker_reason_from_text(text: str) -> tuple[str, str, str] | None:
+    normalized_text = text.lower()
+    for reason, markers in FUZZY_REASON_MARKERS:
+        for marker in markers:
+            if _contains_marker(normalized_text, marker):
+                return reason, "text", marker
+    return None
+
+
+def _contains_marker(text: str, marker: str) -> bool:
+    phrase = marker.lower().strip()
+    if not phrase:
+        return False
+    pattern = r"\b" + r"\s+".join(re.escape(part) for part in phrase.split()) + r"\b"
+    return re.search(pattern, text) is not None
+
+
+def _best_substring_reason_match(
+    candidate_tokens: list[tuple[str, str]],
+    reason_vocab: set[str],
+) -> tuple[str, str, str, float] | None:
+    best: tuple[str, str, str, float] | None = None
+    sorted_vocab = sorted(reason_vocab, key=lambda value: (-len(value), value))
+    for field, candidate in candidate_tokens:
+        if not candidate:
+            continue
+        for reason in sorted_vocab:
+            if len(reason) < SUBSTRING_MIN_TOKEN_LEN:
+                continue
+            if reason in candidate:
+                score = len(reason) / max(1, len(candidate))
+                current = (reason, field, reason, score)
+            elif len(candidate) >= SUBSTRING_MIN_TOKEN_LEN and candidate in reason:
+                score = len(candidate) / max(1, len(reason))
+                current = (reason, field, candidate, score)
+            else:
+                continue
+            if best is None or (current[3], len(current[0]), current[0], current[1]) > (best[3], len(best[0]), best[0], best[1]):
+                best = current
+    return best
+
+
+def _best_allowed_reason_match(text: str, allowed_reason_codes: set[str]) -> tuple[str, float, list[str], list[dict[str, object]]] | None:
+    if not text or not allowed_reason_codes:
+        return None
+    raw_tokens = re.findall(r"[a-z0-9]+", text.lower())
+    text_tokens = set(raw_tokens)
+    for index in range(len(raw_tokens) - 1):
+        joined = f"{raw_tokens[index]}{raw_tokens[index + 1]}"
+        if len(joined) >= SUBSTRING_MIN_TOKEN_LEN:
+            text_tokens.add(joined)
+    best: tuple[str, float, list[str], list[dict[str, object]]] | None = None
+    for code in sorted(allowed_reason_codes):
+        tokens = [token for token in _normalize_reason_token(code).split("_") if token]
+        if not tokens:
+            continue
+
+        exact_matches: list[str] = []
+        fuzzy_matches: list[dict[str, object]] = []
+        for token in tokens:
+            if token in text_tokens:
+                exact_matches.append(token)
+                continue
+            fuzzy_match = None
+            fuzzy_score = 0.0
+            for observed in text_tokens:
+                similarity = _token_similarity(token, observed)
+                if similarity >= LEVENSHTEIN_SIMILARITY_THRESHOLD:
+                    if fuzzy_match is None or (similarity, observed) > (fuzzy_score, str(fuzzy_match)):
+                        fuzzy_match = observed
+                        fuzzy_score = similarity
+            if fuzzy_match is not None:
+                fuzzy_matches.append({"expected": token, "observed": fuzzy_match, "similarity": round(fuzzy_score, 4)})
+
+        phrase_match = _contains_marker(text, code.replace("_", " "))
+        if phrase_match:
+            score = 1.0
+        else:
+            weighted = len(exact_matches) + (0.8 * len(fuzzy_matches))
+            score = weighted / len(tokens)
+
+        if score < 0.67 and not phrase_match:
+            continue
+
+        matched_tokens = sorted(set(exact_matches + [item["expected"] for item in fuzzy_matches]))
+        candidate = (code, score, matched_tokens, fuzzy_matches)
+        if best is None:
+            best = candidate
+            continue
+        if (score, len(matched_tokens), len(code), code) > (best[1], len(best[2]), len(best[0]), best[0]):
+            best = candidate
+    return best
+
+
+def _token_similarity(left: str, right: str) -> float:
+    if not left or not right:
+        return 0.0
+    if left == right:
+        return 1.0
+    distance = _levenshtein_distance(left, right)
+    if distance > LEVENSHTEIN_MAX_DISTANCE:
+        return 0.0
+    denominator = max(len(left), len(right), 1)
+    return max(0.0, 1.0 - (distance / denominator))
+
+
+def _levenshtein_distance(left: str, right: str) -> int:
+    if left == right:
+        return 0
+    if not left:
+        return len(right)
+    if not right:
+        return len(left)
+    previous = list(range(len(right) + 1))
+    for i, lch in enumerate(left, start=1):
+        current = [i]
+        for j, rch in enumerate(right, start=1):
+            insert_cost = current[j - 1] + 1
+            delete_cost = previous[j] + 1
+            replace_cost = previous[j - 1] + (0 if lch == rch else 1)
+            current.append(min(insert_cost, delete_cost, replace_cost))
+        previous = current
+    return previous[-1]
 
 
 def _apply_person_photo_business_gate(normalized: dict) -> dict:

--- a/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/normalization.py
+++ b/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/normalization.py
@@ -88,6 +88,9 @@ def normalize_model_result(
     if "verdict" not in normalized and "recommendation" in normalized:
         normalized["verdict"] = normalized.get("recommendation")
 
+    # Capture original provider reason BEFORE any normalization — used for audit trail only
+    original_provider_reason = str(normalized.get("reason_code") or normalized.get("canonical_reason_code") or normalized.get("reason") or "").strip()
+
     resolved_raw_reason, reason_resolution = _resolve_reason_hint(
         normalized,
         allowed_reason_codes,
@@ -127,8 +130,11 @@ def normalize_model_result(
         if mapped_reason is None and raw_reason_code in allowed_reason_codes:
             mapped_reason = raw_reason_code
         normalized["reason_code"] = mapped_reason or "manual_admin_decision"
+    # Always capture original provider reason as audit trail, for cases where canonical map changed reason_code
     if normalized["reason_code"] != raw_reason_code:
-        normalized.setdefault("raw_reason_code", raw_reason_code)
+        normalized.setdefault("raw_reason_code", original_provider_reason)
+    else:
+        normalized.setdefault("raw_reason_code", original_provider_reason)
 
     raw_reason_hint = str(normalized.get("raw_reason_code") or raw_reason_code).lower()
     if normalized.get("reason_code") in {"underage", "minor_targeting"} or raw_reason_hint in {"underage_concern", "underage", "minor_targeting"}:

--- a/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/normalization.py
+++ b/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/normalization.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+from typing import Any
 
 from .moderation_contract import CANONICAL_REASON_MAP, DEFAULT_PROFILE_CHECKS
 from .validators import is_valid_normalized_result
@@ -44,30 +45,42 @@ DERIVED_CONFIDENCE_BY_REASON = {
     "too_blurry_or_blank": 0.74,
 }
 
-FUZZY_REASON_MARKERS = (
-    ("underage_concern", ("under age", "underage", "minor", "child", "teen", "youth")),
-    ("minor_targeting", ("targets minors", "targeting minors", "minor targeting", "sexualizes youth")),
-    ("pornographic_explicit", ("pornographic", "hard porn", "explicit porn", "sexual act", "intercourse")),
-    ("sexual_content", ("sexual content", "nudity", "nude", "genital", "masturbat")),
-    ("hate_or_harassment", ("hate speech", "slur", "harassment", "threat", "bullying", "abuse")),
-    ("money_request", ("cashapp", "venmo", "paypal", "money request", "sugar")),
-    ("qr_code", ("qr code", "qrcode", "qr-code", "barcode")),
-    ("contact_info_or_ad", ("phone number", "email", "instagram", "snapchat", "telegram", "whatsapp", "social handle", "off platform")),
-    ("ai_generated_or_synthetic", ("ai generated", "ai-generated", "synthetic", "digitally created", "rendered", "generated image")),
-    ("celebrity_or_stock_photo", ("stock photo", "celebrity", "stolen photo", "model image")),
-    ("meme_or_screenshot", ("screenshot", "meme")),
-    ("low_quality_or_unusable", ("blurry", "blurred", "low quality", "dark", "obscured", "not visible", "unusable")),
-    ("not_a_profile_photo", ("not a profile photo", "no person", "not person", "object only", "landscape only")),
-    ("manual_review_needed", ("uncertain", "unclear", "ambiguous", "cannot determine", "not sure")),
-)
-
 REASON_TEXT_FIELDS = ("reason_code", "canonical_reason_code", "reason", "detected_category", "note")
 LEVENSHTEIN_SIMILARITY_THRESHOLD = 0.82
 LEVENSHTEIN_MAX_DISTANCE = 2
 SUBSTRING_MIN_TOKEN_LEN = 4
+FUZZY_MATCH_MIN_SCORE = 0.45
 
+REASON_VOCAB_ALIAS_FIELDS = (
+    "alias",
+    "aliases",
+    "synonym",
+    "synonyms",
+    "keyword",
+    "keywords",
+    "match_term",
+    "match_terms",
+    "prompt_hint",
+    "prompt_instruction",
+    "description",
+    "label",
+    "name",
+)
 
-def normalize_model_result(result: dict, *, default_model: str, allowed_reason_codes: set[str] | None = None) -> dict:
+REASON_VOCAB_WEIGHT_FIELDS = (
+    "keyword_weight",
+    "match_weight",
+    "confidence_weight",
+    "weight",
+)
+
+def normalize_model_result(
+    result: dict,
+    *,
+    default_model: str,
+    allowed_reason_codes: set[str] | None = None,
+    reason_vocabulary: tuple[dict[str, Any], ...] | list[dict[str, Any]] | None = None,
+) -> dict:
     normalized = dict(result)
     allowed_reason_codes = {str(code).strip() for code in (allowed_reason_codes or set()) if str(code).strip()}
     if allowed_reason_codes:
@@ -75,7 +88,11 @@ def normalize_model_result(result: dict, *, default_model: str, allowed_reason_c
     if "verdict" not in normalized and "recommendation" in normalized:
         normalized["verdict"] = normalized.get("recommendation")
 
-    resolved_raw_reason, reason_resolution = _resolve_reason_hint(normalized, allowed_reason_codes)
+    resolved_raw_reason, reason_resolution = _resolve_reason_hint(
+        normalized,
+        allowed_reason_codes,
+        reason_vocabulary=reason_vocabulary,
+    )
     if resolved_raw_reason:
         normalized["reason_code"] = resolved_raw_reason
     normalized["match_source"] = reason_resolution.get("mode")
@@ -161,62 +178,108 @@ def normalize_model_result(result: dict, *, default_model: str, allowed_reason_c
     return normalized
 
 
-def _resolve_reason_hint(normalized: dict, allowed_reason_codes: set[str]) -> tuple[str, dict]:
+def _resolve_reason_hint(
+    normalized: dict,
+    allowed_reason_codes: set[str],
+    *,
+    reason_vocabulary: tuple[dict[str, Any], ...] | list[dict[str, Any]] | None,
+) -> tuple[str, dict]:
     canonical_values = set(CANONICAL_REASON_MAP.values())
+    reason_alias_map, db_vocab_present = _build_reason_alias_map(allowed_reason_codes, reason_vocabulary)
     candidate_tokens: list[tuple[str, str]] = []
     for field in ("reason_code", "canonical_reason_code", "reason", "detected_category"):
         normalized_token = _normalize_reason_token(normalized.get(field))
         if not normalized_token:
             continue
         candidate_tokens.append((field, normalized_token))
-        if normalized_token in CANONICAL_REASON_MAP or normalized_token in canonical_values or normalized_token in allowed_reason_codes:
+        # Provider's own canonical code should pass through unchanged
+        if normalized_token in CANONICAL_REASON_MAP:
             return normalized_token, {
                 "mode": "exact_normalized",
                 "field": field,
                 "token": normalized_token,
+                "score": 1.0,
+                "keyword_weight": 1.0,
+                "db_vocab_present": db_vocab_present,
+            }
+        if normalized_token in reason_alias_map:
+            alias = reason_alias_map[normalized_token]
+            return alias["code"], {
+                "mode": "db_exact_normalized",
+                "field": field,
+                "token": alias["code"],
+                "matched_alias": normalized_token,
+                "score": min(1.0, float(alias["weight"])),
+                "keyword_weight": alias["weight"],
+                "vocab_source": alias["source"],
+                "db_vocab_present": db_vocab_present,
+            }
+        if normalized_token in allowed_reason_codes:
+            return normalized_token, {
+                "mode": "allowed_reason_exact",
+                "field": field,
+                "token": normalized_token,
+                "score": 1.0,
+                "keyword_weight": 1.0,
+                "db_vocab_present": db_vocab_present,
+            }
+        if normalized_token in canonical_values:
+            return normalized_token, {
+                "mode": "exact_normalized",
+                "field": field,
+                "token": normalized_token,
+                "score": 1.0,
+                "keyword_weight": 1.0,
+                "db_vocab_present": db_vocab_present,
             }
 
-    reason_vocab = set(CANONICAL_REASON_MAP.keys()) | canonical_values | set(allowed_reason_codes)
+    reason_vocab = set(reason_alias_map.keys())
     substring_match = _best_substring_reason_match(candidate_tokens, reason_vocab)
     if substring_match is not None:
-        return substring_match[0], {
-            "mode": "normalized_substring",
+        alias = reason_alias_map[substring_match[0]]
+        weighted_score = min(1.0, substring_match[3] * float(alias["weight"]))
+        return alias["code"], {
+            "mode": "db_normalized_substring",
             "field": substring_match[1],
-            "token": substring_match[0],
+            "token": alias["code"],
+            "matched_alias": substring_match[0],
             "matched_fragment": substring_match[2],
-            "score": substring_match[3],
+            "score": weighted_score,
+            "raw_score": substring_match[3],
+            "keyword_weight": alias["weight"],
+            "vocab_source": alias["source"],
+            "db_vocab_present": db_vocab_present,
         }
 
     combined_text = " ".join(str(normalized.get(field, "")) for field in REASON_TEXT_FIELDS if normalized.get(field) is not None).lower()
-    marker_match = _marker_reason_from_text(combined_text)
-    if marker_match is not None:
-        return marker_match[0], {
-            "mode": "fuzzy_marker",
-            "field": marker_match[1],
-            "token": marker_match[0],
-            "matched_marker": marker_match[2],
-        }
-
-    fuzzy_vocab_match = _best_allowed_reason_match(combined_text, reason_vocab)
+    fuzzy_vocab_match = _best_allowed_reason_match(combined_text, reason_alias_map)
     if fuzzy_vocab_match is not None:
-        return fuzzy_vocab_match[0], {
-            "mode": "fuzzy_token",
+        alias = reason_alias_map[fuzzy_vocab_match[0]]
+        # Only accept fuzzy match if the matched code is meaningfully related
+        # (i.e., the provider's own reason code is unknown to the DB)
+        # If the provider's own reason code is NOT in allowed_reason_codes,
+        # never map it to a different code via fuzzy matching.
+        # Preserve the provider's raw reason and fail-closed.
+        explicit_provider_code = _normalize_reason_token(normalized.get("reason_code") or normalized.get("canonical_reason_code"))
+        if explicit_provider_code and explicit_provider_code not in allowed_reason_codes:
+            # Provider emitted an explicit reason_code unknown to DB; do not remap it
+            # to a fuzzy-matched different code. Preserve provider reason and fail closed.
+            fuzzy_vocab_match = None
+
+    if fuzzy_vocab_match is not None:
+        alias = reason_alias_map[fuzzy_vocab_match[0]]
+        return alias["code"], {
+            "mode": "db_fuzzy_token",
             "field": "text",
-            "token": fuzzy_vocab_match[0],
+            "token": alias["code"],
+            "matched_alias": fuzzy_vocab_match[0],
             "score": fuzzy_vocab_match[1],
+            "raw_score": fuzzy_vocab_match[4],
+            "keyword_weight": fuzzy_vocab_match[5],
             "matched_tokens": fuzzy_vocab_match[2],
             "token_matches": fuzzy_vocab_match[3],
-        }
-
-    allowed_match = _best_allowed_reason_match(combined_text, allowed_reason_codes)
-    if allowed_match is not None:
-        return allowed_match[0], {
-            "mode": "allowed_reason_fuzzy",
-            "field": "text",
-            "token": allowed_match[0],
-            "score": allowed_match[1],
-            "matched_tokens": allowed_match[2],
-            "token_matches": allowed_match[3],
+            "vocab_source": alias["source"],
+            "db_vocab_present": db_vocab_present,
         }
 
     fallback_token = _normalize_reason_token(normalized.get("reason_code") or normalized.get("canonical_reason_code") or normalized.get("reason"))
@@ -225,13 +288,111 @@ def _resolve_reason_hint(normalized: dict, allowed_reason_codes: set[str]) -> tu
             "mode": "fallback_token",
             "field": "reason_code",
             "token": fallback_token,
+            "db_vocab_present": db_vocab_present,
+            "fail_closed_reason": "db_vocab_unusable" if not db_vocab_present else "no_reason_match",
         }
 
     return "manual_review_needed", {
         "mode": "unresolved",
         "field": "none",
         "token": "manual_review_needed",
+        "db_vocab_present": db_vocab_present,
+        "fail_closed_reason": "db_vocab_unusable" if not db_vocab_present else "no_reason_match",
     }
+
+
+def _build_reason_alias_map(
+    allowed_reason_codes: set[str],
+    reason_vocabulary: tuple[dict[str, Any], ...] | list[dict[str, Any]] | None,
+) -> tuple[dict[str, dict[str, Any]], bool]:
+    alias_map: dict[str, dict[str, Any]] = {}
+
+    for raw_code in sorted(allowed_reason_codes):
+        code = _normalize_reason_token(raw_code)
+        if not code:
+            continue
+        _upsert_reason_alias(alias_map, code, code, 1.0, "reason_codes.code")
+
+    for row in tuple(reason_vocabulary or ()):
+        if not isinstance(row, dict):
+            continue
+        code = _normalize_reason_token(row.get("code") or row.get("reason_code") or row.get("canonical_reason_code"))
+        if not code:
+            continue
+        weight = _reason_keyword_weight(row)
+        _upsert_reason_alias(alias_map, code, code, weight, "reason_vocabulary.code")
+        for field in REASON_VOCAB_ALIAS_FIELDS:
+            for raw_alias in _iter_alias_candidates(row.get(field)):
+                alias = _normalize_reason_token(raw_alias)
+                if not alias:
+                    continue
+                _upsert_reason_alias(alias_map, alias, code, weight, f"reason_vocabulary.{field}")
+
+    return alias_map, bool(alias_map)
+
+
+def _upsert_reason_alias(
+    alias_map: dict[str, dict[str, Any]],
+    alias: str,
+    code: str,
+    weight: float,
+    source: str,
+) -> None:
+    current = alias_map.get(alias)
+    if current is None:
+        alias_map[alias] = {
+            "code": code,
+            "weight": float(weight),
+            "source": source,
+        }
+        return
+    existing_weight = float(current.get("weight", 0.0))
+    # Only replace if new weight is strictly greater
+    # and don't replace a canonical code entry with an alias entry of equal weight
+    if float(weight) > existing_weight:
+        alias_map[alias] = {
+            "code": code,
+            "weight": float(weight),
+            "source": source,
+        }
+
+
+def _reason_keyword_weight(row: dict[str, Any]) -> float:
+    for field in REASON_VOCAB_WEIGHT_FIELDS:
+        value = row.get(field)
+        try:
+            parsed = float(value)
+        except (TypeError, ValueError):
+            continue
+        if parsed > 0.0:
+            return min(1.5, max(0.2, parsed))
+    return 1.0
+
+
+def _iter_alias_candidates(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return []
+        parts = [text]
+        parts.extend(piece.strip() for piece in re.split(r"[\n,;|]+", text) if piece.strip())
+        seen: set[str] = set()
+        deduped: list[str] = []
+        for part in parts:
+            key = part.lower()
+            if key in seen:
+                continue
+            seen.add(key)
+            deduped.append(part)
+        return deduped
+    if isinstance(value, (list, tuple, set)):
+        flattened: list[str] = []
+        for child in value:
+            flattened.extend(_iter_alias_candidates(child))
+        return flattened
+    return [str(value)]
 
 
 def _resolve_confidence(
@@ -273,11 +434,21 @@ def _resolve_confidence(
             "semantic_layer": "skipped_non_deterministic",
         }
 
-    return float(derived), "derived_reason_map", {
+    match_score = _normalize_confidence(reason_resolution.get("score"))
+    if match_score is None:
+        match_score = 1.0 if reason_resolution.get("mode") in {"db_exact_normalized", "exact_normalized"} else 0.7
+    keyword_weight = _safe_positive_float(reason_resolution.get("keyword_weight"), default=1.0)
+    quality_factor = min(1.0, max(0.35, match_score * min(1.25, keyword_weight)))
+    weighted = float(derived) * quality_factor
+
+    return float(weighted), "derived_reason_map", {
         "mode": "derived_reason_map",
         "reason_hint": reason_hint,
         "canonical_reason": canonical_reason,
         "reason_resolution": reason_resolution,
+        "match_score": match_score,
+        "keyword_weight": keyword_weight,
+        "quality_factor": quality_factor,
         "semantic_layer": "skipped_non_deterministic",
     }
 
@@ -294,6 +465,16 @@ def _normalize_confidence(value: object) -> float | None:
     return parsed
 
 
+def _safe_positive_float(value: object, *, default: float) -> float:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return float(default)
+    if parsed <= 0.0:
+        return float(default)
+    return float(parsed)
+
+
 def _normalize_reason_token(value: object) -> str:
     if value is None:
         return ""
@@ -302,15 +483,6 @@ def _normalize_reason_token(value: object) -> str:
         return ""
     text = re.sub(r"[^a-z0-9]+", "_", text)
     return text.strip("_")
-
-
-def _marker_reason_from_text(text: str) -> tuple[str, str, str] | None:
-    normalized_text = text.lower()
-    for reason, markers in FUZZY_REASON_MARKERS:
-        for marker in markers:
-            if _contains_marker(normalized_text, marker):
-                return reason, "text", marker
-    return None
 
 
 def _contains_marker(text: str, marker: str) -> bool:
@@ -346,8 +518,11 @@ def _best_substring_reason_match(
     return best
 
 
-def _best_allowed_reason_match(text: str, allowed_reason_codes: set[str]) -> tuple[str, float, list[str], list[dict[str, object]]] | None:
-    if not text or not allowed_reason_codes:
+def _best_allowed_reason_match(
+    text: str,
+    reason_alias_map: dict[str, dict[str, Any]],
+) -> tuple[str, float, list[str], list[dict[str, object]], float, float] | None:
+    if not text or not reason_alias_map:
         return None
     raw_tokens = re.findall(r"[a-z0-9]+", text.lower())
     text_tokens = set(raw_tokens)
@@ -355,9 +530,12 @@ def _best_allowed_reason_match(text: str, allowed_reason_codes: set[str]) -> tup
         joined = f"{raw_tokens[index]}{raw_tokens[index + 1]}"
         if len(joined) >= SUBSTRING_MIN_TOKEN_LEN:
             text_tokens.add(joined)
-    best: tuple[str, float, list[str], list[dict[str, object]]] | None = None
-    for code in sorted(allowed_reason_codes):
-        tokens = [token for token in _normalize_reason_token(code).split("_") if token]
+
+    best: tuple[str, float, list[str], list[dict[str, object]], float, float] | None = None
+    for alias in sorted(reason_alias_map):
+        meta = reason_alias_map[alias]
+        weight = _safe_positive_float(meta.get("weight"), default=1.0)
+        tokens = [token for token in _normalize_reason_token(alias).split("_") if token]
         if not tokens:
             continue
 
@@ -378,22 +556,23 @@ def _best_allowed_reason_match(text: str, allowed_reason_codes: set[str]) -> tup
             if fuzzy_match is not None:
                 fuzzy_matches.append({"expected": token, "observed": fuzzy_match, "similarity": round(fuzzy_score, 4)})
 
-        phrase_match = _contains_marker(text, code.replace("_", " "))
+        phrase_match = _contains_marker(text, alias.replace("_", " "))
         if phrase_match:
-            score = 1.0
+            raw_score = 1.0
         else:
             weighted = len(exact_matches) + (0.8 * len(fuzzy_matches))
-            score = weighted / len(tokens)
+            raw_score = weighted / len(tokens)
 
-        if score < 0.67 and not phrase_match:
+        if raw_score < FUZZY_MATCH_MIN_SCORE and not phrase_match:
             continue
 
+        weighted_score = min(1.0, raw_score * min(1.5, weight))
         matched_tokens = sorted(set(exact_matches + [item["expected"] for item in fuzzy_matches]))
-        candidate = (code, score, matched_tokens, fuzzy_matches)
+        candidate = (alias, weighted_score, matched_tokens, fuzzy_matches, raw_score, weight)
         if best is None:
             best = candidate
             continue
-        if (score, len(matched_tokens), len(code), code) > (best[1], len(best[2]), len(best[0]), best[0]):
+        if (weighted_score, raw_score, len(matched_tokens), len(alias), alias) > (best[1], best[4], len(best[2]), len(best[0]), best[0]):
             best = candidate
     return best
 

--- a/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/runner.py
+++ b/Pryan-Fire/projects/backend/anewluv-photo-moderation/src/photo_sweeper/runner.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import urllib.parse
 import uuid
 import json
+import os
 from pathlib import Path
 from typing import Any
 
@@ -472,16 +473,78 @@ def _summary(photos: list[dict], *, dry_run: bool, failures: list[dict] | None =
     }
 
 
+def _build_reason_vocabulary(runtime_contract: RuntimeContract) -> tuple[dict[str, Any], ...]:
+    vocab_rows: list[dict[str, Any]] = []
+
+    for code, row in sorted(runtime_contract.reason_codes.items()):
+        if not isinstance(row, dict):
+            continue
+        entry = dict(row)
+        entry.setdefault("code", code)
+        vocab_rows.append(entry)
+
+    for row in runtime_contract.review_items:
+        if not isinstance(row, dict):
+            continue
+        code = str(row.get("reason_code") or row.get("code") or "").strip()
+        if not code:
+            continue
+        entry = dict(row)
+        entry.setdefault("code", code)
+        vocab_rows.append(entry)
+
+    vocab_rows.extend(_load_reason_vocab_supplement())
+    return tuple(vocab_rows)
+
+
+def _load_reason_vocab_supplement() -> list[dict[str, Any]]:
+    path = os.environ.get("ANEWLUV_REASON_MATCH_CONFIG_PATH") or os.environ.get("ANEWLUV_REASON_MATCH_CONFIG")
+    if not path:
+        return []
+    try:
+        payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    except Exception:
+        return []
+
+    rows: list[dict[str, Any]] = []
+    if isinstance(payload, list):
+        for item in payload:
+            if isinstance(item, dict):
+                rows.append(dict(item))
+        return rows
+
+    if not isinstance(payload, dict):
+        return []
+
+    for key in ("items", "rows", "reason_vocabulary", "aliases"):
+        value = payload.get(key)
+        if isinstance(value, list):
+            for item in value:
+                if isinstance(item, dict):
+                    rows.append(dict(item))
+
+    mapping = payload.get("reason_alias_map")
+    if isinstance(mapping, dict):
+        for code, aliases in mapping.items():
+            if not code:
+                continue
+            rows.append({"code": str(code), "aliases": aliases})
+
+    return rows
+
+
 def _build_adapter(model_adapter: str, model_fixture: Path | None, *, runtime_contract: RuntimeContract):
     normalized = model_adapter.strip().lower()
     allowed_reason_codes = set(runtime_contract.reason_codes)
+    reason_vocabulary = _build_reason_vocabulary(runtime_contract)
     if normalized == "mock":
-        return MockModelAdapter(model_fixture, allowed_reason_codes=allowed_reason_codes)
+        return MockModelAdapter(model_fixture, allowed_reason_codes=allowed_reason_codes, reason_vocabulary=reason_vocabulary)
     if normalized in PROVIDER_CHAIN_ADAPTER_NAMES:
         return ProviderChainAdapter(
             stage1=MockModelAdapter(
                 model_fixture,
                 allowed_reason_codes=allowed_reason_codes,
+                reason_vocabulary=reason_vocabulary,
                 key_field="moderation_fixture_key",
                 default_model="mock_moderation_api",
                 provider_defaults={
@@ -490,12 +553,22 @@ def _build_adapter(model_adapter: str, model_fixture: Path | None, *, runtime_co
                     "vision_model_used": "not_called",
                 },
             ),
-            stage2=MockModelAdapter(model_fixture, allowed_reason_codes=allowed_reason_codes, default_model="mock_vision_llm"),
+            stage2=MockModelAdapter(
+                model_fixture,
+                allowed_reason_codes=allowed_reason_codes,
+                reason_vocabulary=reason_vocabulary,
+                default_model="mock_vision_llm",
+            ),
         )
     if normalized in VISION_ONLY_CHAIN_ADAPTER_NAMES:
         return ProviderChainAdapter(
             stage1=None,
-            stage2=MockModelAdapter(model_fixture, allowed_reason_codes=allowed_reason_codes, default_model="mock_vision_llm"),
+            stage2=MockModelAdapter(
+                model_fixture,
+                allowed_reason_codes=allowed_reason_codes,
+                reason_vocabulary=reason_vocabulary,
+                default_model="mock_vision_llm",
+            ),
             vision_only=True,
         )
     if normalized in CODEX_OPENAI_ADAPTER_NAMES:
@@ -504,7 +577,11 @@ def _build_adapter(model_adapter: str, model_fixture: Path | None, *, runtime_co
             from .moderation_contract import provider_instructions
 
             instructions = provider_instructions(review_items_prompt_text(runtime_contract.review_items))
-        return CodexOpenAIAdapter(instructions=instructions, allowed_reason_codes=allowed_reason_codes)
+        return CodexOpenAIAdapter(
+            instructions=instructions,
+            allowed_reason_codes=allowed_reason_codes,
+            reason_vocabulary=reason_vocabulary,
+        )
     if normalized in OPENAI_MODERATIONS_ADAPTER_NAMES:
         raise ValueError("openai-moderations adapter is not available in this checkout")
     if normalized in MINIMAX_FALLBACK_ADAPTER_NAMES:

--- a/Pryan-Fire/projects/backend/anewluv-photo-moderation/tests/test_smoke.py
+++ b/Pryan-Fire/projects/backend/anewluv-photo-moderation/tests/test_smoke.py
@@ -179,8 +179,9 @@ class PhotoSweeperSmokeTests(unittest.TestCase):
         self.assertEqual(approve["validator"], "fail")
         self.assertEqual(approve["verdict"], "review")
         self.assertEqual(approve["normalization_applied"], "no")
-        self.assertEqual(reject["verdict"], "reject_recommendation")
-        self.assertEqual(reject["normalization_applied"], "yes")
+        self.assertEqual(reject["verdict"], "escalate")
+        self.assertEqual(reject["reason_code"], "manual_admin_decision")
+        self.assertEqual(reject.get("fail_closed_route"), "needs_human_admin")
         self.assertEqual(reject["validator"], "pass")
         self.assertEqual(unknown["validator"], "fail")
         self.assertEqual(unknown["verdict"], "review")
@@ -242,6 +243,88 @@ class PhotoSweeperSmokeTests(unittest.TestCase):
 
         self.assertEqual(result["detected_category"], "ai_generated_or_synthetic")
         self.assertEqual(result["reason_code"], "ai_generated")
+
+    def test_missing_confidence_derives_non_zero_confidence_with_audit_fields(self):
+        result = normalize_model_result(
+            {
+                "verdict": "reject_recommendation",
+                "reason": "AI generated portrait with synthetic face",
+                "detected_category": "rendered profile",
+                "confidence": None,
+                "unsafe_categories": ["ai_generated_or_synthetic"],
+            },
+            default_model="fixture",
+        )
+
+        self.assertGreater(result["confidence"], 0.0)
+        self.assertEqual(result["confidence_source"], "derived_reason_map")
+        self.assertEqual(result["reason_code"], "ai_generated")
+        self.assertIn(result["match_source"], {"normalized_substring", "fuzzy_marker", "fuzzy_token"})
+        self.assertIn("match_evidence", result)
+
+    def test_provider_confidence_is_preserved_when_valid(self):
+        result = normalize_model_result(
+            {
+                "verdict": "reject_recommendation",
+                "confidence": 0.77,
+                "reason_code": "contact_info_or_ad",
+                "unsafe_categories": [],
+            },
+            default_model="fixture",
+        )
+
+        self.assertEqual(result["confidence"], 0.77)
+        self.assertEqual(result["confidence_source"], "provider")
+
+    def test_levenshtein_fuzzy_match_maps_near_miss_reason_tokens(self):
+        result = normalize_model_result(
+            {
+                "verdict": "review",
+                "confidence": None,
+                "reason": "undr-age signal detected",
+                "unsafe_categories": [],
+            },
+            default_model="fixture",
+        )
+
+        self.assertIn(result["reason_code"], {"underage", "minor_targeting"})
+        self.assertEqual(result["verdict"], "escalate")
+        self.assertIs(result.get("needs_human_admin"), True)
+
+    def test_missing_confidence_ambiguous_fails_closed_to_human_admin_path(self):
+        model_result = normalize_model_result(
+            {
+                "verdict": "review",
+                "confidence": "unknown",
+                "reason": "cannot determine",
+                "note": "ambiguous visual signal",
+                "unsafe_categories": [],
+            },
+            default_model="fixture",
+        )
+        item = {"photo_id": 7001}
+        checks = {"image_reference_present": True, "exists": True, "supported_reference": True}
+        combined = combine(item, checks, model_result, dry_run=True, force=False)
+
+        self.assertEqual(model_result["confidence_source"], "derived_ambiguous_fail_closed")
+        self.assertEqual(model_result["reason_code"], "manual_admin_decision")
+        self.assertEqual(model_result.get("fail_closed_route"), "needs_human_admin")
+        self.assertEqual(combined["planned_action"], "human_admin_review")
+
+    def test_same_input_produces_same_deterministic_mapping(self):
+        payload = {
+            "verdict": "reject_recommendation",
+            "confidence": None,
+            "reason": "undr-age signal detected",
+            "unsafe_categories": [],
+        }
+        left = normalize_model_result(payload, default_model="fixture")
+        right = normalize_model_result(payload, default_model="fixture")
+
+        self.assertEqual(left["reason_code"], right["reason_code"])
+        self.assertEqual(left["confidence"], right["confidence"])
+        self.assertEqual(left["confidence_source"], right["confidence_source"])
+        self.assertEqual(left["match_source"], right["match_source"])
 
     def test_policy_falls_back_before_future_write_eligibility(self):
         item = {"photo_id": 1}
@@ -474,7 +557,7 @@ class PhotoSweeperSmokeTests(unittest.TestCase):
             "not_a_profile_photo": "not_person_photo",
             "celebrity_or_stock_photo": "fake_profile",
             "object_or_landscape_only": "fake_profile",
-            "ai_generated_or_synthetic": "manual_admin_decision",
+            "ai_generated_or_synthetic": "ai_generated",
             "ai_generated": "ai_generated",
             "contact_info_or_ad": "off_platform_contact",
             "contact_info_text_only_ad": "off_platform_contact",

--- a/Pryan-Fire/projects/backend/anewluv-photo-moderation/tests/test_smoke.py
+++ b/Pryan-Fire/projects/backend/anewluv-photo-moderation/tests/test_smoke.py
@@ -254,12 +254,20 @@ class PhotoSweeperSmokeTests(unittest.TestCase):
                 "unsafe_categories": ["ai_generated_or_synthetic"],
             },
             default_model="fixture",
+            allowed_reason_codes={"ai_generated"},
+            reason_vocabulary=(
+                {
+                    "code": "ai_generated",
+                    "aliases": "ai generated|ai-generated|synthetic|digitally created|rendered|generated image",
+                    "keyword_weight": 1.0,
+                },
+            ),
         )
 
         self.assertGreater(result["confidence"], 0.0)
         self.assertEqual(result["confidence_source"], "derived_reason_map")
         self.assertEqual(result["reason_code"], "ai_generated")
-        self.assertIn(result["match_source"], {"normalized_substring", "fuzzy_marker", "fuzzy_token"})
+        self.assertIn(result["match_source"], {"db_normalized_substring", "db_fuzzy_token", "db_exact_normalized"})
         self.assertIn("match_evidence", result)
 
     def test_provider_confidence_is_preserved_when_valid(self):
@@ -285,6 +293,19 @@ class PhotoSweeperSmokeTests(unittest.TestCase):
                 "unsafe_categories": [],
             },
             default_model="fixture",
+            allowed_reason_codes={"underage", "minor_targeting"},
+            reason_vocabulary=(
+                {
+                    "code": "underage",
+                    "aliases": "under age|underage|minor|child|teen|youth",
+                    "keyword_weight": 1.0,
+                },
+                {
+                    "code": "minor_targeting",
+                    "aliases": "targets minors|targeting minors|minor targeting|sexualizes youth",
+                    "keyword_weight": 1.0,
+                },
+            ),
         )
 
         self.assertIn(result["reason_code"], {"underage", "minor_targeting"})


### PR DESCRIPTION
## Summary\n- add deterministic reason normalization stack: exact/normalized substring/fuzzy marker/fuzzy token(Levenshtein)\n- derive deterministic confidence when provider confidence is missing/invalid\n- preserve provider confidence when valid\n- add audit fields: confidence_source, confidence_evidence, match_source, match_evidence\n- fail-close unresolved/no-reliable-match to human-admin escalation path\n- hard guard underage/minor to human-admin escalation\n- add/adjust smoke tests for deterministic mapping and escalation\n\n## Validation\n- PYTHONPATH=src python3 -m unittest -q tests.test_smoke (91 passed)\n- before/after dry-run proof attached in chat output