### PR TITLE
SoulDrifter: establish QA and public dual-release artifacts

### DIFF
--- a/.github/workflows/souldrifter-qa-release.yml
+++ b/.github/workflows/souldrifter-qa-release.yml
@@ -1,6 +1,9 @@
 name: SoulDrifter QA release
 
 on:
+  pull_request:
+    branches:
+      - qa
   push:
     branches:
       - qa
@@ -90,6 +93,7 @@ jobs:
         run: yarn verify:release
 
       - name: Upload gated Sites artifact
+        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v7
         with:
           name: souldrifter-sites-${{ steps.source.outputs.short_sha }}

--- a/.github/workflows/souldrifter-qa-release.yml
+++ b/.github/workflows/souldrifter-qa-release.yml
@@ -1,0 +1,99 @@
+name: SoulDrifter QA release
+
+on:
+  push:
+    branches:
+      - qa
+  workflow_dispatch:
+    inputs:
+      source_ref:
+        description: Reviewed qa branch, tag, or commit to package
+        required: false
+        default: qa
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: souldrifter-qa-release
+  cancel-in-progress: false
+
+jobs:
+  build-sites-artifact:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out merged QA source
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.source_ref || github.sha }}
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
+
+      - name: Resolve source commit
+        id: source
+        shell: bash
+        run: |
+          source_sha="$(git rev-parse HEAD)"
+          echo "sha=$source_sha" >> "$GITHUB_OUTPUT"
+          echo "short_sha=${source_sha:0:12}" >> "$GITHUB_OUTPUT"
+
+      - name: Confirm source came from a merged QA pull request
+        if: github.event_name == 'push'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_SHA: ${{ steps.source.outputs.sha }}
+        run: |
+          merged_qa_prs="$(
+            gh api \
+              -H "Accept: application/vnd.github+json" \
+              "/repos/${GITHUB_REPOSITORY}/commits/${SOURCE_SHA}/pulls" \
+              --jq '[.[] | select(.merged_at != null and .base.ref == "qa")] | length'
+          )"
+
+          if [ "$merged_qa_prs" -lt 1 ]; then
+            echo "Refusing to package ${SOURCE_SHA}: it is not associated with a merged PR into qa."
+            exit 1
+          fi
+
+      - name: Enable Yarn 1
+        shell: bash
+        run: |
+          corepack enable
+          corepack prepare yarn@1.22.22 --activate
+
+      - name: Install dependencies
+        working-directory: Arianus-Sky/projects/games/SoulDrifterWeb
+        run: yarn install --non-interactive --no-progress
+
+      - name: Run tests
+        working-directory: Arianus-Sky/projects/games/SoulDrifterWeb
+        run: yarn test
+
+      - name: Type-check
+        working-directory: Arianus-Sky/projects/games/SoulDrifterWeb
+        run: yarn typecheck
+
+      - name: Build QA and public artifacts
+        working-directory: Arianus-Sky/projects/games/SoulDrifterWeb
+        env:
+          SOULDRIFTER_SOURCE_COMMIT: ${{ steps.source.outputs.sha }}
+        run: yarn build
+
+      - name: Verify release target separation and provenance
+        working-directory: Arianus-Sky/projects/games/SoulDrifterWeb
+        run: yarn verify:release
+
+      - name: Upload gated Sites artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: souldrifter-sites-${{ steps.source.outputs.short_sha }}
+          path: Arianus-Sky/projects/games/SoulDrifterWeb/dist
+          include-hidden-files: true
+          if-no-files-found: error
+          retention-days: 14

--- a/Arianus-Sky/projects/games/SoulDrifterWeb/.gitignore
+++ b/Arianus-Sky/projects/games/SoulDrifterWeb/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 dist/
+dist-pages/
 coverage/
 *.log
 

--- a/Arianus-Sky/projects/games/SoulDrifterWeb/docs/DUAL_DEPLOYMENT.md
+++ b/Arianus-Sky/projects/games/SoulDrifterWeb/docs/DUAL_DEPLOYMENT.md
@@ -4,10 +4,10 @@ Tracking: [The-Nexus #437](https://github.com/The-Nexus-Decoded/The-Nexus/issues
 
 SoulDrifter has two release surfaces with different routing and access contracts:
 
-| Target | URL | Audience | Entry route | Build artifact |
-|---|---|---|---|---|
-| GitHub Pages | `https://the-nexus-decoded.github.io/` | Public | `/` | `dist-pages/` |
-| ChatGPT Sites | `https://souldrifter-first-breach.ola-lawal.chatgpt.site/play` | Password-gated QA | `/play` | `dist/` |
+| Target | Source branch | URL | Audience | Entry route | Build artifact |
+|---|---|---|---|---|---|
+| GitHub Pages | `main` | `https://the-nexus-decoded.github.io/` | Public | `/` | `dist-pages/` |
+| ChatGPT Sites | `qa` | `https://souldrifter-first-breach.ola-lawal.chatgpt.site/play` | Password-gated QA | `/play` | `dist/` |
 
 ## One source, two artifacts
 
@@ -20,16 +20,42 @@ yarn verify:release
 
 The Vite client is first copied unchanged to `dist-pages/`. That copy opens the game directly at the root and is the only artifact allowed to enter the Pages repository. The build then prepares `dist/` for ChatGPT Sites by embedding the original game shell in the worker and replacing `dist/client/index.html` with the `/play` redirect.
 
-Both artifacts contain the same `release.json`, including the source commit and release ID. A deployment is synchronized only when those values match on both targets.
+Both artifacts contain a `release.json`, including the source commit and release ID. The QA site may intentionally run ahead while a release is under review. A promoted deployment is synchronized only when those values match on both targets.
+
+## Branch and merge policy
+
+- Merging a PR into `qa` publishes a validated candidate to the gated ChatGPT Sites project.
+- Merging a PR into `main` publishes a validated stable build to public GitHub Pages.
+- Opening, updating, or closing a PR without merging never deploys.
+- Feature-branch pushes and direct branch pushes do not satisfy the merge gate.
+- The hosting monitors poll because GitHub and ChatGPT Sites do not share a native cross-repository push event. Expect a merged PR to be detected within several minutes.
+
+## GitHub Pages publication
+
+The public repository owns a `Deploy SoulDrifter` workflow. It detects a new PR merge on The-Nexus `main`, resolves the exact merge commit, runs the full SoulDrifter test and build gates, and uploads only `dist-pages/` through GitHub Pages. Unchanged commits are skipped, and no cross-repository write token is required.
+
+Manual dispatch remains available for a reviewed rollback commit:
+
+```powershell
+$sourceCommit = git rev-parse HEAD
+gh workflow run deploy-souldrifter.yml `
+  --repo The-Nexus-Decoded/The-Nexus-Decoded.github.io `
+  --ref main `
+  -f source_ref=$sourceCommit
+```
+
+The workflow's checkout SHA is passed to `SOULDRIFTER_SOURCE_COMMIT`, so the hosted `release.json` identifies The-Nexus source rather than the Pages workflow commit.
+
+The gated Sites project is deployed by the Codex QA monitor because Sites version saving and deployment are connector operations, not a public GitHub Action. The monitor applies the same test, typecheck, build, target-separation, and source-commit gates before publishing a newly merged `qa` commit.
 
 ## Release order
 
-1. Start from a clean, reviewed commit on `main`.
-2. Run tests, typecheck, build, and `verify:release`.
-3. Publish `dist-pages/` to `The-Nexus-Decoded/The-Nexus-Decoded.github.io`.
-4. Package `dist/` with the Sites packaging helper, save a Sites version using the same source commit, and deploy it.
-5. Verify the Pages root, the gated Sites `/play` route, the lore atlas, character creation, 3D asset loading, and entry into First Breach combat.
-6. Compare both hosted `release.json` files before declaring the release synchronized.
+1. Merge the reviewed release candidate PR into `qa`.
+2. Let the QA monitor run tests, typecheck, build, `verify:release`, package `dist/`, and deploy the gated Sites version.
+3. Verify the gated `/play` route, lore atlas, character creation, 3D asset loading, and First Breach entry.
+4. Promote the approved candidate through a PR into `main`.
+5. Let the Pages workflow rebuild the merged `main` commit and publish only `dist-pages/`.
+6. Verify the public root and compare hosted `release.json` files when the release is expected to be synchronized.
 
 Never copy all of `dist/` into GitHub Pages. Its root document intentionally redirects to `/play`, a worker route that static Pages cannot provide.
 
@@ -37,4 +63,4 @@ Never copy all of `dist/` into GitHub Pages. Its root document intentionally red
 
 The ChatGPT Sites project currently uses the app worker's `BETA_PASSWORD` and `SESSION_SECRET` gate. Those values stay in Sites environment secrets and never enter Git. Platform-level Sites sharing is a separate setting and must not be described as the beta gate.
 
-Roll back Pages by restoring the prior known-good Pages commit. Roll back Sites by redeploying the prior saved Sites version. Rollbacks are independent; record both resulting versions on issue #437.
+Roll back Pages by dispatching the workflow with the prior known-good The-Nexus source commit. Roll back Sites by redeploying the prior saved Sites version. Rollbacks are independent; record both resulting versions on issue #437.

--- a/Arianus-Sky/projects/games/SoulDrifterWeb/docs/DUAL_DEPLOYMENT.md
+++ b/Arianus-Sky/projects/games/SoulDrifterWeb/docs/DUAL_DEPLOYMENT.md
@@ -24,11 +24,11 @@ Both artifacts contain a `release.json`, including the source commit and release
 
 ## Branch and merge policy
 
-- Merging a PR into `qa` publishes a validated candidate to the gated ChatGPT Sites project.
+- Merging a PR into `qa` publishes a validated candidate to the gated ChatGPT Sites project. The QA Action runs on the resulting branch update and refuses to package the commit unless GitHub associates it with a merged PR whose base is `qa`; this lets the gate work before the workflow is promoted to the default branch.
 - Merging a PR into `main` publishes a validated stable build to public GitHub Pages.
 - Opening, updating, or closing a PR without merging never deploys.
 - Feature-branch pushes and direct branch pushes do not satisfy the merge gate.
-- The hosting monitors poll because GitHub and ChatGPT Sites do not share a native cross-repository push event. Expect a merged PR to be detected within several minutes.
+- The Sites publication monitor polls because GitHub Actions and ChatGPT Sites do not share a native deployment event. Expect a successfully packaged QA merge to be detected within several minutes.
 
 ## GitHub Pages publication
 

--- a/Arianus-Sky/projects/games/SoulDrifterWeb/docs/DUAL_DEPLOYMENT.md
+++ b/Arianus-Sky/projects/games/SoulDrifterWeb/docs/DUAL_DEPLOYMENT.md
@@ -25,6 +25,7 @@ Both artifacts contain a `release.json`, including the source commit and release
 ## Branch and merge policy
 
 - Merging a PR into `qa` publishes a validated candidate to the gated ChatGPT Sites project. The QA Action runs on the resulting branch update and refuses to package the commit unless GitHub associates it with a merged PR whose base is `qa`; this lets the gate work before the workflow is promoted to the default branch.
+- PRs targeting `qa` run the same tests, typecheck, build, and release verification before merge once this workflow exists on the default branch. The initial workflow bootstrap must carry equivalent local verification evidence on its PR.
 - Merging a PR into `main` publishes a validated stable build to public GitHub Pages.
 - Opening, updating, or closing a PR without merging never deploys.
 - Feature-branch pushes and direct branch pushes do not satisfy the merge gate.

--- a/Arianus-Sky/projects/games/SoulDrifterWeb/docs/DUAL_DEPLOYMENT.md
+++ b/Arianus-Sky/projects/games/SoulDrifterWeb/docs/DUAL_DEPLOYMENT.md
@@ -1,0 +1,40 @@
+# SoulDrifter dual deployment
+
+Tracking: [The-Nexus #437](https://github.com/The-Nexus-Decoded/The-Nexus/issues/437)
+
+SoulDrifter has two release surfaces with different routing and access contracts:
+
+| Target | URL | Audience | Entry route | Build artifact |
+|---|---|---|---|---|
+| GitHub Pages | `https://the-nexus-decoded.github.io/` | Public | `/` | `dist-pages/` |
+| ChatGPT Sites | `https://souldrifter-first-breach.ola-lawal.chatgpt.site/play` | Password-gated QA | `/play` | `dist/` |
+
+## One source, two artifacts
+
+Run the normal build once:
+
+```powershell
+yarn build
+yarn verify:release
+```
+
+The Vite client is first copied unchanged to `dist-pages/`. That copy opens the game directly at the root and is the only artifact allowed to enter the Pages repository. The build then prepares `dist/` for ChatGPT Sites by embedding the original game shell in the worker and replacing `dist/client/index.html` with the `/play` redirect.
+
+Both artifacts contain the same `release.json`, including the source commit and release ID. A deployment is synchronized only when those values match on both targets.
+
+## Release order
+
+1. Start from a clean, reviewed commit on `main`.
+2. Run tests, typecheck, build, and `verify:release`.
+3. Publish `dist-pages/` to `The-Nexus-Decoded/The-Nexus-Decoded.github.io`.
+4. Package `dist/` with the Sites packaging helper, save a Sites version using the same source commit, and deploy it.
+5. Verify the Pages root, the gated Sites `/play` route, the lore atlas, character creation, 3D asset loading, and entry into First Breach combat.
+6. Compare both hosted `release.json` files before declaring the release synchronized.
+
+Never copy all of `dist/` into GitHub Pages. Its root document intentionally redirects to `/play`, a worker route that static Pages cannot provide.
+
+## Access and rollback
+
+The ChatGPT Sites project currently uses the app worker's `BETA_PASSWORD` and `SESSION_SECRET` gate. Those values stay in Sites environment secrets and never enter Git. Platform-level Sites sharing is a separate setting and must not be described as the beta gate.
+
+Roll back Pages by restoring the prior known-good Pages commit. Roll back Sites by redeploying the prior saved Sites version. Rollbacks are independent; record both resulting versions on issue #437.

--- a/Arianus-Sky/projects/games/SoulDrifterWeb/package.json
+++ b/Arianus-Sky/projects/games/SoulDrifterWeb/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "dev": "vite --host 0.0.0.0",
     "build": "node scripts/clean-build.mjs && tsc -b && vite build && node scripts/prepare-sites-build.mjs",
+    "verify:release": "node scripts/verify-release-targets.mjs",
     "preview": "vite preview --host 0.0.0.0",
     "typecheck": "tsc -b",
     "test": "vitest run"

--- a/Arianus-Sky/projects/games/SoulDrifterWeb/scripts/prepare-sites-build.mjs
+++ b/Arianus-Sky/projects/games/SoulDrifterWeb/scripts/prepare-sites-build.mjs
@@ -1,11 +1,27 @@
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { execFile } from "node:child_process";
+import { cp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
 
 const projectRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const workerSource = resolve(projectRoot, "worker/static-sites-worker.js");
 const workerOutput = resolve(projectRoot, "dist/server/index.js");
-const clientIndex = resolve(projectRoot, "dist/client/index.html");
+const sitesClientRoot = resolve(projectRoot, "dist/client");
+const clientIndex = resolve(sitesClientRoot, "index.html");
+const pagesOutput = resolve(projectRoot, "dist-pages");
+const run = promisify(execFile);
+
+async function resolveSourceCommit() {
+  if (process.env.SOULDRIFTER_SOURCE_COMMIT) return process.env.SOULDRIFTER_SOURCE_COMMIT;
+  if (process.env.GITHUB_SHA) return process.env.GITHUB_SHA;
+  try {
+    const { stdout } = await run("git", ["rev-parse", "HEAD"], { cwd: projectRoot });
+    return stdout.trim();
+  } catch {
+    return "unknown";
+  }
+}
 
 await mkdir(dirname(workerOutput), { recursive: true });
 const [workerTemplate, gameHtml] = await Promise.all([
@@ -14,6 +30,29 @@ const [workerTemplate, gameHtml] = await Promise.all([
 ]);
 const marker = "const EMBEDDED_GAME_HTML = null;";
 if (!workerTemplate.includes(marker)) throw new Error("Static Sites worker game-shell marker is missing.");
+
+const sourceCommit = await resolveSourceCommit();
+const release = {
+  app: "SoulDrifter — The First Breach",
+  sourceCommit,
+  releaseId: process.env.SOULDRIFTER_RELEASE_ID ?? sourceCommit.slice(0, 12),
+  builtAt: new Date().toISOString(),
+  targets: {
+    githubPages: { entry: "/", artifact: "dist-pages" },
+    chatgptSites: { entry: "/play", artifact: "dist" },
+  },
+};
+const releaseJson = `${JSON.stringify(release, null, 2)}\n`;
+
+// Preserve the untouched Vite client for GitHub Pages before the Sites-specific
+// root shell is rewritten to /play. Keeping this outside dist also prevents the
+// Sites archive from doubling in size by packaging the Pages copy.
+await rm(pagesOutput, { recursive: true, force: true });
+await cp(sitesClientRoot, pagesOutput, { recursive: true });
+await Promise.all([
+  writeFile(resolve(pagesOutput, "release.json"), releaseJson),
+  writeFile(resolve(sitesClientRoot, "release.json"), releaseJson),
+]);
 await writeFile(workerOutput, workerTemplate.replace(marker, `const EMBEDDED_GAME_HTML = ${JSON.stringify(gameHtml)};`));
 await writeFile(clientIndex, `<!doctype html>
 <html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">

--- a/Arianus-Sky/projects/games/SoulDrifterWeb/scripts/prepare-sites-build.mjs
+++ b/Arianus-Sky/projects/games/SoulDrifterWeb/scripts/prepare-sites-build.mjs
@@ -57,5 +57,5 @@ await writeFile(workerOutput, workerTemplate.replace(marker, `const EMBEDDED_GAM
 await writeFile(clientIndex, `<!doctype html>
 <html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <meta http-equiv="cache-control" content="no-store"><title>SoulDrifter Beta</title>
-<script>location.replace("/play" + location.search + location.hash)</script></head>
+<meta http-equiv="refresh" content="0;url=/play"><link rel="canonical" href="/play"></head>
 <body><p><a href="/play">Enter SoulDrifter</a></p></body></html>`);

--- a/Arianus-Sky/projects/games/SoulDrifterWeb/scripts/verify-release-targets.mjs
+++ b/Arianus-Sky/projects/games/SoulDrifterWeb/scripts/verify-release-targets.mjs
@@ -1,0 +1,41 @@
+import { access, readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const projectRoot = resolve(fileURLToPath(new URL("..", import.meta.url)));
+const pagesRoot = resolve(projectRoot, "dist-pages");
+const sitesRoot = resolve(projectRoot, "dist");
+
+const [pagesIndex, sitesIndex, sitesWorker, pagesRelease, sitesRelease] = await Promise.all([
+  readFile(resolve(pagesRoot, "index.html"), "utf8"),
+  readFile(resolve(sitesRoot, "client/index.html"), "utf8"),
+  readFile(resolve(sitesRoot, "server/index.js"), "utf8"),
+  readFile(resolve(pagesRoot, "release.json"), "utf8").then(JSON.parse),
+  readFile(resolve(sitesRoot, "client/release.json"), "utf8").then(JSON.parse),
+]);
+
+function requireCondition(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+requireCondition(!pagesIndex.includes('location.replace("/play"'), "Pages index must open the game at root, not redirect to /play.");
+requireCondition(pagesIndex.includes("character-creation"), "Pages index does not contain the SoulDrifter game shell.");
+requireCondition(sitesIndex.includes('location.replace("/play"'), "Sites index must redirect authenticated traffic to /play.");
+requireCondition(!sitesWorker.includes("const EMBEDDED_GAME_HTML = null;"), "Sites worker still contains the empty game-shell marker.");
+requireCondition(pagesRelease.sourceCommit === sitesRelease.sourceCommit, "Release artifacts do not identify the same source commit.");
+requireCondition(pagesRelease.releaseId === sitesRelease.releaseId, "Release artifacts do not identify the same release.");
+requireCondition(pagesRelease.targets.githubPages.entry === "/", "Pages release entry must be root.");
+requireCondition(sitesRelease.targets.chatgptSites.entry === "/play", "Sites release entry must be /play.");
+
+await Promise.all([
+  access(resolve(pagesRoot, "lore-atlas/index.html")),
+  access(resolve(sitesRoot, "client/lore-atlas/index.html")),
+]);
+
+process.stdout.write(`${JSON.stringify({
+  ok: true,
+  sourceCommit: pagesRelease.sourceCommit,
+  releaseId: pagesRelease.releaseId,
+  pages: "dist-pages/",
+  sites: "dist/",
+}, null, 2)}\n`);

--- a/Arianus-Sky/projects/games/SoulDrifterWeb/scripts/verify-release-targets.mjs
+++ b/Arianus-Sky/projects/games/SoulDrifterWeb/scripts/verify-release-targets.mjs
@@ -18,9 +18,10 @@ function requireCondition(condition, message) {
   if (!condition) throw new Error(message);
 }
 
-requireCondition(!pagesIndex.includes('location.replace("/play"'), "Pages index must open the game at root, not redirect to /play.");
+requireCondition(!pagesIndex.includes('url=/play'), "Pages index must open the game at root, not redirect to /play.");
 requireCondition(pagesIndex.includes("character-creation"), "Pages index does not contain the SoulDrifter game shell.");
-requireCondition(sitesIndex.includes('location.replace("/play"'), "Sites index must redirect authenticated traffic to /play.");
+requireCondition(sitesIndex.includes('http-equiv="refresh"') && sitesIndex.includes('url=/play'), "Sites index must redirect traffic to /play without inline JavaScript.");
+requireCondition(!sitesIndex.includes("<script"), "Sites redirect shell must remain compatible with the gate's strict CSP.");
 requireCondition(!sitesWorker.includes("const EMBEDDED_GAME_HTML = null;"), "Sites worker still contains the empty game-shell marker.");
 requireCondition(pagesRelease.sourceCommit === sitesRelease.sourceCommit, "Release artifacts do not identify the same source commit.");
 requireCondition(pagesRelease.releaseId === sitesRelease.releaseId, "Release artifacts do not identify the same release.");

--- a/Arianus-Sky/projects/games/SoulDrifterWeb/tests/avatarIdentity.test.ts
+++ b/Arianus-Sky/projects/games/SoulDrifterWeb/tests/avatarIdentity.test.ts
@@ -34,27 +34,31 @@ describe("canonical avatar identity", () => {
     });
   });
 
-  it("routes every supported humanoid Shadowknight race through one compatible rig", () => {
+  it("routes every supported humanoid Shadowknight race through a compatible rig", () => {
     const elf = elfShadowknight();
     const human = { ...elf, raceId: "human", raceName: "Human" };
     const dwarf = { ...elf, raceId: "dwarf", raceName: "Dwarf" };
     const halfling = { ...elf, raceId: "halfling", raceName: "Halfling" };
-    expect(resolvePlayerModelPath(elf)).toBe("/assets/3d/characters/elf-shadowknight/elf-shadowknight.glb");
-    expect(resolvePlayerModelPath(human)).toBe(resolvePlayerModelPath(elf));
-    expect(resolvePlayerModelPath(dwarf)).toBe(resolvePlayerModelPath(elf));
-    expect(resolvePlayerModelPath(halfling)).toBe(resolvePlayerModelPath(elf));
+    expect(resolvePlayerModelPath(elf)).toBe("/assets/3d/characters/elf-shadowknight-v2/elf-shadowknight-v2.glb");
+    expect(resolvePlayerModelPath(human)).toBe("/assets/3d/characters/human-shadowknight/human-shadowknight.glb");
+    expect(resolvePlayerModelPath(dwarf)).toBe(resolvePlayerModelPath(human));
+    expect(resolvePlayerModelPath(halfling)).toBe(resolvePlayerModelPath(human));
   });
 
   it("keeps model and optional same-rig animation packs on one identity manifest", () => {
     const elf = elfShadowknight();
     const dwarf = { ...elf, raceId: "dwarf", raceName: "Dwarf" };
 
-    const expected = {
-      modelPath: "/assets/3d/characters/elf-shadowknight/elf-shadowknight.glb",
+    const elfExpected = {
+      modelPath: "/assets/3d/characters/elf-shadowknight-v2/elf-shadowknight-v2.glb",
       animationPacks: [...HUMANOID_ACTIVE_ANIMATION_PACKS, SIPHON_CLEAVE_PACK, WEAPON_STRIKE_PACK],
     };
-    expect(resolvePlayerAvatarManifest(elf)).toEqual(expected);
-    expect(resolvePlayerAvatarManifest(dwarf)).toEqual(expected);
+    const humanExpected = {
+      modelPath: "/assets/3d/characters/human-shadowknight/human-shadowknight.glb",
+      animationPacks: [...HUMANOID_ACTIVE_ANIMATION_PACKS, SIPHON_CLEAVE_PACK, WEAPON_STRIKE_PACK],
+    };
+    expect(resolvePlayerAvatarManifest(elf)).toEqual(elfExpected);
+    expect(resolvePlayerAvatarManifest(dwarf)).toEqual(humanExpected);
 
     const dwarfWarrior = { ...dwarf, callingId: "warrior" as const, callingName: "Warrior" };
     expect(resolvePlayerAvatarManifest(dwarfWarrior)).toEqual({

--- a/Arianus-Sky/projects/games/SoulDrifterWeb/tests/presentationBoundaries.test.js
+++ b/Arianus-Sky/projects/games/SoulDrifterWeb/tests/presentationBoundaries.test.js
@@ -225,7 +225,8 @@ describe("screen-space HUD and live paper-doll boundaries", () => {
     expect(avatarIdentity).toContain("PLAYER_AVATAR_BY_IDENTITY");
     expect(world).toContain("animationPackCache");
     expect(world).toMatch(/loadExternalAnimationPack[\s\S]*loadCachedAnimationPack[\s\S]*bindOptionalCompatibleAnimationClip/s);
-    expect(world).toMatch(/normalizeAnimationPackRootMotion\(bound, spec\.rootNodeName\)/);
+    expect(world).toMatch(/const boundRootNode = bound\.tracks[\s\S]*spec\.rootNodeName/);
+    expect(world).toMatch(/normalizeAnimationPackRootMotion\(bound, boundRootNode\)/);
     expect(world).not.toMatch(/sanitizeAttackClip\(bound\)/);
     expect(world).toMatch(/resolvePlayerAvatarManifest\(this\.profile\)[\s\S]*playerAvatar\.animationPacks/s);
     expect(world).toMatch(/Promise\.all\(animationPacks\.map\(async \(spec\)[\s\S]*await this\.loadExternalAnimationPack\(spec, model\)[\s\S]*if \(externalClip\) clips\.set\(externalClip\.name/s);


### PR DESCRIPTION
## Summary
Establishes the first branch-aware SoulDrifter dual release candidate for #437.

This PR targets `qa`. Once merged, the QA Action validates the exact merge, packages the gated Sites artifact, and the Codex Sites monitor publishes it. After QA approval, only the owner initiates the separate `qa` -> `main` promotion PR that enables the public Pages release.

## Changes
- Preserve the untouched root-hosted Vite client as `dist-pages/` before preparing the Sites worker artifact in `dist/`.
- Stamp both artifacts with source-commit `release.json` provenance.
- Verify Pages never receives the Sites-only `/play` redirect.
- Use a CSP-safe Sites root redirect.
- Align avatar/model and animation-root tests with the merged v14 runtime contracts.
- Add a QA workflow that tests PR candidates and only uploads a deployable artifact after GitHub confirms a merge into `qa`.
- Document the permanent feature -> `qa` -> owner-approved `main` promotion policy for future agents.

## Verification
Verified at `2292b07cd5c7579270130b390a2c2648d934a308`:
- 135/135 tests pass (22/22 files).
- TypeScript passes.
- Production build passes.
- Dual-target release verification passes.
- `actionlint` v1.7.12 passes for the QA workflow.
- ESLint is not configured in SoulDrifterWeb.

## Deployment
Merging this PR targets only `qa`. It does not change The-Nexus `main` or trigger the public Pages release. The owner retains control of the later `qa` -> `main` promotion.

Related public Pages workflow PR: https://github.com/The-Nexus-Decoded/The-Nexus-Decoded.github.io/pull/1