### PR TITLE
[P1] SoulDrifter runtime asset budget for QA

### DIFF
--- a/Arianus-Sky/projects/games/SoulDrifterWeb/package.json
+++ b/Arianus-Sky/projects/games/SoulDrifterWeb/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite --host 0.0.0.0",
-    "build": "node scripts/clean-build.mjs && tsc -b && vite build && node scripts/prepare-sites-build.mjs",
+    "build": "node scripts/clean-build.mjs && tsc -b && vite build && node scripts/prepare-sites-build.mjs && node scripts/prune-runtime-assets.mjs",
     "preview": "vite preview --host 0.0.0.0",
     "typecheck": "tsc -b",
     "test": "vitest run"

--- a/Arianus-Sky/projects/games/SoulDrifterWeb/scripts/prune-runtime-assets.mjs
+++ b/Arianus-Sky/projects/games/SoulDrifterWeb/scripts/prune-runtime-assets.mjs
@@ -1,0 +1,160 @@
+import { access, readFile, readdir, rm, stat } from "node:fs/promises";
+import { dirname, relative, resolve, sep } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const projectRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const defaultManifestPath = resolve(projectRoot, "scripts/runtime-asset-manifest.json");
+const textExtensions = new Set([".css", ".html", ".js", ".json", ".map", ".svg", ".txt"]);
+
+function normalizeAssetPath(path) {
+  const normalized = path.split(sep).join("/").replace(/^\.\//, "");
+  if (!normalized || normalized.startsWith("/") || normalized.split("/").includes("..")) {
+    throw new Error(`Unsafe runtime asset path: ${path}`);
+  }
+  return normalized;
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[|\\{}()[\]^$+?.]/g, "\\$&");
+}
+
+export function globToRegExp(glob) {
+  const normalized = normalizeAssetPath(glob);
+  let expression = "";
+  for (let index = 0; index < normalized.length; index += 1) {
+    const character = normalized[index];
+    if (character !== "*") {
+      expression += escapeRegExp(character);
+      continue;
+    }
+    if (normalized[index + 1] === "*") {
+      expression += ".*";
+      index += 1;
+    } else {
+      expression += "[^/]*";
+    }
+  }
+  return new RegExp(`^${expression}$`);
+}
+
+async function exists(path) {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function walkFiles(root) {
+  if (!(await exists(root))) return [];
+  const files = [];
+  const entries = await readdir(root, { withFileTypes: true });
+  for (const entry of entries) {
+    const path = resolve(root, entry.name);
+    if (entry.isDirectory()) files.push(...await walkFiles(path));
+    else if (entry.isFile()) files.push(path);
+  }
+  return files;
+}
+
+export async function loadAssetManifest(path = defaultManifestPath) {
+  const manifest = JSON.parse(await readFile(path, "utf8"));
+  if (!Number.isSafeInteger(manifest.maxBytes) || manifest.maxBytes <= 0) {
+    throw new Error("Runtime asset manifest requires a positive integer maxBytes value.");
+  }
+  manifest.excludeGlobs.forEach(normalizeAssetPath);
+  manifest.protectedPaths.forEach(normalizeAssetPath);
+  return manifest;
+}
+
+export async function collectPrunableFiles(assetRoot, excludeGlobs) {
+  const matchers = excludeGlobs.map(globToRegExp);
+  const files = await walkFiles(assetRoot);
+  return files.filter((path) => {
+    const assetPath = normalizeAssetPath(relative(assetRoot, path));
+    return matchers.some((matcher) => matcher.test(assetPath));
+  });
+}
+
+async function assertProtectedAssets(assetRoot, protectedPaths) {
+  const missing = [];
+  for (const assetPath of protectedPaths) {
+    if (!(await exists(resolve(assetRoot, normalizeAssetPath(assetPath))))) missing.push(assetPath);
+  }
+  if (missing.length > 0) {
+    throw new Error(`Runtime build is missing protected assets:\n${missing.join("\n")}`);
+  }
+}
+
+async function assertCandidatesAreUnreferenced(assetRoot, candidates) {
+  if (candidates.length === 0) return;
+  const candidatePaths = new Map(candidates.map((path) => {
+    const assetPath = normalizeAssetPath(relative(assetRoot, path));
+    return [assetPath, assetPath.split("/").at(-1)];
+  }));
+  const textFiles = (await walkFiles(assetRoot)).filter((path) => {
+    if (candidates.includes(path)) return false;
+    const extension = path.slice(path.lastIndexOf(".")).toLowerCase();
+    return textExtensions.has(extension);
+  });
+  const references = [];
+  for (const textFile of textFiles) {
+    const contents = await readFile(textFile, "utf8");
+    for (const [assetPath, fileName] of candidatePaths) {
+      if (contents.includes(assetPath) || contents.includes(fileName)) {
+        references.push(`${normalizeAssetPath(relative(assetRoot, textFile))} -> ${assetPath}`);
+      }
+    }
+  }
+  if (references.length > 0) {
+    throw new Error(`Refusing to prune referenced runtime assets:\n${references.join("\n")}`);
+  }
+}
+
+export async function directoryBytes(root) {
+  const sizes = await Promise.all((await walkFiles(root)).map(async (path) => (await stat(path)).size));
+  return sizes.reduce((total, size) => total + size, 0);
+}
+
+export async function pruneAssetRoot(assetRoot, manifest) {
+  await assertProtectedAssets(assetRoot, manifest.protectedPaths);
+  const candidates = await collectPrunableFiles(assetRoot, manifest.excludeGlobs);
+  await assertCandidatesAreUnreferenced(assetRoot, candidates);
+  const removedBytes = (await Promise.all(candidates.map(async (path) => (await stat(path)).size)))
+    .reduce((total, size) => total + size, 0);
+  await Promise.all(candidates.map((path) => rm(path, { force: true })));
+  await assertProtectedAssets(assetRoot, manifest.protectedPaths);
+  return {
+    removedFiles: candidates.length,
+    removedBytes,
+  };
+}
+
+export async function pruneRuntimeAssets(root = projectRoot) {
+  const manifest = await loadAssetManifest(resolve(root, "scripts/runtime-asset-manifest.json"));
+  const results = [];
+  for (const target of manifest.targets) {
+    const assetRoot = resolve(root, normalizeAssetPath(target.assetRoot));
+    if (!(await exists(assetRoot))) continue;
+    const result = await pruneAssetRoot(assetRoot, manifest);
+    const budgetRoot = resolve(root, normalizeAssetPath(target.budgetRoot));
+    const bytes = await directoryBytes(budgetRoot);
+    if (bytes > manifest.maxBytes) {
+      throw new Error(`${target.budgetRoot} is ${bytes} bytes, exceeding the ${manifest.maxBytes}-byte runtime budget.`);
+    }
+    results.push({
+      target: target.budgetRoot,
+      bytes,
+      preferredBudgetMet: bytes <= manifest.preferredMaxBytes,
+      ...result,
+    });
+  }
+  if (results.length === 0) throw new Error("No runtime build targets were found to prune.");
+  return results;
+}
+
+if (process.argv[1] && pathToFileURL(resolve(process.argv[1])).href === import.meta.url) {
+  const results = await pruneRuntimeAssets();
+  process.stdout.write(`${JSON.stringify({ ok: true, results }, null, 2)}\n`);
+}

--- a/Arianus-Sky/projects/games/SoulDrifterWeb/scripts/runtime-asset-manifest.json
+++ b/Arianus-Sky/projects/games/SoulDrifterWeb/scripts/runtime-asset-manifest.json
@@ -1,0 +1,45 @@
+{
+  "maxBytes": 150000000,
+  "preferredMaxBytes": 140000000,
+  "excludeGlobs": [
+    "assets/generated/*-class-atlas-*-v1.png",
+    "assets/generated/*-starter-atlas-*-v1.png",
+    "assets/generated/sentinel-*-v1.png",
+    "assets/generated/sentinel.png",
+    "assets/generated/shadowknight-starter-*.png",
+    "assets/generated/tutorial-npcs-*-v1.png",
+    "assets/generated/action-icons/*-atlas.png",
+    "assets/generated/characters/advanced/**",
+    "lore-atlas/assets/P-*_painted.png",
+    "lore-atlas/assets/maps/*.svg"
+  ],
+  "protectedPaths": [
+    "assets/generated/first-breach-environment-v1.png",
+    "assets/generated/action-icons/basic-weapon-strike.svg",
+    "assets/generated/action-icons/imprint-discipline.svg",
+    "assets/generated/characters/elf-shadowknight-highlevel.png",
+    "assets/generated/characters/human-shadowknight-highlevel.png",
+    "assets/3d/characters/elf-shadowknight-v2/elf-shadowknight-v2.glb",
+    "assets/3d/characters/human-shadowknight/human-shadowknight.glb",
+    "assets/3d/characters/enemy-breachling.gltf",
+    "lore-atlas/assets/M-001_painted_cosmology.png",
+    "lore-atlas/assets/M-003_painted_atlas.png",
+    "lore-atlas/assets/maps/abarrach_painted.png",
+    "lore-atlas/assets/maps/arianus_painted.png",
+    "lore-atlas/assets/maps/chelestra_painted.png",
+    "lore-atlas/assets/maps/labyrinth_painted.png",
+    "lore-atlas/assets/maps/nexus_painted.png",
+    "lore-atlas/assets/maps/pryan_painted.png",
+    "lore-atlas/index.html"
+  ],
+  "targets": [
+    {
+      "assetRoot": "dist/client",
+      "budgetRoot": "dist"
+    },
+    {
+      "assetRoot": "dist-pages",
+      "budgetRoot": "dist-pages"
+    }
+  ]
+}

--- a/Arianus-Sky/projects/games/SoulDrifterWeb/tests/runtimeAssetBudget.test.js
+++ b/Arianus-Sky/projects/games/SoulDrifterWeb/tests/runtimeAssetBudget.test.js
@@ -1,0 +1,78 @@
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, resolve } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  collectPrunableFiles,
+  directoryBytes,
+  loadAssetManifest,
+  pruneAssetRoot,
+} from "../scripts/prune-runtime-assets.mjs";
+
+const temporaryRoots = [];
+
+async function writeFixture(root, path, contents = path) {
+  const output = resolve(root, path);
+  await mkdir(dirname(output), { recursive: true });
+  await writeFile(output, contents);
+}
+
+afterEach(async () => {
+  await Promise.all(temporaryRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("runtime asset budget", () => {
+  it("identifies only build-time source art in the real public asset tree", async () => {
+    const manifest = await loadAssetManifest();
+    const publicRoot = resolve(import.meta.dirname, "../public");
+    const candidates = (await collectPrunableFiles(publicRoot, manifest.excludeGlobs))
+      .map((path) => path.replaceAll("\\", "/"));
+    const removableBytes = await Promise.all(candidates.map(async (path) => (await readFile(path)).byteLength));
+
+    expect(candidates.some((path) => path.endsWith("/P-ARIANUS_painted.png"))).toBe(true);
+    expect(candidates.some((path) => path.endsWith("/human-class-atlas-alpha-v1.png"))).toBe(true);
+    expect(candidates.some((path) => path.endsWith("/characters/advanced/human-warrior.png"))).toBe(true);
+    expect(candidates.some((path) => path.endsWith("/first-breach-environment-v1.png"))).toBe(false);
+    expect(candidates.some((path) => path.endsWith("/maps/arianus_painted.png"))).toBe(false);
+    expect(removableBytes.reduce((total, size) => total + size, 0)).toBeGreaterThan(70 * 1024 * 1024);
+  });
+
+  it("prunes matching unreferenced files while preserving required runtime assets", async () => {
+    const root = await mkdtemp(resolve(tmpdir(), "souldrifter-assets-"));
+    temporaryRoots.push(root);
+    await Promise.all([
+      writeFixture(root, "assets/generated/human-class-atlas-alpha-v1.png"),
+      writeFixture(root, "assets/generated/characters/advanced/human-warrior.png"),
+      writeFixture(root, "assets/generated/first-breach-environment-v1.png"),
+      writeFixture(root, "index.html", "<main>SoulDrifter</main>"),
+    ]);
+    const manifest = {
+      excludeGlobs: ["assets/generated/*-class-atlas-*-v1.png", "assets/generated/characters/advanced/**"],
+      protectedPaths: ["assets/generated/first-breach-environment-v1.png", "index.html"],
+    };
+
+    const result = await pruneAssetRoot(root, manifest);
+
+    expect(result.removedFiles).toBe(2);
+    await expect(readFile(resolve(root, "assets/generated/human-class-atlas-alpha-v1.png"))).rejects.toThrow();
+    await expect(readFile(resolve(root, "assets/generated/first-breach-environment-v1.png"), "utf8"))
+      .resolves.toContain("first-breach");
+    expect(await directoryBytes(root)).toBeGreaterThan(0);
+  });
+
+  it("fails closed when a future runtime file references an excluded asset", async () => {
+    const root = await mkdtemp(resolve(tmpdir(), "souldrifter-assets-"));
+    temporaryRoots.push(root);
+    await Promise.all([
+      writeFixture(root, "lore-atlas/assets/P-ARIANUS_painted.png"),
+      writeFixture(root, "lore-atlas/index.html", '<img src="assets/P-ARIANUS_painted.png">'),
+    ]);
+    const manifest = {
+      excludeGlobs: ["lore-atlas/assets/P-*_painted.png"],
+      protectedPaths: ["lore-atlas/index.html"],
+    };
+
+    await expect(pruneAssetRoot(root, manifest)).rejects.toThrow(/Refusing to prune referenced runtime assets/);
+    await expect(readFile(resolve(root, "lore-atlas/assets/P-ARIANUS_painted.png"))).resolves.toBeTruthy();
+  });
+});


### PR DESCRIPTION
Closes #440

## Summary
- prune build-only SoulDrifter source art from deployment artifacts without deleting repository assets
- enforce a 150 MB unpacked runtime budget for both ChatGPT Sites and GitHub Pages outputs
- fail closed if future runtime files reference an excluded asset
- protect active First Breach, lore-map, portrait, model, animation, and UI assets

## Verification
- `yarn test`: 138/138 passed
- `yarn typecheck`: passed
- `yarn build`: passed
  - ChatGPT Sites `dist`: 145,680,219 bytes
  - GitHub Pages `dist-pages`: 145,670,059 bytes
  - 71 build-only files / 80,882,215 bytes removed from each target
- `yarn verify:release`: passed
- compressed Sites package proof: 112,884,647 bytes (107.66 MiB)
- ESLint: not configured in SoulDrifterWeb

## Deployment discipline
This PR targets `qa`. It does not promote or deploy `main`, and it does not call 3D AI Studio or spend credits.