### PR TITLE
feat(souldrifter): atlas fog discipline + exploration sync

### DIFF
--- a/Arianus-Sky/projects/games/SoulDrifterWeb/public/lore-atlas/app.js
+++ b/Arianus-Sky/projects/games/SoulDrifterWeb/public/lore-atlas/app.js
@@ -59,6 +59,8 @@
     bindHeader();
   }
 
+  const embedded = window.self !== window.top;  // inside the game iframe: no review controls
+
   function headerHTML() {
     return `
       <div class="brand">
@@ -71,10 +73,11 @@
         ${tabBtn("book", "Lore Book")}
       </nav>
       <div class="header-actions">
+        ${embedded ? "" : `
         <label class="preview-toggle" title="Review build only — bypasses all locks and fog">
           <input type="checkbox" id="previewAll" ${previewAll ? "checked" : ""}> Preview All
         </label>
-        <button class="btn ghost" id="stateBtn">Game State</button>
+        <button class="btn ghost" id="stateBtn">Game State</button>`}
       </div>`;
   }
   function tabBtn(id, label) {
@@ -83,8 +86,8 @@
   function bindHeader() {
     app.querySelectorAll(".tab").forEach(b =>
       b.addEventListener("click", () => { currentTab = b.dataset.tab; selectedPoi = null; render(); }));
-    app.querySelector("#previewAll").addEventListener("change", e => { previewAll = e.target.checked; render(); });
-    app.querySelector("#stateBtn").addEventListener("click", () => {
+    app.querySelector("#previewAll")?.addEventListener("change", e => { previewAll = e.target.checked; render(); });
+    app.querySelector("#stateBtn")?.addEventListener("click", () => {
       document.querySelector(".state-drawer").classList.toggle("open");
     });
   }
@@ -216,14 +219,22 @@
     }).join("");
     chips.querySelectorAll(".chip").forEach(c => c.addEventListener("click", () => {
       const id = c.dataset.realm;
-      if (!realmUnlocked(id)) { toast("Sealed. Unlock this realm through the Soul Wells first."); return; }
+      // Sealed realms open too — their map shows, drowned under full fog (DIR-4/4a)
       currentRealm = id; selectedPoi = null; realmView = "lore"; render();
     }));
     wrap.appendChild(chips);
 
     if (locked) {
-      wrap.appendChild(el("div", "locked-panel",
-        `<h2>🔒 ${realm.name} is sealed</h2><p>The Soul Wells have not opened this road. Return when your journey unlocks it.</p>`));
+      const body = el("div", "map-body");
+      const stage = el("div", "map-stage");
+      const zoomer = el("div", "zoom-inner");
+      zoomer.innerHTML = `<img class="map-img game-toned" src="${realm.map}" alt="${realm.name} map (sealed)" draggable="false">`;
+      zoomer.appendChild(fogCanvas(realm, []));  // full fog, no holes — nothing charted yet
+      stage.appendChild(zoomer);
+      stage.appendChild(el("div", "sealed-overlay",
+        `<h2>🔒 ${realm.name} is sealed</h2><p>The Soul Wells have not opened this road. The land lies under the smoke — its roads and cities stay hidden until your journey unlocks it.</p>`));
+      body.appendChild(stage);
+      wrap.appendChild(body);
       return wrap;
     }
 
@@ -603,6 +614,12 @@
     importJSON: (str) => { state = JSON.parse(str); saveState(); render(); },
     reset: () => { state = JSON.parse(JSON.stringify(D.defaultState)); saveState(); render(); }
   };
+
+  /* The game writes exploration to the same localStorage key; when the atlas
+     panel is open in its iframe, refresh live on every write. */
+  window.addEventListener("storage", (event) => {
+    if (event.key === LS_KEY) { state = loadState(); render(); }
+  });
 
   /* deep links: #wheel · #maps · #maps:<realmId> · #book · #book:<page> */
   (function applyHash() {

--- a/Arianus-Sky/projects/games/SoulDrifterWeb/public/lore-atlas/atlas.css
+++ b/Arianus-Sky/projects/games/SoulDrifterWeb/public/lore-atlas/atlas.css
@@ -252,3 +252,19 @@ html, body { margin: 0; height: 100%; background: var(--ink); color: var(--parch
   .book-toc { flex-direction: row; flex-wrap: wrap; border-right: none; border-bottom: 1px solid var(--line); }
   .state-drawer { width: 320px; }
 }
+
+/* Sealed realm: painted map drowned under full fog, caption on top */
+.sealed-overlay {
+  position: absolute;
+  inset: auto 24px 24px 24px;
+  z-index: 5;
+  padding: 18px 22px;
+  border: 1px solid #4a3f2c;
+  border-radius: 10px;
+  background: rgba(10, 12, 14, 0.82);
+  backdrop-filter: blur(3px);
+  text-align: center;
+  pointer-events: none;
+}
+.sealed-overlay h2 { margin: 0 0 6px; color: var(--gold, #d9b45c); font-size: 20px; }
+.sealed-overlay p { margin: 0; color: var(--parchment-dim, #b9ac90); font-size: 13px; line-height: 1.5; }

--- a/Arianus-Sky/projects/games/SoulDrifterWeb/src/game/World3D.ts
+++ b/Arianus-Sky/projects/games/SoulDrifterWeb/src/game/World3D.ts
@@ -105,6 +105,7 @@ import {
 } from "./avatarMotionController";
 import { animationTuningRegistry } from "./animationTuning";
 import { lightingTuningRegistry } from "./lightingTuning";
+import { markAtlasPoi } from "./atlasSync";
 
 const TILE_SIZE = 1.75;
 const PAPER_DOLL_UP = new THREE.Vector3(0, 1, 0);
@@ -507,6 +508,8 @@ export class World3D {
     this.bindInput();
     this.bindUI();
     this.revealRoom("training", false);
+    // The awakening itself charts the Soul Well on the Lore Atlas map.
+    markAtlasPoi("thalenyr", "soulwell", "explored");
     this.resize();
     this.updateCamera(true, 0);
     this.initializeHud();

--- a/Arianus-Sky/projects/games/SoulDrifterWeb/src/game/atlasSync.ts
+++ b/Arianus-Sky/projects/games/SoulDrifterWeb/src/game/atlasSync.ts
@@ -1,0 +1,61 @@
+/**
+ * Writes the game's exploration progress into the Lore Atlas state
+ * (localStorage "souldrifter.atlasState.v1"). The atlas iframe reads the same
+ * key and live-refreshes via storage events, so maps reveal as the player
+ * actually visits places. Realm locks and POI reveals are never demoted here.
+ */
+
+const ATLAS_LS_KEY = "souldrifter.atlasState.v1";
+
+export type AtlasPoiStatus = "rumored" | "explored" | "completed";
+
+interface AtlasState {
+  realms: Record<string, { unlocked: boolean }>;
+  pois: Record<string, string>;
+}
+
+const STATUS_ORDER: Record<string, number> = { unknown: 0, rumored: 1, explored: 2, completed: 3 };
+
+/** Thalenyr is the start realm; a sync write must never strand it locked. */
+const SEED: AtlasState = { realms: { thalenyr: { unlocked: true } }, pois: {} };
+
+function loadAtlasState(): AtlasState {
+  try {
+    const raw = localStorage.getItem(ATLAS_LS_KEY);
+    if (raw) {
+      const parsed = JSON.parse(raw) as Partial<AtlasState>;
+      return {
+        realms: { ...SEED.realms, ...(parsed.realms ?? {}) },
+        pois: { ...(parsed.pois ?? {}) },
+      };
+    }
+  } catch {
+    // Private-mode storage refusals are fine; the atlas stays at its default.
+  }
+  return JSON.parse(JSON.stringify(SEED)) as AtlasState;
+}
+
+function saveAtlasState(state: AtlasState): void {
+  try {
+    localStorage.setItem(ATLAS_LS_KEY, JSON.stringify(state));
+  } catch {
+    // A full or blocked store must never interrupt gameplay.
+  }
+}
+
+export function markAtlasPoi(realmId: string, poiId: string, status: AtlasPoiStatus): void {
+  const state = loadAtlasState();
+  const key = `${realmId}.${poiId}`;
+  const current = STATUS_ORDER[state.pois[key] ?? "unknown"] ?? 0;
+  const next = STATUS_ORDER[status] ?? 0;
+  if (current >= next) return;
+  state.pois[key] = status;
+  saveAtlasState(state);
+}
+
+export function unlockAtlasRealm(realmId: string): void {
+  const state = loadAtlasState();
+  if (state.realms[realmId]?.unlocked) return;
+  state.realms[realmId] = { unlocked: true };
+  saveAtlasState(state);
+}


### PR DESCRIPTION
Sealed realms show their painted map drowned under full fog with a sealed caption (DIR-4/4a). Game writes exploration to the atlas state (Soul Well marked explored at awakening; never demotes, Thalenyr always seeded unlocked). Atlas panel live-refreshes via storage events. Preview/Game State review controls hidden when embedded in the game.